### PR TITLE
Fix frontmatter formatting in web-design-guidelines

### DIFF
--- a/skills/web-design-guidelines/SKILL.md
+++ b/skills/web-design-guidelines/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: web-design-guidelines
 description: Review UI code for Web Interface Guidelines compliance. Use when asked to "review my UI", "check accessibility", "audit design", "review UX", or "check my site against best practices".
-argument-hint: <file-or-pattern>
 metadata:
   author: vercel
   version: "1.0.0"
+  argument-hint: <file-or-pattern>
 ---
 
 # Web Interface Guidelines


### PR DESCRIPTION
`argument-hint` is disallowed frontmatter key; you may have meant to put it in metadata?

Sharing in case this wasn't intentional as wasn't working on my end - thank you for making this 🙏 .
