### PR TITLE
Add caching and pagination guidelines for sitemaps

### DIFF
--- a/packages/react-best-practices-build/test-cases.json
+++ b/packages/react-best-practices-build/test-cases.json
@@ -854,5 +854,37 @@
     "code": "async function Page() {\n  const user = await fetchUser()\n  return <Profile name={user.name} />\n}\n\n'use client'\nfunction Profile({ name }: { name: string }) {\n  return <div>{name}</div>\n}",
     "language": "tsx",
     "description": "serializes only 1 field"
+  },
+  {
+    "ruleId": "",
+    "ruleTitle": "Cache and Paginate Sitemaps",
+    "type": "bad",
+    "code": "// app/sitemap.xml/route.ts\nexport async function GET() {\n  const pages = await db.page.findMany({\n    where: { published: true },\n    select: { slug: true, updatedAt: true }\n  })\n\n  const xml = buildSitemapXml(\n    pages.map(page => ({\n      loc: `https://example.com/${page.slug}`,\n      lastmod: page.updatedAt.toISOString()\n    }))\n  )\n\n  return new Response(xml, {\n    headers: { 'Content-Type': 'application/xml' }\n  })\n}",
+    "language": "typescript",
+    "description": "full table scan on every request"
+  },
+  {
+    "ruleId": "",
+    "ruleTitle": "Cache and Paginate Sitemaps",
+    "type": "good",
+    "code": "// app/sitemap.xml/route.ts\nconst PAGE_SIZE = 10000\n\nexport async function GET(request: Request) {\n  const { searchParams } = new URL(request.url)\n  const page = Number(searchParams.get('page') ?? '1')\n\n  const items = await db.page.findMany({\n    where: { published: true },\n    orderBy: { updatedAt: 'desc' },\n    select: { slug: true, updatedAt: true },\n    take: PAGE_SIZE,\n    skip: (page - 1) * PAGE_SIZE\n  })\n\n  const xml = buildSitemapXml(\n    items.map(item => ({\n      loc: `https://example.com/${item.slug}`,\n      lastmod: item.updatedAt.toISOString()\n    }))\n  )\n\n  return new Response(xml, {\n    headers: {\n      'Content-Type': 'application/xml',\n      'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400'\n    }\n  })\n}",
+    "language": "typescript",
+    "description": "paged sitemap with cache headers"
+  },
+  {
+    "ruleId": "",
+    "ruleTitle": "Cache and Paginate Sitemaps",
+    "type": "good",
+    "code": "// app/sitemap.ts\nconst PAGE_SIZE = 10000\n\nexport async function generateSitemaps() {\n  const total = await db.page.count({ where: { published: true } })\n  const pageCount = Math.ceil(total / PAGE_SIZE)\n\n  return Array.from({ length: pageCount }, (_, index) => ({\n    page: index + 1\n  }))\n}\n\nexport default async function sitemap({ page }: { page: number }) {\n  const items = await db.page.findMany({\n    where: { published: true },\n    orderBy: { updatedAt: 'desc' },\n    select: { slug: true, updatedAt: true },\n    take: PAGE_SIZE,\n    skip: (page - 1) * PAGE_SIZE\n  })\n\n  return items.map(item => ({\n    url: `https://example.com/${item.slug}`,\n    lastModified: item.updatedAt\n  }))\n}",
+    "language": "typescript",
+    "description": "generateSitemaps with paging"
+  },
+  {
+    "ruleId": "",
+    "ruleTitle": "Cache and Paginate Sitemaps",
+    "type": "good",
+    "code": "// app/[site]/sitemap.ts\nexport async function generateSitemaps() {\n  const sites = await db.site.findMany({\n    where: { isActive: true },\n    select: { slug: true }\n  })\n\n  return sites.map(site => ({\n    site: site.slug\n  }))\n}\n\nexport default async function sitemap({ site }: { site: string }) {\n  const items = await db.page.findMany({\n    where: { published: true, siteSlug: site },\n    select: { slug: true, updatedAt: true }\n  })\n\n  return items.map(item => ({\n    url: `https://${site}.example.com/${item.slug}`,\n    lastModified: item.updatedAt\n  }))\n}",
+    "language": "typescript",
+    "description": "dynamic route + generateSitemaps"
   }
 ]

--- a/skills/react-best-practices/rules/server-sitemap-caching.md
+++ b/skills/react-best-practices/rules/server-sitemap-caching.md
@@ -1,0 +1,130 @@
+---
+title: Cache and Paginate Sitemaps
+impact: MEDIUM
+impactDescription: reduces DB load from crawler spikes
+tags: server, sitemap, seo, caching, pagination
+---
+
+## Cache and Paginate Sitemaps
+
+Sitemaps are requested by crawlers, monitors, and uptime checks. Generating them by scanning the entire database on every request wastes CPU/DB and can cause timeouts. Cache the response and page large sitemaps so each request does bounded work.
+
+**Incorrect (full table scan on every request):**
+
+```typescript
+// app/sitemap.xml/route.ts
+export async function GET() {
+  const pages = await db.page.findMany({
+    where: { published: true },
+    select: { slug: true, updatedAt: true }
+  })
+
+  const xml = buildSitemapXml(
+    pages.map(page => ({
+      loc: `https://example.com/${page.slug}`,
+      lastmod: page.updatedAt.toISOString()
+    }))
+  )
+
+  return new Response(xml, {
+    headers: { 'Content-Type': 'application/xml' }
+  })
+}
+```
+
+**Correct (paged sitemap with cache headers):**
+
+```typescript
+// app/sitemap.xml/route.ts
+const PAGE_SIZE = 10000
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const page = Number(searchParams.get('page') ?? '1')
+
+  const items = await db.page.findMany({
+    where: { published: true },
+    orderBy: { updatedAt: 'desc' },
+    select: { slug: true, updatedAt: true },
+    take: PAGE_SIZE,
+    skip: (page - 1) * PAGE_SIZE
+  })
+
+  const xml = buildSitemapXml(
+    items.map(item => ({
+      loc: `https://example.com/${item.slug}`,
+      lastmod: item.updatedAt.toISOString()
+    }))
+  )
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/xml',
+      'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400'
+    }
+  })
+}
+```
+
+**Also good (generateSitemaps with paging):**
+
+```typescript
+// app/sitemap.ts
+const PAGE_SIZE = 10000
+
+export async function generateSitemaps() {
+  const total = await db.page.count({ where: { published: true } })
+  const pageCount = Math.ceil(total / PAGE_SIZE)
+
+  return Array.from({ length: pageCount }, (_, index) => ({
+    page: index + 1
+  }))
+}
+
+export default async function sitemap({ page }: { page: number }) {
+  const items = await db.page.findMany({
+    where: { published: true },
+    orderBy: { updatedAt: 'desc' },
+    select: { slug: true, updatedAt: true },
+    take: PAGE_SIZE,
+    skip: (page - 1) * PAGE_SIZE
+  })
+
+  return items.map(item => ({
+    url: `https://example.com/${item.slug}`,
+    lastModified: item.updatedAt
+  }))
+}
+```
+
+**Also good (dynamic route + generateSitemaps):**
+
+```typescript
+// app/[site]/sitemap.ts
+export async function generateSitemaps() {
+  const sites = await db.site.findMany({
+    where: { isActive: true },
+    select: { slug: true }
+  })
+
+  return sites.map(site => ({
+    site: site.slug
+  }))
+}
+
+export default async function sitemap({ site }: { site: string }) {
+  const items = await db.page.findMany({
+    where: { published: true, siteSlug: site },
+    select: { slug: true, updatedAt: true }
+  })
+
+  return items.map(item => ({
+    url: `https://${site}.example.com/${item.slug}`,
+    lastModified: item.updatedAt
+  }))
+}
+```
+
+If your sitemap data already exists behind an internal API (or a public endpoint you control), you can fetch it instead of querying the database directly. Just keep the same caching and pagination discipline to avoid moving the bottleneck from DB to API.
+
+If you have multiple sitemap pages, expose a sitemap index that lists each page URL, and cache that index too. Prefer cursor-based pagination over deep offsets for very large tables.


### PR DESCRIPTION
Notes:
- Google limits sitemaps to 50,000 URLs and 50MB per file, so PAGE_SIZE should stay well below this.
- Ensure proper DB indexes (e.g., published, updatedAt) to avoid expensive sort operations.
- Prefer Next.js built-in sitemap API when possible; route handlers are useful when custom caching logic is required.