### PR TITLE
fix: clarify use client directive placement in code examples

### DIFF
--- a/skills/react-best-practices/AGENTS.md
+++ b/skills/react-best-practices/AGENTS.md
@@ -702,7 +702,7 @@ RSC→client serialization deduplicates by object reference, not value. Same ref
 // RSC: send once
 <ClientList usernames={usernames} />
 
-// Client: transform there
+// Client: transform there (in separate file or at top)
 'use client'
 const sorted = useMemo(() => [...usernames].sort(), [usernames])
 ```
@@ -787,7 +787,7 @@ Reference: [https://github.com/isaacs/node-lru-cache](https://github.com/isaacs/
 
 The React Server/Client boundary serializes all object properties into strings and embeds them in the HTML response and subsequent RSC requests. This serialized data directly impacts page weight and load time, so **size matters a lot**. Only pass fields that the client actually uses.
 
-**Incorrect: serializes all 50 fields**
+**Incorrect (serializes all 50 fields):**
 
 ```tsx
 async function Page() {
@@ -795,13 +795,14 @@ async function Page() {
   return <Profile user={user} />
 }
 
+// In a separate file (Profile.tsx):
 'use client'
 function Profile({ user }: { user: User }) {
   return <div>{user.name}</div>  // uses 1 field
 }
 ```
 
-**Correct: serializes only 1 field**
+**Correct (serializes only 1 field):**
 
 ```tsx
 async function Page() {
@@ -809,6 +810,7 @@ async function Page() {
   return <Profile name={user.name} />
 }
 
+// In a separate file (Profile.tsx):
 'use client'
 function Profile({ name }: { name: string }) {
   return <div>{name}</div>

--- a/skills/react-best-practices/rules/server-dedup-props.md
+++ b/skills/react-best-practices/rules/server-dedup-props.md
@@ -24,7 +24,7 @@ RSC→client serialization deduplicates by object reference, not value. Same ref
 // RSC: send once
 <ClientList usernames={usernames} />
 
-// Client: transform there
+// In a separate file or at top of this file:
 'use client'
 const sorted = useMemo(() => [...usernames].sort(), [usernames])
 ```

--- a/skills/react-best-practices/rules/server-serialization.md
+++ b/skills/react-best-practices/rules/server-serialization.md
@@ -17,6 +17,7 @@ async function Page() {
   return <Profile user={user} />
 }
 
+// In a separate file (Profile.tsx):
 'use client'
 function Profile({ user }: { user: User }) {
   return <div>{user.name}</div>  // uses 1 field
@@ -31,6 +32,7 @@ async function Page() {
   return <Profile name={user.name} />
 }
 
+// In a separate file (Profile.tsx):
 'use client'
 function Profile({ name }: { name: string }) {
   return <div>{name}</div>


### PR DESCRIPTION
## Summary

Fixes the placement of 'use client' directive in code examples. The directive should be shown as being in a separate file or at the top of the file, not inline within code blocks showing RSC examples.

## Changes

- **server-dedup-props.md**: Clarified that 'use client' goes at the top of a separate client file
- **server-serialization.md**: Same fix
- **AGENTS.md**: Same fix for all 3 instances

This fixes issue #136 which reports that showing 'use client' inline in RSC code examples is confusing and technically incorrect.