### PR TITLE
Add LiteRT skill for on-device AI deployment

### DIFF
--- a/skills/litert/LICENSE
+++ b/skills/litert/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 farmhutsoftwareteam
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/litert/README.md
+++ b/skills/litert/README.md
@@ -1,0 +1,72 @@
+# LiteRT Skill for Claude Code
+
+A Claude Code skill for **Google LiteRT** — the universal framework for on-device AI (successor to TensorFlow Lite).
+
+## Installation
+
+```bash
+npx skills add farmhutsoftwareteam/litert-skill
+```
+
+Or manually clone to your skills directory:
+
+```bash
+git clone https://github.com/farmhutsoftwareteam/litert-skill ~/.claude/skills/litert
+```
+
+## What This Skill Provides
+
+This skill gives Claude Code expertise in deploying ML and GenAI models on edge devices using LiteRT.
+
+### Coverage
+
+| Topic | Description |
+|-------|-------------|
+| **GPU Acceleration** | OpenCL, OpenGL, Metal, WebGPU setup with zero-copy buffers |
+| **NPU Acceleration** | Qualcomm & MediaTek support, AOT/JIT compilation |
+| **LiteRT-LM** | Deploy LLMs (Gemma, Phi, Qwen) on device |
+| **Model Conversion** | PyTorch, TensorFlow, JAX → .tflite |
+| **Migration** | TensorFlow Lite → LiteRT migration guide |
+
+### Supported Platforms
+
+| Platform | CPU | GPU | NPU |
+|----------|-----|-----|-----|
+| Android | ✅ | ✅ | ✅ |
+| iOS | ✅ | ✅ | Soon |
+| macOS | ✅ | ✅ | Soon |
+| Windows | ✅ | ✅ | Soon |
+| Linux | ✅ | ✅ | — |
+| Web | ✅ | ✅ | Soon |
+
+## When This Skill Triggers
+
+- Working with `.tflite` models
+- On-device ML/AI inference
+- Mobile ML deployment (Android/iOS)
+- GPU/NPU hardware acceleration
+- Running models like Gemma on device
+- Migrating from TensorFlow Lite
+
+## Skill Structure
+
+```
+litert-skill/
+├── SKILL.md                    # Main skill file
+└── references/
+    ├── gpu-acceleration.md     # GPU setup & optimization
+    ├── npu-acceleration.md     # NPU setup & vendor support
+    ├── litert-lm.md            # LLM deployment
+    ├── model-conversion.md     # Model conversion guides
+    └── migration.md            # TFLite migration
+```
+
+## Resources
+
+- [LiteRT Documentation](https://ai.google.dev/edge/litert)
+- [LiteRT GitHub](https://github.com/google-ai-edge/LiteRT)
+- [LiteRT-LM GitHub](https://github.com/google-ai-edge/LiteRT-LM)
+
+## License
+
+MIT

--- a/skills/litert/SKILL.md
+++ b/skills/litert/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: litert
+description: Google's on-device AI framework for deploying ML and GenAI models on edge devices (successor to TensorFlow Lite). Use when working with on-device inference, .tflite models, mobile ML deployment, GPU/NPU acceleration, LiteRT-LM for LLMs, model conversion from PyTorch/TensorFlow/JAX, or migrating from TensorFlow Lite. Triggers on Android/iOS/Web ML inference, CompiledModel API, hardware acceleration, edge AI deployment, or running models like Gemma on device.
+license: MIT
+metadata:
+  author: munyaradzi makosa
+  version: "1.0.0"
+---
+
+# LiteRT: On-Device AI Framework
+
+## Overview
+
+LiteRT (Lite Runtime) is Google's framework for deploying ML and generative AI on edge devices. It's the successor to TensorFlow Lite with advanced GPU/NPU acceleration delivering up to 100x faster inference than CPU.
+
+## Platform Support
+
+| Platform | CPU | GPU | NPU |
+|----------|-----|-----|-----|
+| Android | Yes | OpenCL, OpenGL | Qualcomm, MediaTek |
+| iOS | Yes | Metal | ANE (coming) |
+| macOS | Yes | Metal, WebGPU | ANE (coming) |
+| Windows | Yes | WebGPU | Intel (coming) |
+| Linux | Yes | WebGPU | - |
+| Web | Yes | WebGPU | Coming |
+
+## Quick Start
+
+### Android (Kotlin)
+
+```kotlin
+// Add dependency: implementation 'com.google.ai.edge.litert:litert:2.1.0'
+
+val model = CompiledModel.create(
+    context.assets,
+    "model.tflite",
+    CompiledModel.Options(Accelerator.GPU)  // or NPU, CPU
+)
+
+val inputBuffers = model.createInputBuffers()
+val outputBuffers = model.createOutputBuffers()
+
+inputBuffers[0].writeFloat(inputData)
+model.run(inputBuffers, outputBuffers)
+val result = outputBuffers[0].readFloat()
+```
+
+### C++
+
+```cpp
+#include "litert/cc/litert_compiled_model.h"
+#include "litert/cc/litert_environment.h"
+
+LITERT_ASSIGN_OR_RETURN(auto env, Environment::Create({}));
+LITERT_ASSIGN_OR_RETURN(auto compiled_model,
+    CompiledModel::Create(env, "model.tflite", kLiteRtHwAcceleratorGpu));
+
+LITERT_ASSIGN_OR_RETURN(auto inputs, compiled_model.CreateInputBuffers());
+LITERT_ASSIGN_OR_RETURN(auto outputs, compiled_model.CreateOutputBuffers());
+compiled_model.Run(inputs, outputs);
+```
+
+### Python
+
+```python
+from ai_edge_litert.interpreter import Interpreter
+
+interpreter = Interpreter(model_path='model.tflite')
+interpreter.allocate_tensors()
+interpreter.set_tensor(input_index, input_data)
+interpreter.invoke()
+output = interpreter.get_tensor(output_index)
+```
+
+## APIs
+
+### CompiledModel API (Recommended)
+- Modern API for hardware acceleration
+- Supports GPU, NPU, CPU
+- Zero-copy buffer interop
+- Async execution
+
+### Interpreter API (Legacy)
+- TensorFlow Lite compatible
+- CPU-only in v2.x
+- Use for backward compatibility
+
+## Task Decision Tree
+
+**Running inference on device?**
+- Use CompiledModel API with appropriate accelerator
+- See [gpu-acceleration.md](references/gpu-acceleration.md) or [npu-acceleration.md](references/npu-acceleration.md)
+
+**Deploying LLMs (Gemma, Phi, Qwen)?**
+- Use LiteRT-LM framework
+- See [litert-lm.md](references/litert-lm.md)
+
+**Converting models to .tflite?**
+- PyTorch: Use `litert-torch` package
+- TensorFlow: Use `tf.lite.TFLiteConverter`
+- JAX: Use jax2tf bridge
+- See [model-conversion.md](references/model-conversion.md)
+
+**Migrating from TensorFlow Lite?**
+- Package name changes only
+- See [migration.md](references/migration.md)
+
+## Performance Tips
+
+1. **Choose the right accelerator**: NPU > GPU > CPU for most models
+2. **Use zero-copy buffers**: Pass camera/GPU buffers directly
+3. **Enable async execution**: Overlap CPU/GPU work
+4. **Cache NPU compilation**: Use `CompilerCacheDir` environment option
+5. **Quantize models**: INT8 reduces size 4x, improves speed
+
+## Dependencies
+
+### Android (Gradle)
+
+```groovy
+implementation 'com.google.ai.edge.litert:litert:2.1.0'
+```
+
+### Python
+
+```bash
+pip install ai-edge-litert           # Runtime
+pip install litert-torch             # PyTorch conversion
+pip install ai-edge-quantizer        # Quantization
+```
+
+## Resources
+
+- **Official docs**: https://ai.google.dev/edge/litert
+- **GitHub**: https://github.com/google-ai-edge/LiteRT
+- **LiteRT-LM**: https://github.com/google-ai-edge/LiteRT-LM
+
+## Reference Files
+
+- [gpu-acceleration.md](references/gpu-acceleration.md) - GPU setup, zero-copy, async execution
+- [npu-acceleration.md](references/npu-acceleration.md) - NPU setup, AOT/JIT compilation, vendor support
+- [litert-lm.md](references/litert-lm.md) - LLM deployment with LiteRT-LM
+- [model-conversion.md](references/model-conversion.md) - Converting PyTorch/TF/JAX to .tflite
+- [migration.md](references/migration.md) - Migration from TensorFlow Lite

--- a/skills/litert/metadata.json
+++ b/skills/litert/metadata.json
@@ -1,0 +1,18 @@
+{
+  "name": "litert",
+  "description": "Google LiteRT on-device AI framework for ML/GenAI deployment",
+  "author": "munyaradzi makosa",
+  "version": "1.0.0",
+  "license": "MIT",
+  "repository": "https://github.com/farmhutsoftwareteam/litert-skill",
+  "keywords": [
+    "litert",
+    "tensorflow-lite",
+    "on-device-ai",
+    "edge-ai",
+    "mobile-ml",
+    "gpu-acceleration",
+    "npu",
+    "machine-learning"
+  ]
+}

--- a/skills/litert/references/gpu-acceleration.md
+++ b/skills/litert/references/gpu-acceleration.md
@@ -1,0 +1,130 @@
+# GPU Acceleration with LiteRT
+
+## Overview
+
+LiteRT provides GPU acceleration across Android, iOS, macOS, Windows, Linux, and Web via ML Drift, delivering 1.4x faster performance than legacy TFLite GPU delegate.
+
+## Supported Technologies
+
+| Platform | GPU Backend |
+|----------|-------------|
+| Android | OpenCL, OpenGL |
+| iOS/macOS | Metal |
+| Windows/Linux | WebGPU |
+| Web | WebGPU |
+
+## Basic GPU Setup
+
+### Kotlin (Android)
+
+```kotlin
+val model = CompiledModel.create(
+    context.assets,
+    "mymodel.tflite",
+    CompiledModel.Options(Accelerator.GPU),
+    env
+)
+
+val inputBuffers = model.createInputBuffers()
+val outputBuffers = model.createOutputBuffers()
+
+inputBuffers[0].writeFloat(inputData)
+model.run(inputBuffers, outputBuffers)
+val result = outputBuffers[0].readFloat()
+```
+
+### C++
+
+```cpp
+#include "litert/cc/litert_compiled_model.h"
+#include "litert/cc/litert_environment.h"
+
+// Create environment
+LITERT_ASSIGN_OR_RETURN(auto env, Environment::Create({}));
+
+// Load model with GPU acceleration
+LITERT_ASSIGN_OR_RETURN(auto compiled_model,
+    CompiledModel::Create(env, "mymodel.tflite", kLiteRtHwAcceleratorGpu));
+
+// Create buffers
+LITERT_ASSIGN_OR_RETURN(auto input_buffers, compiled_model.CreateInputBuffers());
+LITERT_ASSIGN_OR_RETURN(auto output_buffers, compiled_model.CreateOutputBuffers());
+
+// Run inference
+compiled_model.Run(input_buffers, output_buffers);
+```
+
+## Zero-Copy Buffer Interop
+
+Transfer GPU buffers directly without CPU copies for up to 2x performance in real-time applications.
+
+### OpenGL Buffer (C++)
+
+```cpp
+// Wrap existing OpenGL buffer
+LITERT_ASSIGN_OR_RETURN(auto gl_input_buffer,
+    TensorBuffer::CreateFromGlBuffer(
+        env,
+        tensor_type,
+        opengl_buffer.target,
+        opengl_buffer.id,
+        opengl_buffer.size_bytes,
+        opengl_buffer.offset
+    ));
+
+// Use directly in inference
+compiled_model.Run({gl_input_buffer}, output_buffers);
+```
+
+### AHardwareBuffer (Android NDK)
+
+```cpp
+// Wrap Android hardware buffer
+LITERT_ASSIGN_OR_RETURN(auto ahwb_buffer,
+    TensorBuffer::CreateFromAhwb(env, tensor_type, ahw_buffer, 0));
+```
+
+## Asynchronous Execution
+
+Run GPU inference without blocking CPU for parallel workloads.
+
+```cpp
+// Create event for synchronization
+LITERT_ASSIGN_OR_RETURN(auto input_event,
+    Event::CreateManagedEvent(env, LiteRtEventTypeEglSyncFence));
+
+// Attach event to input
+inputs[0].SetEvent(std::move(input_event));
+
+// Run async - CPU continues while GPU processes
+compiled_model.RunAsync(inputs, outputs);
+
+// Do other CPU work here...
+
+// Wait for completion when needed
+outputs[0].GetEvent().Wait();
+```
+
+## Dependencies
+
+### Android (Gradle)
+
+```groovy
+implementation 'com.google.ai.edge.litert:litert:2.1.0'
+// GPU acceleration is built-in, no additional dependency needed
+```
+
+### C++ (CMake)
+
+Requires:
+- LiteRT C API shared library
+- GLES dependencies
+- GPU accelerator prebuilts via `litert_gpu_accelerator_prebuilts()`
+
+## Performance Tips
+
+1. **Batch operations** - Combine multiple inferences when possible
+2. **Reuse buffers** - Create input/output buffers once, reuse across calls
+3. **Use zero-copy** - Pass GPU buffers directly from camera/rendering pipelines
+4. **Async execution** - Overlap CPU preprocessing with GPU inference
+5. **Warm-up** - Run one inference at startup to initialize GPU pipeline

--- a/skills/litert/references/litert-lm.md
+++ b/skills/litert/references/litert-lm.md
@@ -1,0 +1,183 @@
+# LiteRT-LM: On-Device LLM Deployment
+
+## Overview
+
+LiteRT-LM is a C++ library for running large language models on edge devices. It powers Gemini Nano deployments in Chrome, Chromebook Plus, and Pixel Watch.
+
+## Supported Models
+
+| Model | Size | Quantization | Type |
+|-------|------|--------------|------|
+| Gemma3-1B | 557 MB | 4-bit | Chat |
+| Gemma-3n-E2B | 2965 MB | 4-bit | Chat |
+| Gemma-3n-E4B | 4235 MB | 4-bit | Chat |
+| Phi-4-mini | 3728 MB | 8-bit | Chat |
+| Qwen2.5-1.5b | 1524 MB | 8-bit | Chat |
+| FunctionGemma-270M | 288 MB | - | Base |
+
+Models use `.litertlm` format (converted from standard formats).
+
+## Performance Benchmarks
+
+**Gemma3-1B (1024 prefill, 256 decode):**
+
+| Device | Prefill (tok/s) | Decode (tok/s) |
+|--------|-----------------|----------------|
+| MacBook Pro M3 (CPU) | 422.98 | 66.89 |
+| Samsung S24 Ultra (GPU) | 1876.5 | 44.57 |
+| Samsung S25 Ultra (NPU) | 5836.6 | 84.8 |
+
+LiteRT-LM outperforms llama.cpp by 3x on CPU, 7x on GPU decode, and 19x on GPU prefill.
+
+## Quick Start with CLI (LIT)
+
+### Install
+
+Pre-built binaries available for macOS ARM64, Linux x86_64/ARM64, Windows x86_64.
+
+```bash
+# Download from GitHub releases
+# Set HuggingFace token for model downloads
+export HUGGING_FACE_HUB_TOKEN="your_token"
+```
+
+### List and Download Models
+
+```bash
+lit list --show_all
+lit pull gemma3-1b
+```
+
+### Run Inference
+
+```bash
+# Interactive mode
+lit run gemma3-1b --backend=cpu
+
+# With GPU
+lit run gemma3-1b --backend=gpu
+
+# Custom prompt
+lit run gemma3-1b --input_prompt="Write me a song"
+```
+
+### Benchmarking
+
+```bash
+lit run gemma3-1b --backend=cpu \
+    --benchmark \
+    --benchmark_prefill_tokens=1024 \
+    --benchmark_decode_tokens=256
+```
+
+## C++ API
+
+### Engine (Entry Point)
+
+```cpp
+#include "litert_lm/engine.h"
+
+// Create engine from model
+auto engine = Engine::Create("model.litertlm", backend);
+```
+
+### Conversation API (Recommended)
+
+Handles tokenization, prompt templating, and stateful chat.
+
+```cpp
+// Create conversation
+auto conversation = engine->CreateConversation();
+
+// Add messages
+conversation->AddUserMessage("Hello, how are you?");
+
+// Generate response
+auto response = conversation->Generate();
+std::cout << response.text << std::endl;
+
+// Continue conversation
+conversation->AddUserMessage("Tell me more");
+auto response2 = conversation->Generate();
+```
+
+### Session API (Low-Level)
+
+For fine-grained control over prefill/decode phases.
+
+```cpp
+auto session = engine->CreateSession();
+
+// Manual prefill
+session->Prefill(token_ids);
+
+// Manual decode loop
+while (!done) {
+    auto next_token = session->Decode();
+    // Process token...
+}
+```
+
+## Android Deployment
+
+### AI Edge Gallery App
+
+Available on Google Play Store for testing models on device.
+
+### Building from Source
+
+```bash
+git clone https://github.com/google-ai-edge/LiteRT-LM.git
+cd LiteRT-LM
+
+# Build for Android
+bazel build //runtime/engine:litert_lm_main \
+    --config=android_arm64
+```
+
+### Gradle Integration
+
+```groovy
+// Coming in stable release
+implementation 'com.google.ai.edge.litert:litert-lm:x.x.x'
+```
+
+## Multimodal Support
+
+LiteRT-LM supports vision and audio inputs for multimodal models:
+
+```cpp
+// Add image to conversation
+conversation->AddImage(image_data);
+conversation->AddUserMessage("What's in this image?");
+auto response = conversation->Generate();
+```
+
+## Function Calling
+
+For models like FunctionGemma:
+
+```cpp
+// Define available functions
+conversation->SetFunctions(function_definitions);
+
+// Generate with potential function calls
+auto response = conversation->Generate();
+if (response.has_function_call) {
+    // Execute function and provide result
+    conversation->AddFunctionResult(result);
+    auto final_response = conversation->Generate();
+}
+```
+
+## Model Conversion
+
+Convert PyTorch transformer models using AI Edge Torch Generative API:
+
+```python
+import ai_edge_torch
+
+# Convert model
+converted = ai_edge_torch.generative.convert(model)
+converted.export("model.litertlm")
+```

--- a/skills/litert/references/migration.md
+++ b/skills/litert/references/migration.md
@@ -1,0 +1,138 @@
+# Migration from TensorFlow Lite to LiteRT
+
+## Overview
+
+LiteRT is the new name for TensorFlow Lite. Migration requires only package name updates - no logic changes needed. The `.tflite` file format remains unchanged.
+
+## Android Migration
+
+### Maven Dependencies
+
+Replace TensorFlow Lite packages with LiteRT equivalents:
+
+| Old Package | New Package |
+|-------------|-------------|
+| `org.tensorflow:tensorflow-lite` | `com.google.ai.edge.litert:litert` |
+| `org.tensorflow:tensorflow-lite-gpu` | `com.google.ai.edge.litert:litert-gpu` |
+| `org.tensorflow:tensorflow-lite-metadata` | `com.google.ai.edge.litert:litert-metadata` |
+| `org.tensorflow:tensorflow-lite-support` | `com.google.ai.edge.litert:litert-support` |
+
+### Gradle Update
+
+```groovy
+// Before
+implementation 'org.tensorflow:tensorflow-lite:2.x.x'
+implementation 'org.tensorflow:tensorflow-lite-gpu:2.x.x'
+
+// After
+implementation 'com.google.ai.edge.litert:litert:2.1.0'
+```
+
+### Important: GPU with Interpreter API
+
+GPU acceleration with Interpreter API is only available in Maven V1 packages. For V2 packages, use CompiledModel API for GPU inference.
+
+### Play Services
+
+If using TensorFlow Lite via Google Play Services, no changes needed:
+
+```groovy
+// Continue using this - no changes required
+implementation 'com.google.android.gms:play-services-tflite-java:x.x.x'
+implementation 'com.google.android.gms:play-services-tflite-gpu:x.x.x'
+```
+
+## Python Migration
+
+### Package Update
+
+```bash
+# Remove old package
+pip uninstall tflite-runtime
+
+# Install LiteRT
+pip install ai-edge-litert
+```
+
+### Import Changes
+
+```python
+# Before
+from tflite_runtime.interpreter import Interpreter
+
+# After
+from ai_edge_litert.interpreter import Interpreter
+```
+
+Usage remains identical:
+
+```python
+interpreter = Interpreter(model_path='model.tflite')
+interpreter.allocate_tensors()
+# ... rest of code unchanged
+```
+
+## iOS/macOS, C++, Swift, Objective-C
+
+No migration needed. Continue using TensorFlow Lite packages - these SDKs have not been renamed.
+
+## API Comparison
+
+### Interpreter API (Legacy, Compatible)
+
+Works identically in both TFLite and LiteRT:
+
+```kotlin
+// Android Kotlin
+val interpreter = Interpreter(modelBuffer)
+interpreter.run(input, output)
+```
+
+### CompiledModel API (New, Recommended)
+
+LiteRT-exclusive API for hardware acceleration:
+
+```kotlin
+// Android Kotlin - New API
+val model = CompiledModel.create(
+    context.assets,
+    "model.tflite",
+    CompiledModel.Options(Accelerator.GPU)
+)
+val inputBuffers = model.createInputBuffers()
+val outputBuffers = model.createOutputBuffers()
+inputBuffers[0].writeFloat(inputData)
+model.run(inputBuffers, outputBuffers)
+```
+
+## Version Requirements
+
+### LiteRT 2.1.0 (Latest)
+- Minimum Android SDK: 23 (Android 6)
+- Minimum NDK: r26a
+- APIs: CompiledModel + Interpreter
+
+### LiteRT 1.4.1 (Legacy)
+- Minimum Android SDK: 21 (Android 5)
+- APIs: Interpreter only
+
+## tf.lite Deprecation
+
+The `tf.lite` module in TensorFlow is deprecated and will be removed from future TensorFlow packages. Migrate to LiteRT for continued updates:
+
+```python
+# Deprecated - will be removed
+import tensorflow as tf
+converter = tf.lite.TFLiteConverter.from_saved_model('model')
+
+# Future-proof alternative
+# Use ai-edge-litert package directly
+```
+
+## File Format
+
+No changes to `.tflite` files:
+- Same FlatBuffer format
+- Same file extension
+- Full backward compatibility
+- Existing models work without modification

--- a/skills/litert/references/model-conversion.md
+++ b/skills/litert/references/model-conversion.md
@@ -1,0 +1,188 @@
+# Model Conversion to LiteRT
+
+## Overview
+
+LiteRT accepts models in `.tflite` format (FlatBuffer). Convert from PyTorch, TensorFlow, or JAX.
+
+## PyTorch Conversion
+
+### Installation
+
+```bash
+pip install litert-torch-nightly torchvision
+# Or stable: pip install litert-torch
+```
+
+### Basic Conversion
+
+```python
+import litert_torch
+import torch
+import torchvision
+
+# Load PyTorch model
+model = torchvision.models.resnet18(pretrained=True).eval()
+
+# Create sample inputs (required for tracing)
+sample_inputs = (torch.randn(1, 3, 224, 224),)
+
+# Convert to LiteRT
+edge_model = litert_torch.convert(model, sample_inputs)
+
+# Validate outputs
+pytorch_output = model(*sample_inputs)
+edge_output = edge_model(*sample_inputs)
+assert numpy.allclose(pytorch_output.detach().numpy(), edge_output, rtol=1e-3)
+
+# Export to .tflite
+edge_model.export('resnet18.tflite')
+```
+
+### Requirements
+
+- PyTorch 2.1.0+ (model must be `torch.export` compliant)
+- Model must be in eval mode: `model.eval()`
+
+### Visualization
+
+```bash
+pip install ai-edge-model-explorer
+```
+
+```python
+import model_explorer
+model_explorer.visualize('resnet18.tflite')
+```
+
+## TensorFlow Conversion
+
+### From SavedModel
+
+```python
+import tensorflow as tf
+
+# Load SavedModel
+converter = tf.lite.TFLiteConverter.from_saved_model('saved_model_dir')
+tflite_model = converter.convert()
+
+# Save
+with open('model.tflite', 'wb') as f:
+    f.write(tflite_model)
+```
+
+### From Keras Model
+
+```python
+import tensorflow as tf
+
+# Convert Keras model directly
+model = tf.keras.applications.MobileNetV2()
+converter = tf.lite.TFLiteConverter.from_keras_model(model)
+tflite_model = converter.convert()
+
+with open('mobilenet.tflite', 'wb') as f:
+    f.write(tflite_model)
+```
+
+## JAX Conversion
+
+Use jax2tf bridge:
+
+```python
+import jax
+import jax.numpy as jnp
+from jax.experimental import jax2tf
+import tensorflow as tf
+
+# JAX function
+def jax_fn(x):
+    return jax.nn.relu(x @ weights + bias)
+
+# Convert to TensorFlow
+tf_fn = jax2tf.convert(jax_fn)
+
+# Then use TFLite converter
+concrete_func = tf.function(tf_fn).get_concrete_function(
+    tf.TensorSpec([1, 784], tf.float32))
+converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete_func])
+tflite_model = converter.convert()
+```
+
+## Quantization
+
+Reduce model size and improve inference speed.
+
+### Post-Training Dynamic Quantization
+
+```python
+converter = tf.lite.TFLiteConverter.from_saved_model('saved_model_dir')
+converter.optimizations = [tf.lite.Optimize.DEFAULT]
+tflite_model = converter.convert()
+```
+
+### Post-Training Integer Quantization (INT8)
+
+```python
+def representative_dataset():
+    for _ in range(100):
+        yield [np.random.rand(1, 224, 224, 3).astype(np.float32)]
+
+converter = tf.lite.TFLiteConverter.from_saved_model('saved_model_dir')
+converter.optimizations = [tf.lite.Optimize.DEFAULT]
+converter.representative_dataset = representative_dataset
+converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
+converter.inference_input_type = tf.int8
+converter.inference_output_type = tf.int8
+tflite_model = converter.convert()
+```
+
+### Float16 Quantization
+
+```python
+converter = tf.lite.TFLiteConverter.from_saved_model('saved_model_dir')
+converter.optimizations = [tf.lite.Optimize.DEFAULT]
+converter.target_spec.supported_types = [tf.float16]
+tflite_model = converter.convert()
+```
+
+## AI Edge Quantizer
+
+Additional optimization tool:
+
+```bash
+pip install ai-edge-quantizer
+```
+
+```python
+from ai_edge_quantizer import quantize
+
+# Quantize existing tflite model
+quantized_model = quantize('model.tflite', 'int8')
+quantized_model.export('model_int8.tflite')
+```
+
+## LLM Conversion (LiteRT-LM)
+
+For transformer models, use AI Edge Torch Generative API:
+
+```python
+import ai_edge_torch.generative as generative
+
+# Convert transformer model
+converted = generative.convert(
+    model,
+    tokenizer=tokenizer,
+    quantization='int4'  # or 'int8', 'fp16'
+)
+converted.export('llm.litertlm')
+```
+
+## Supported Operations
+
+LiteRT supports most common ML operations. Check compatibility:
+- https://ai.google.dev/edge/litert/models/ops_compatibility
+
+Unsupported ops can use:
+1. Custom operators
+2. Flex delegate (TensorFlow ops fallback)
+3. Model modification to use supported ops

--- a/skills/litert/references/npu-acceleration.md
+++ b/skills/litert/references/npu-acceleration.md
@@ -1,0 +1,137 @@
+# NPU Acceleration with LiteRT
+
+## Overview
+
+NPUs deliver up to 100x faster inference than CPU and 10x faster than GPU with significantly lower power consumption. LiteRT provides unified NPU support across major vendors.
+
+## Supported NPU Vendors
+
+| Vendor | Status | Compilation |
+|--------|--------|-------------|
+| Qualcomm AI Engine Direct | Production | AOT + JIT |
+| MediaTek NeuroPilot | Production | AOT + JIT |
+| Google Tensor | Experimental | Contact Google |
+
+## Compilation Strategies
+
+### AOT (Ahead-of-Time)
+- Best for large, complex models
+- Reduces app initialization time
+- Lower memory usage at startup
+- Requires knowing target SoC at build time
+
+### JIT (On-Device)
+- Best for platform-agnostic distribution
+- Higher first-run overhead
+- No preparation needed
+- Ideal for smaller models
+
+## Basic NPU Setup
+
+### Kotlin (Android)
+
+```kotlin
+// NPU with GPU fallback
+val model = CompiledModel.create(
+    context.assets,
+    "model/mymodel.tflite",
+    CompiledModel.Options(Accelerator.NPU, Accelerator.GPU)
+)
+
+val inputBuffers = model.createInputBuffers()
+val outputBuffers = model.createOutputBuffers()
+
+inputBuffers[0].writeFloat(inputData)
+model.run(inputBuffers, outputBuffers)
+val result = outputBuffers[0].readFloat()
+```
+
+### C++
+
+```cpp
+// Setup environment with NPU dispatch library
+std::vector<Environment::Option> environment_options = {
+    {Environment::OptionTag::DispatchLibraryDir, "/usr/lib64/npu_dispatch/"}
+};
+LITERT_ASSIGN_OR_RETURN(auto env,
+    Environment::Create(absl::MakeConstSpan(environment_options)));
+
+// Load model
+LITERT_ASSIGN_OR_RETURN(auto model, Model::Load("mymodel_npu.tflite"));
+
+// Create compiled model with NPU acceleration
+LITERT_ASSIGN_OR_RETURN(auto compiled_model,
+    CompiledModel::Create(env, model, kLiteRtHwAcceleratorNpu));
+
+// Run inference
+LITERT_ASSIGN_OR_RETURN(auto input_buffers, compiled_model.CreateInputBuffers());
+LITERT_ASSIGN_OR_RETURN(auto output_buffers, compiled_model.CreateOutputBuffers());
+compiled_model.Run(input_buffers, output_buffers);
+```
+
+## Zero-Copy with AHardwareBuffer
+
+```cpp
+// Direct NPU access from camera/video buffers
+LITERT_ASSIGN_OR_RETURN(auto npu_input_buffer,
+    TensorBuffer::CreateFromAhwb(env, tensor_type, ahw_buffer, 0));
+
+compiled_model.Run({npu_input_buffer}, output_buffers);
+```
+
+## JIT Compilation Caching
+
+Cache compilation artifacts to avoid recompilation on subsequent runs.
+
+```cpp
+std::vector<Environment::Option> options = {
+    {Environment::OptionTag::DispatchLibraryDir, "/path/to/npu_dispatch/"},
+    {Environment::OptionTag::CompilerCacheDir, "/path/to/cache/"}
+};
+LITERT_ASSIGN_OR_RETURN(auto env, Environment::Create(options));
+```
+
+Benefits:
+- 37-97% reduction in initialization time
+- Significant memory savings
+- Cache invalidates when vendor version, build fingerprint, model, or options change
+
+## Android Deployment
+
+### Requirements
+- Minimum API level 31+
+- arm64-v8a architecture only
+
+### Google Play Delivery Options
+
+**On-demand delivery:**
+```xml
+<dist:module
+    dist:title="@string/npu_model">
+    <dist:delivery>
+        <dist:on-demand/>
+    </dist:delivery>
+</dist:module>
+```
+
+**Install-time delivery:**
+```xml
+<dist:delivery>
+    <dist:install-time/>
+</dist:delivery>
+```
+
+## Accelerator Fallback
+
+LiteRT automatically handles fallback when NPU is unavailable:
+
+**Priority order:** NPU → GPU → CPU
+
+Partial delegation is supported - unsupported operations run on fallback accelerators seamlessly.
+
+## Performance Benchmarks (Snapdragon 8 Elite)
+
+- NPU: Up to 100x faster than CPU
+- NPU: ~10x faster than GPU
+- 50+ models run in under 5ms
+- Power usage: ~1/5 of CPU


### PR DESCRIPTION
## Summary

Adds a new skill for **Google LiteRT** — the universal framework for on-device AI (successor to TensorFlow Lite).

## What This Skill Provides

| Topic | Description |
|-------|-------------|
| **GPU Acceleration** | OpenCL, OpenGL, Metal, WebGPU setup with zero-copy buffers |
| **NPU Acceleration** | Qualcomm & MediaTek support, AOT/JIT compilation |
| **LiteRT-LM** | Deploy LLMs (Gemma, Phi, Qwen) on device |
| **Model Conversion** | PyTorch, TensorFlow, JAX → .tflite |
| **Migration** | TensorFlow Lite → LiteRT migration guide |

## Supported Platforms

- Android, iOS, macOS, Windows, Linux, Web
- GPU acceleration via OpenCL, OpenGL, Metal, WebGPU
- NPU support for Qualcomm and MediaTek chipsets

## Trigger Examples

- "Help me deploy a model on Android with GPU acceleration"
- "Convert my PyTorch model to tflite"
- "Run Gemma on device with LiteRT-LM"
- "Migrate from TensorFlow Lite to LiteRT"

## Files Added

- `skills/litert/SKILL.md` - Main skill file
- `skills/litert/metadata.json` - Skill metadata
- `skills/litert/references/` - Detailed guides for GPU, NPU, LLMs, conversion, migration

## Resources Used

- [LiteRT Documentation](https://ai.google.dev/edge/litert)
- [LiteRT GitHub](https://github.com/google-ai-edge/LiteRT)
- [LiteRT-LM GitHub](https://github.com/google-ai-edge/LiteRT-LM)

## License

MIT

---

🤖 Generated with [Claude Code](https://claude.ai/code)