### PR TITLE
Make React Compiler detection actionable in react-best-practices skill

### DIFF
--- a/skills/react-best-practices/AGENTS.md
+++ b/skills/react-best-practices/AGENTS.md
@@ -28,7 +28,7 @@ Check these locations in the target project:
 
 1. **package.json** - Look for `babel-plugin-react-compiler` in dependencies or devDependencies
 2. **babel.config.js / .babelrc** - Look for `babel-plugin-react-compiler` in plugins
-3. **next.config.js** - Look for `experimental: { reactCompiler: true }`
+3. **next.config.js** - Look for `reactCompiler: true` or `experimental: { reactCompiler: true }`
 
 ### Rules to SKIP When React Compiler is Enabled
 
@@ -1019,7 +1019,7 @@ function ShareButton({ chatId }: { chatId: string }) {
 
 **Impact: MEDIUM (enables early returns)**
 
-> **⚠️ Skip this rule if React Compiler is enabled.** Check for `babel-plugin-react-compiler` in package.json or `experimental.reactCompiler: true` in next.config.js. The compiler automatically handles memoization.
+> **⚠️ Skip this rule if React Compiler is enabled.** Check for `babel-plugin-react-compiler` in package.json or `reactCompiler: true` (or `experimental.reactCompiler: true`) in next.config.js. The compiler automatically handles memoization.
 
 Extract expensive work into memoized components to enable early returns before computation.
 
@@ -1397,7 +1397,7 @@ For 1000 messages, browser skips layout/paint for ~990 off-screen items (10× fa
 
 **Impact: LOW (avoids re-creation)**
 
-> **⚠️ Skip this rule if React Compiler is enabled.** Check for `babel-plugin-react-compiler` in package.json or `experimental.reactCompiler: true` in next.config.js. The compiler automatically hoists static elements.
+> **⚠️ Skip this rule if React Compiler is enabled.** Check for `babel-plugin-react-compiler` in package.json or `reactCompiler: true` (or `experimental.reactCompiler: true`) in next.config.js. The compiler automatically hoists static elements.
 
 Extract static JSX outside components to avoid re-creation.
 

--- a/skills/react-best-practices/SKILL.md
+++ b/skills/react-best-practices/SKILL.md
@@ -13,7 +13,7 @@ Comprehensive performance optimization guide for React and Next.js applications,
 
 1. Look for `babel-plugin-react-compiler` in `package.json` dependencies
 2. Check `babel.config.js` or `.babelrc` for `babel-plugin-react-compiler`
-3. Check `next.config.js` for `experimental.reactCompiler: true`
+3. Check `next.config.js` for `reactCompiler: true` or `experimental.reactCompiler: true`
 
 **If React Compiler is detected, SKIP these patterns:**
 - `memo()` wrappers (rule 5.2)

--- a/skills/react-best-practices/rules/rendering-hoist-jsx.md
+++ b/skills/react-best-practices/rules/rendering-hoist-jsx.md
@@ -7,7 +7,7 @@ tags: rendering, jsx, static, optimization
 
 ## Hoist Static JSX Elements
 
-> **⚠️ Skip this rule if React Compiler is enabled.** Check for `babel-plugin-react-compiler` in package.json or `experimental.reactCompiler: true` in next.config.js. The compiler automatically hoists static elements.
+> **⚠️ Skip this rule if React Compiler is enabled.** Check for `babel-plugin-react-compiler` in package.json or `reactCompiler: true` (or `experimental.reactCompiler: true`) in next.config.js. The compiler automatically hoists static elements.
 
 Extract static JSX outside components to avoid re-creation.
 

--- a/skills/react-best-practices/rules/rerender-memo.md
+++ b/skills/react-best-practices/rules/rerender-memo.md
@@ -7,7 +7,7 @@ tags: rerender, memo, useMemo, optimization
 
 ## Extract to Memoized Components
 
-> **⚠️ Skip this rule if React Compiler is enabled.** Check for `babel-plugin-react-compiler` in package.json or `experimental.reactCompiler: true` in next.config.js. The compiler automatically handles memoization.
+> **⚠️ Skip this rule if React Compiler is enabled.** Check for `babel-plugin-react-compiler` in package.json or `reactCompiler: true` (or `experimental.reactCompiler: true`) in next.config.js. The compiler automatically handles memoization.
 
 Extract expensive work into memoized components to enable early returns before computation.
 


### PR DESCRIPTION
## Problem

The `react-best-practices` skill correctly mentions that `memo()`, `useMemo()`, and manual JSX hoisting are unnecessary when React Compiler is enabled. However, this information is buried as a passive footnote at the end of individual rules:

> **Note:** If your project has React Compiler enabled, manual memoization with `memo()` and `useMemo()` is not necessary.

The issue: AI agents read the "correct" pattern (which uses `memo()`) and apply it regardless of whether React Compiler is present, because the note is **passive information**, not an **actionable instruction**.

## Solution

This PR makes the React Compiler check **actionable** by:

1. **Adding upfront detection instructions** to `SKILL.md` and `AGENTS.md` - a new "React Compiler Detection (Check First!)" section that tells agents to check for React Compiler before applying memoization rules

2. **Adding skip warnings** at the top of affected rules (5.2 and 6.3):
   > ⚠️ Skip this rule if React Compiler is enabled.

3. **Replacing passive footnotes** with "With React Compiler" code examples showing what clean code looks like without manual memoization

## Files Changed

- `SKILL.md` - Added React Compiler detection section
- `AGENTS.md` - Added detection section + updated rules 5.2 and 6.3
- `rules/rerender-memo.md` - Added skip warning + React Compiler example
- `rules/rendering-hoist-jsx.md` - Added skip warning + React Compiler example

## How to Detect React Compiler

The skill now instructs agents to check:
1. `package.json` for `babel-plugin-react-compiler`
2. `babel.config.js` / `.babelrc` for the plugin
3. `next.config.js` for `experimental.reactCompiler: true`