### PR TITLE
fix: update barrel imports example

### DIFF
--- a/skills/react-best-practices/rules/bundle-barrel-imports.md
+++ b/skills/react-best-practices/rules/bundle-barrel-imports.md
@@ -16,10 +16,6 @@ Popular icon and component libraries can have **up to 10,000 re-exports** in the
 **Incorrect (imports entire library):**
 
 ```tsx
-import { Check, X, Menu } from 'lucide-react'
-// Loads 1,583 modules, takes ~2.8s extra in dev
-// Runtime cost: 200-800ms on every cold start
-
 import { Button, TextField } from '@mui/material'
 // Loads 2,225 modules, takes ~4.2s extra in dev
 ```
@@ -27,11 +23,6 @@ import { Button, TextField } from '@mui/material'
 **Correct (imports only what you need):**
 
 ```tsx
-import Check from 'lucide-react/dist/esm/icons/check'
-import X from 'lucide-react/dist/esm/icons/x'
-import Menu from 'lucide-react/dist/esm/icons/menu'
-// Loads only 3 modules (~2KB vs ~1MB)
-
 import Button from '@mui/material/Button'
 import TextField from '@mui/material/TextField'
 // Loads only what you use
@@ -43,17 +34,17 @@ import TextField from '@mui/material/TextField'
 // next.config.js - use optimizePackageImports
 module.exports = {
   experimental: {
-    optimizePackageImports: ['lucide-react', '@mui/material']
+    optimizePackageImports: ['@mui/material']
   }
 }
 
 // Then you can keep the ergonomic barrel imports:
-import { Check, X, Menu } from 'lucide-react'
+import { Button, TextField } from '@mui/material'
 // Automatically transformed to direct imports at build time
 ```
 
 Direct imports provide 15-70% faster dev boot, 28% faster builds, 40% faster cold starts, and significantly faster HMR.
 
-Libraries commonly affected: `lucide-react`, `@mui/material`, `@mui/icons-material`, `@tabler/icons-react`, `react-icons`, `@headlessui/react`, `@radix-ui/react-*`, `lodash`, `ramda`, `date-fns`, `rxjs`, `react-use`.
+Libraries commonly affected: `@mui/material`, `@mui/icons-material`, `@tabler/icons-react`, `react-icons`, `@headlessui/react`, `@radix-ui/react-*`, `lodash`, `ramda`, `date-fns`, `rxjs`, `react-use`.
 
 Reference: [How we optimized package imports in Next.js](https://vercel.com/blog/how-we-optimized-package-imports-in-next-js)


### PR DESCRIPTION
## **Summary**
Removed the `lucide-react` example from the bundle-barrel-imports agent skill documentation as it is no longer an appropriate example.

The current documentation includes lucide-react as an example of a library that benefits from avoiding barrel imports. However, according to the [official lucide-react documentation](https://lucide.dev/guide/packages/lucide-react#how-to-use), lucide-react now supports tree-shaking out of the box.

## **Changes**
Removed `lucide-react` from the barrel import examples in bundle-barrel-imports skill documentation
