### PR TITLE
doc: missing argument in the correct example

### DIFF
--- a/skills/react-native-skills/rules/list-performance-callbacks.md
+++ b/skills/react-native-skills/rules/list-performance-callbacks.md
@@ -30,7 +30,7 @@ return (
 **Correct (a single function instance passed to each item):**
 
 ```typescript
-const onPress = useCallback(() => handlePress(item.id), [handlePress, item.id])
+const onPress = useCallback((item) => handlePress(item.id), [handlePress])
 
 return (
   <LegendList


### PR DESCRIPTION
Summary
in the guideline: skills/react-native-skills/rules/list-performance-callbacks.md, there seems to be a missing argument in a callback function in its correct version example. 
It may not affect how ai agents behave since  they are pretty smart, but I thought it wouldn't hurt.

Changes
I added `item` arg and remove 'item.id' from the dependency array of the callback function in the example code.
