### PR TITLE
Update SKILL.md

### DIFF
--- a/skills/react-best-practices/SKILL.md
+++ b/skills/react-best-practices/SKILL.md
@@ -39,7 +39,7 @@ Rules are prioritized by impact:
 
 **Eliminate Waterfalls:**
 - Defer await until needed (move into branches)
-- Use `Promise.all()` for independent async operations
+- Use `Promise.allSettled()` for independent async operations
 - Start promises early, await late
 - Use `better-all` for partial dependencies
 - Use Suspense boundaries to stream content


### PR DESCRIPTION
Suggest switching to Promise.allSettled so a single rejected promise doesn’t fail the whole operation and we can handle results individually.

Promise.all is fail-fast. Using Promise.allSettled lets us handle partial successes instead of failing the entire request.