### PR TITLE
fix: add cross-platform support for Windows in parser.ts

### DIFF
--- a/packages/react-best-practices-build/src/parser.ts
+++ b/packages/react-best-practices-build/src/parser.ts
@@ -3,6 +3,7 @@
  */
 
 import { readFile } from 'fs/promises'
+import { basename } from 'path'
 import { Rule, ImpactLevel } from './types.js'
 
 export interface RuleFile {
@@ -15,7 +16,9 @@ export interface RuleFile {
  * Parse a rule markdown file into a Rule object
  */
 export async function parseRuleFile(filePath: string): Promise<RuleFile> {
-  const content = await readFile(filePath, 'utf-8')
+  const rawContent = await readFile(filePath, 'utf-8')
+  // Normalize Windows CRLF line endings to LF for consistent parsing
+  const content = rawContent.replace(/\r\n/g, '\n')
   const lines = content.split('\n')
 
   // Extract frontmatter if present
@@ -194,7 +197,7 @@ export async function parseRuleFile(filePath: string): Promise<RuleFile> {
 
   // Infer section from filename patterns
   // Pattern: area-description.md where area determines section
-  const filename = filePath.split('/').pop() || ''
+  const filename = basename(filePath)
   const sectionMap: Record<string, number> = {
     async: 1,
     bundle: 2,


### PR DESCRIPTION
## Description

This PR fixes cross-platform compatibility issues in [packages/react-best-practices-build/src/parser.ts](cci:7://file:///c:/agent-skills/packages/react-best-practices-build/src/parser.ts:0:0-0:0) that cause the parser to fail on Windows systems.

When running `npx tsx src/validate.ts` on Windows, all 47 rule files fail validation with "Missing examples" errors, even though the markdown files contain valid examples. This happens because:

1. **Path separator issue:** The code uses `filePath.split('/').pop()` to extract the filename, but Windows paths use backslashes (`\`), causing the entire path to be treated as the filename.

2. **Line ending issue:** Windows files use CRLF (`\r\n`) line endings, but the parser's regex patterns expect LF (`\n`) endings, causing pattern matches to fail.

## Changes Made

**File:** [packages/react-best-practices-build/src/parser.ts](cci:7://file:///c:/agent-skills/packages/react-best-practices-build/src/parser.ts:0:0-0:0)

| Line | Change |
|------|--------|
| 6 | Added `import { basename } from 'path'` |
| 19-21 | Normalize CRLF to LF: `rawContent.replace(/\r\n/g, '\n')` |
| 200 | Use `basename(filePath)` instead of `filePath.split('/').pop()` |

## Before & After

### Before 

<img width="919" height="860" alt="Screenshot 2026-01-18 191512" src="https://github.com/user-attachments/assets/ddeb9203-5be7-4104-848b-adfa364844f6" />



### After

<img width="720" height="106" alt="Screenshot 2026-01-18 202349" src="https://github.com/user-attachments/assets/6abd131d-3460-4773-b996-704c6a949a40" />



## Testing

- Tested on Windows 11 with Node.js v22.19.0
- All 47 rule files now validate successfully
- No impact on Linux/Mac (LF files remain unchanged by the normalize step)
- Build script also works correctly: `npx tsx src/build.ts`

