### PR TITLE
Fix markdown formatting in rule file structure section

### DIFF
--- a/skills/react-best-practices/README.md
+++ b/skills/react-best-practices/README.md
@@ -55,7 +55,7 @@ A structured repository for creating and maintaining React Best Practices optimi
 
 Each rule file should follow this structure:
 
-```markdown
+````markdown
 ---
 title: Rule Title Here
 impact: MEDIUM
@@ -78,6 +78,7 @@ Brief explanation of the rule and why it matters.
 ```typescript
 // Good code example
 ```
+````
 
 Optional explanatory text after examples.
 


### PR DESCRIPTION
The markdown block was closed too early because of the internal markdown-end markers, causing agents to potentially not use the correct structure. Additionally, the human rendering looked off. This PR fixes the early closing by adding another backtick to the parent code block, correctly encapsulating the content.