### PR TITLE
Add rule for effect cleanup and aborting async work

### DIFF
--- a/skills/react-best-practices/rules/client-effect-cleanup.md
+++ b/skills/react-best-practices/rules/client-effect-cleanup.md
@@ -16,7 +16,7 @@ function Notifications() {
   const [data, setData] = useState<Notification[]>([])
 
   useEffect(() => {
-    const onResize = () => setData(prev => prev) // example listener
+    const onResize = () => { /* ... */ }
     window.addEventListener('resize', onResize)
 
     fetch('/api/notifications')


### PR DESCRIPTION
What

- Add a new React best‑practice rule covering effect cleanup and aborting async work.

Why

- Prevents memory leaks and stale setState calls after unmount.
- Encourages proper cleanup of subscriptions and event listeners.