### PR TITLE
Refactor "Prevent Waterfall Chains" example to use Promise chaining

### DIFF
--- a/packages/react-best-practices-build/test-cases.json
+++ b/packages/react-best-practices-build/test-cases.json
@@ -59,7 +59,7 @@
     "ruleId": "",
     "ruleTitle": "Prevent Waterfall Chains in API Routes",
     "type": "good",
-    "code": "export async function GET(request: Request) {\n  const sessionPromise = auth()\n  const configPromise = fetchConfig()\n  const session = await sessionPromise\n  const [config, data] = await Promise.all([\n    configPromise,\n    fetchData(session.user.id)\n  ])\n  return Response.json({ data, config })\n}",
+    "code": "export async function GET(request: Request) {\n  const configPromise = fetchConfig()\n  const dataPromise = auth().then(session => fetchData(session.user.id))\n  const [config, data] = await Promise.all([\n    configPromise,\n    dataPromise\n  ])\n  return Response.json({ data, config })\n}",
     "language": "typescript",
     "description": "auth and config start immediately"
   },

--- a/skills/react-best-practices/AGENTS.md
+++ b/skills/react-best-practices/AGENTS.md
@@ -238,12 +238,11 @@ export async function GET(request: Request) {
 
 ```typescript
 export async function GET(request: Request) {
-  const sessionPromise = auth()
   const configPromise = fetchConfig()
-  const session = await sessionPromise
+  const dataPromise = auth().then(session => fetchData(session.user.id))
   const [config, data] = await Promise.all([
     configPromise,
-    fetchData(session.user.id)
+    dataPromise
   ])
   return Response.json({ data, config })
 }

--- a/skills/react-best-practices/rules/async-api-routes.md
+++ b/skills/react-best-practices/rules/async-api-routes.md
@@ -24,12 +24,11 @@ export async function GET(request: Request) {
 
 ```typescript
 export async function GET(request: Request) {
-  const sessionPromise = auth()
   const configPromise = fetchConfig()
-  const session = await sessionPromise
+  const dataPromise = auth().then(session => fetchData(session.user.id))
   const [config, data] = await Promise.all([
     configPromise,
-    fetchData(session.user.id)
+    dataPromise
   ])
   return Response.json({ data, config })
 }


### PR DESCRIPTION

This PR updates the "good" example for the "Prevent Waterfall Chains in API Routes" rule.

The previous example initiated promises but awaited the session explicitly to start the dependent fetch:
```typescript
const session = await sessionPromise
// ...
fetchData(session.user.id)
```

The updated example uses promise chaining (`.then()`) to handle the dependent request (`auth` -> `fetchData`):
```typescript
const dataPromise = auth().then(session => fetchData(session.user.id))
```

This allows all top-level promises to be passed directly to `Promise.all`, avoiding any intermediate blocking `await` in the function body and promoting a more declarative concurrency pattern.
