### PR TITLE
fix(react-best-practices): fix waterfall in children prop parallel fetching example

### DIFF
--- a/skills/react-best-practices/rules/server-parallel-fetching.md
+++ b/skills/react-best-practices/rules/server-parallel-fetching.md
@@ -54,19 +54,23 @@ export default function Page() {
 **Alternative with children prop:**
 
 ```tsx
-async function Layout({ children }: { children: ReactNode }) {
-  const header = await fetchHeader()
-  return (
-    <div>
-      <div>{header}</div>
-      {children}
-    </div>
-  )
+async function Header() {
+  const data = await fetchHeader()
+  return <div>{data}</div>
 }
 
 async function Sidebar() {
   const items = await fetchSidebarItems()
   return <nav>{items.map(renderItem)}</nav>
+}
+
+function Layout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <Header />
+      {children}
+    </div>
+  )
 }
 
 export default function Page() {


### PR DESCRIPTION
## Summary

Fix the "Alternative with children prop" example in `server-parallel-fetching.md` that incorrectly demonstrated parallel data fetching.

## Problem

The previous example had `Layout` as an async function that awaited `fetchHeader()`:

```tsx
async function Layout({ children }: { children: ReactNode }) {
  const header = await fetchHeader()
  return (
    <div>
      <div>{header}</div>
      {children}
    </div>
  )
}
```

This still causes a waterfall because `Sidebar` (passed as children) has to wait for `Layout` to complete its fetch before rendering.

## Solution

Extracted `Header` into a separate async component so both `Header` and `Sidebar` can fetch in parallel:

```tsx
async function Header() {
  const data = await fetchHeader()
  return <div>{data}</div>
}

function Layout({ children }: { children: ReactNode }) {
  return (
    <div>
      <Header />
      {children}
    </div>
  )
}
```