### PR TITLE
fix(react-best-practices): align skill name with directory name

### DIFF
--- a/skills/react-best-practices/SKILL.md
+++ b/skills/react-best-practices/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: vercel-react-best-practices
+name: react-best-practices
 description: React and Next.js performance optimization guidelines from Vercel Engineering. This skill should be used when writing, reviewing, or refactoring React/Next.js code to ensure optimal performance patterns. Triggers on tasks involving React components, Next.js pages, data fetching, bundle optimization, or performance improvements.
 license: MIT
 metadata:


### PR DESCRIPTION
## Summary

- Fixed skill name mismatch in `skills/react-best-practices/SKILL.md`
- Changed `name: vercel-react-best-practices` → `name: react-best-practices`

## Problem

Claude Code requires the skill `name` field to match the directory name for validation to pass. The current configuration causes validation errors when loading the skill.

From the [Claude Code skill specification](https://docs.anthropic.com/en/docs/claude-code/skills):
> The name must be lowercase with hyphens, ≤64 characters, and **must match the directory name**.

## Changes

```diff
- name: vercel-react-best-practices
+ name: react-best-practices
```

## Test Plan

- [x] Verified skill loads correctly in Claude Code after the fix
- [x] No other references to the old name found in the skill files

---

🤖 Generated with [Claude Code](https://claude.ai/code)