### PR TITLE
docs: add sk installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ Claim URL:   https://vercel.com/claim-deployment?code=...
 npx add-skill vercel-labs/agent-skills
 ```
 
+### Install with `sk`
+
+Install via [sk](https://github.com/803/skills-supply), the universal package manager for AI agent skills (supports Claude Code, Amp, Codex, OpenCode, Factory, etc.).
+
+```bash
+# Add --global flag if you'd like to install in user-scope (defaults to project-scope)
+sk pkg add gh vercel-labs/agent-skills --path skills
+sk sync
+```
+
 ## Usage
 
 Skills are automatically available once installed. The agent will use them when relevant tasks are detected.


### PR DESCRIPTION
`sk` is a universal package manager for agent skills (npm/cargo for agents). it works across most coding agents, handles updates, and more. It installs skills using the native installation location for each coding agent. It also supports loading skills from claude-plugins (it'll extract the skill folders and put it into the right spot for other agents)

Right now it just supports skills but I want to add support for commands and agent-specific things. It would be awesome to have a common container spec for agent extensions/packages/plugins, with some way to override for agent-specific tuning. That’s at least the direction I’m taking.

would you be open to adding this?
