### PR TITLE
Enhance react event-handler refs and use-latest rule examples

### DIFF
--- a/skills/react-best-practices/rules/advanced-event-handler-refs.md
+++ b/skills/react-best-practices/rules/advanced-event-handler-refs.md
@@ -12,7 +12,7 @@ Store callbacks in refs when used in effects that shouldn't re-subscribe on call
 **Incorrect (re-subscribes on every render):**
 
 ```tsx
-function useWindowEvent(event: string, handler: () => void) {
+function useWindowEvent(event: string, handler: (e) => void) {
   useEffect(() => {
     window.addEventListener(event, handler)
     return () => window.removeEventListener(event, handler)
@@ -23,14 +23,14 @@ function useWindowEvent(event: string, handler: () => void) {
 **Correct (stable subscription):**
 
 ```tsx
-function useWindowEvent(event: string, handler: () => void) {
+function useWindowEvent(event: string, handler: (e) => void) {
   const handlerRef = useRef(handler)
   useEffect(() => {
     handlerRef.current = handler
   }, [handler])
 
   useEffect(() => {
-    const listener = () => handlerRef.current()
+    const listener = (e) => handlerRef.current(e)
     window.addEventListener(event, listener)
     return () => window.removeEventListener(event, listener)
   }, [event])
@@ -42,7 +42,7 @@ function useWindowEvent(event: string, handler: () => void) {
 ```tsx
 import { useEffectEvent } from 'react'
 
-function useWindowEvent(event: string, handler: () => void) {
+function useWindowEvent(event: string, handler: (e) => void) {
   const onEvent = useEffectEvent(handler)
 
   useEffect(() => {

--- a/skills/react-best-practices/rules/advanced-use-latest.md
+++ b/skills/react-best-practices/rules/advanced-use-latest.md
@@ -14,7 +14,7 @@ Access latest values in callbacks without adding them to dependency arrays. Prev
 ```typescript
 function useLatest<T>(value: T) {
   const ref = useRef(value)
-  useEffect(() => {
+  useLayoutEffect(() => {
     ref.current = value
   }, [value])
   return ref


### PR DESCRIPTION
Enhance react event-handler refs and use-latest rule examples

- Switch useEffect to useLayoutEffect for the useLatest hook example
It ensures the ref update happens synchronously immediately after DOM mutations but before the browser paints and guarantees:
  - The ref is updated in the same task as the render.
  - Child components or external listeners accessing the ref during their own layout phases will always see the most recent value.
- Forward event object to handler in useWindowEvent example, ensuring consumers can make use of event object if needed