### PR TITLE
fix(react-best-practices): remove undefined setEnabled call in example

### DIFF
--- a/skills/react-best-practices/rules/bundle-conditional.md
+++ b/skills/react-best-practices/rules/bundle-conditional.md
@@ -19,7 +19,7 @@ function AnimationPlayer({ enabled }: { enabled: boolean }) {
     if (enabled && !frames && typeof window !== 'undefined') {
       import('./animation-frames.js')
         .then(mod => setFrames(mod.frames))
-        .catch(() => setEnabled(false))
+        .catch(console.error)
     }
   }, [enabled, frames])
 


### PR DESCRIPTION
## Summary

- Fix runtime error in `bundle-conditional.md` example where `setEnabled(false)` is called but `setEnabled` doesn't exist

## Problem

The `AnimationPlayer` component receives `enabled` as a **prop**, but the error handler calls `setEnabled(false)`:

```tsx
function AnimationPlayer({ enabled }: { enabled: boolean }) {
  const [frames, setFrames] = useState<Frame[] | null>(null)

  useEffect(() => {
    if (enabled && !frames && typeof window !== 'undefined') {
      import('./animation-frames.js')
        .then(mod => setFrames(mod.frames))
        .catch(() => setEnabled(false))  // ❌ setEnabled doesn't exist!
    }
  }, [enabled, frames])
  // ...
}
```

Per [React documentation](https://react.dev/learn/passing-props-to-a-component):
- Props are immutable and have no setters
- State setters only exist when declared via `useState`

This code would throw `ReferenceError: setEnabled is not defined` at runtime when the import fails.

## Solution

Replace with `console.error` to keep the example focused on conditional loading while still demonstrating error handling:

```tsx
.catch(console.error)
```

## Test plan

- [x] Verified the fix compiles (no TypeScript errors)
- [x] Confirmed the example still demonstrates conditional module loading

🤖 Generated with [Claude Code](https://claude.ai/code)