### PR TITLE
fix: update deprecated skill installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Claim URL:   https://vercel.com/claim-deployment?code=...
 ## Installation
 
 ```bash
-npx add-skill vercel-labs/agent-skills
+npx skills add vercel-labs/agent-skills
 ```
 
 ## Usage


### PR DESCRIPTION
The usage of the command `npx add-skill vercel-labs/agent-skills` is deprecated, I replaced it with the new command instead.

<img width="410" height="128" alt="Screen Shot 2026-01-27 at 22 09 45 PM" src="https://github.com/user-attachments/assets/33248380-004b-4fb1-90c5-c84b824a1fdb" />
