### PR TITLE
make react skill background skill

### DIFF
--- a/skills/react-best-practices/SKILL.md
+++ b/skills/react-best-practices/SKILL.md
@@ -2,6 +2,7 @@
 name: vercel-react-best-practices
 description: React and Next.js performance optimization guidelines from Vercel Engineering. This skill should be used when writing, reviewing, or refactoring React/Next.js code to ensure optimal performance patterns. Triggers on tasks involving React components, Next.js pages, data fetching, bundle optimization, or performance improvements.
 license: MIT
+user-invocable: false
 metadata:
   author: vercel
   version: "1.0.0"


### PR DESCRIPTION
This is an optimization for CC only

You can set `user-invocable: false` in a skill's frontmatter to hide it from the / menu. This is useful for background knowledge users shouldn't invoke directly. When this is set, only Claude can invoke the skill, and the description is always loaded into context