### PR TITLE
Fix skill name mismatch in react-best-practices skill

### DIFF
--- a/skills/react-best-practices/SKILL.md
+++ b/skills/react-best-practices/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: vercel-react-best-practices
+name: react-best-practices
 description: React and Next.js performance optimization guidelines from Vercel Engineering. This skill should be used when writing, reviewing, or refactoring React/Next.js code to ensure optimal performance patterns. Triggers on tasks involving React components, Next.js pages, data fetching, bundle optimization, or performance improvements.
 license: MIT
 metadata:


### PR DESCRIPTION
## Summary
Fixes skill name mismatch to comply with Agent Skills specification and restore compatibility with tools like Cline.

## Changes
- Updated skill name in `SKILL.md`: `vercel-react-best-practices` → `react-best-practices`
- Name now matches parent directory as required by specification

## Why
The Agent Skills spec requires the skill name to match its directory name. This mismatch prevented the skill from being detected by spec-compliant tools.

Closes #112
