### PR TITLE
Add setEnabled prop to AnimationPlayer component

### DIFF
--- a/skills/react-best-practices/rules/bundle-conditional.md
+++ b/skills/react-best-practices/rules/bundle-conditional.md
@@ -12,7 +12,7 @@ Load large data or modules only when a feature is activated.
 **Example (lazy-load animation frames):**
 
 ```tsx
-function AnimationPlayer({ enabled }: { enabled: boolean }) {
+function AnimationPlayer({ enabled, setEnabled }: { enabled: boolean; setEnabled: React.Dispatch<React.SetStateAction<boolean>> }) {
   const [frames, setFrames] = useState<Frame[] | null>(null)
 
   useEffect(() => {


### PR DESCRIPTION
Updated AnimationPlayer component to include setEnabled prop for better state management.

Closes #37, closes #31.