### PR TITLE
fix(react-best-practices): correct rule 5.4 - memo checks props not default parameter values

### DIFF
--- a/skills/react-best-practices/AGENTS.md
+++ b/skills/react-best-practices/AGENTS.md
@@ -1797,14 +1797,19 @@ function UserProfile({ user, theme }) {
 
 **Impact: MEDIUM (restores memoization by using a constant for default value)**
 
-When memoized component has a default value for some non-primitive optional parameter, such as an array, function, or object, calling the component without that parameter results in broken memoization. This is because new value instances are created on every rerender, and they do not pass strict equality comparison in `memo()`.
+`memo()` compares **incoming props**, not internal default parameter values. A default like `onClick = () => {}` is only evaluated inside the component body after `memo` has already decided whether to re-render — so it does not affect memoization on its own.
 
-To address this issue, extract the default value into a constant.
+However, when the component is called without that prop and the default value is used as a dependency in `useEffect`, `useCallback`, or `useMemo`, a new function instance is created on every render. This causes those hooks to re-run unnecessarily on every render.
 
-**Incorrect: `onClick` has different values on every rerender**
+To fix this, extract the default value into a constant at the module level.
 
+**Incorrect (`onClick` default creates a new instance on every render, causing `useEffect` to re-run):**
 ```tsx
 const UserAvatar = memo(function UserAvatar({ onClick = () => {} }: { onClick?: () => void }) {
+  useEffect(() => {
+    document.addEventListener('click', onClick)
+    return () => document.removeEventListener('click', onClick)
+  }, [onClick]) // ← new function instance on every render = effect re-runs constantly
   // ...
 })
 
@@ -1812,12 +1817,15 @@ const UserAvatar = memo(function UserAvatar({ onClick = () => {} }: { onClick?: 
 <UserAvatar />
 ```
 
-**Correct: stable default value**
-
+**Correct (stable default value):**
 ```tsx
-const NOOP = () => {};
+const NOOP = () => {}
 
 const UserAvatar = memo(function UserAvatar({ onClick = NOOP }: { onClick?: () => void }) {
+  useEffect(() => {
+    document.addEventListener('click', onClick)
+    return () => document.removeEventListener('click', onClick)
+  }, [onClick]) // ← stable reference, effect only re-runs when onClick genuinely changes
   // ...
 })
 

--- a/skills/react-best-practices/rules/rerender-memo-with-default-value.md
+++ b/skills/react-best-practices/rules/rerender-memo-with-default-value.md
@@ -7,13 +7,9 @@ tags: rerender, memo, optimization
 
 ## Extract Default Non-primitive Parameter Value from Memoized Component to Constant
 
-`memo()` compares **incoming props**, not internal default parameter values. A default like `onClick = () => {}` is only evaluated inside the component body after `memo` has already decided whether to re-render — so it does not affect memoization on its own.
+`memo()` compares **incoming props**, not internal default parameter values. A default like `onClick = () => {}` is only evaluated inside the component body after `memo` has already decided whether to re-render — so it does not affect memoization on its own. However, when the component is called without that prop and the default value is used as a dependency in `useEffect`, `useCallback`, or `useMemo`, a new function instance is created on every render, causing those hooks to re-run unnecessarily. To fix this, extract the default value into a constant at the module level.
 
-However, when the component is called without that prop and the default value is used as a dependency in `useEffect`, `useCallback`, or `useMemo`, a new function instance is created on every render. This causes those hooks to re-run unnecessarily.
-
-To fix this, extract the default value into a constant at the module level.
-
-### Bad Example
+**Incorrect:**
 ```tsx
 const UserAvatar = memo(function UserAvatar({ onClick = () => {} }: { onClick?: () => void }) {
   useEffect(() => {
@@ -27,7 +23,7 @@ const UserAvatar = memo(function UserAvatar({ onClick = () => {} }: { onClick?: 
 <UserAvatar />
 ```
 
-### Good Example
+**Correct:**
 ```tsx
 const NOOP = () => {}
 

--- a/skills/react-best-practices/rules/rerender-memo-with-default-value.md
+++ b/skills/react-best-practices/rules/rerender-memo-with-default-value.md
@@ -1,17 +1,20 @@
-title	impact	impactDescription	tags
-Extract Default Non-primitive Parameter Value from Memoized Component to Constant
-MEDIUM
-restores memoization by using a constant for default value
-rerender, memo, optimization
-Extract Default Non-primitive Parameter Value from Memoized Component to Constant
-memo() compares incoming props, not internal default parameter values. A default like onClick = () => {} is only evaluated inside the component body after memo has already decided whether to re-render — so it does not affect memoization on its own.
+---
+title: Extract Default Non-primitive Parameter Value from Memoized Component to Constant
+impact: MEDIUM
+impactDescription: restores memoization by using a constant for default value
+tags: rerender, memo, optimization
+---
 
-However, when the component is called without that prop and the default value is used as a dependency in useEffect, useCallback, or useMemo, a new function instance is created on every render. This causes those hooks to re-run unnecessarily on every render.
+## Extract Default Non-primitive Parameter Value from Memoized Component to Constant
+
+`memo()` compares **incoming props**, not internal default parameter values. A default like `onClick = () => {}` is only evaluated inside the component body after `memo` has already decided whether to re-render — so it does not affect memoization on its own.
+
+However, when the component is called without that prop and the default value is used as a dependency in `useEffect`, `useCallback`, or `useMemo`, a new function instance is created on every render. This causes those hooks to re-run unnecessarily.
 
 To fix this, extract the default value into a constant at the module level.
 
-Incorrect (onClick default creates a new instance on every render, causing useEffect to re-run):
-
+### Bad Example
+```tsx
 const UserAvatar = memo(function UserAvatar({ onClick = () => {} }: { onClick?: () => void }) {
   useEffect(() => {
     document.addEventListener('click', onClick)
@@ -22,8 +25,10 @@ const UserAvatar = memo(function UserAvatar({ onClick = () => {} }: { onClick?: 
 
 // Used without optional onClick
 <UserAvatar />
-Correct (stable default value):
+```
 
+### Good Example
+```tsx
 const NOOP = () => {}
 
 const UserAvatar = memo(function UserAvatar({ onClick = NOOP }: { onClick?: () => void }) {
@@ -36,3 +41,4 @@ const UserAvatar = memo(function UserAvatar({ onClick = NOOP }: { onClick?: () =
 
 // Used without optional onClick
 <UserAvatar />
+```

--- a/skills/react-best-practices/rules/rerender-memo-with-default-value.md
+++ b/skills/react-best-practices/rules/rerender-memo-with-default-value.md
@@ -1,38 +1,38 @@
----
+title	impact	impactDescription	tags
+Extract Default Non-primitive Parameter Value from Memoized Component to Constant
+MEDIUM
+restores memoization by using a constant for default value
+rerender, memo, optimization
+Extract Default Non-primitive Parameter Value from Memoized Component to Constant
+memo() compares incoming props, not internal default parameter values. A default like onClick = () => {} is only evaluated inside the component body after memo has already decided whether to re-render — so it does not affect memoization on its own.
 
-title: Extract Default Non-primitive Parameter Value from Memoized Component to Constant
-impact: MEDIUM
-impactDescription: restores memoization by using a constant for default value
-tags: rerender, memo, optimization
+However, when the component is called without that prop and the default value is used as a dependency in useEffect, useCallback, or useMemo, a new function instance is created on every render. This causes those hooks to re-run unnecessarily on every render.
 
----
+To fix this, extract the default value into a constant at the module level.
 
-## Extract Default Non-primitive Parameter Value from Memoized Component to Constant
+Incorrect (onClick default creates a new instance on every render, causing useEffect to re-run):
 
-When memoized component has a default value for some non-primitive optional parameter, such as an array, function, or object, calling the component without that parameter results in broken memoization. This is because new value instances are created on every rerender, and they do not pass strict equality comparison in `memo()`.
-
-To address this issue, extract the default value into a constant.
-
-**Incorrect (`onClick` has different values on every rerender):**
-
-```tsx
 const UserAvatar = memo(function UserAvatar({ onClick = () => {} }: { onClick?: () => void }) {
+  useEffect(() => {
+    document.addEventListener('click', onClick)
+    return () => document.removeEventListener('click', onClick)
+  }, [onClick]) // ← new function instance on every render = effect re-runs constantly
   // ...
 })
 
 // Used without optional onClick
 <UserAvatar />
-```
+Correct (stable default value):
 
-**Correct (stable default value):**
-
-```tsx
-const NOOP = () => {};
+const NOOP = () => {}
 
 const UserAvatar = memo(function UserAvatar({ onClick = NOOP }: { onClick?: () => void }) {
+  useEffect(() => {
+    document.addEventListener('click', onClick)
+    return () => document.removeEventListener('click', onClick)
+  }, [onClick]) // ← stable reference, effect only re-runs when onClick genuinely changes
   // ...
 })
 
 // Used without optional onClick
 <UserAvatar />
-```


### PR DESCRIPTION
Closes #140

The original rule 5.4 incorrectly claimed that using a default non-primitive parameter (like `onClick = () => {}`) in a `memo` component breaks memoization when called without that prop.

This is inaccurate. `memo()` compares **incoming props**, not internal default values. When `<UserAvatar />` is called without `onClick`, memo sees `undefined === undefined` and correctly skips the re-render.

The real issue occurs when the default value is used as a dependency in `useEffect`, `useCallback`, or `useMemo` — a new function instance is created on every render, causing those hooks to re-run unnecessarily.

### Changes
- Corrected the description in `rerender-memo-with-default-value.md` and `AGENTS.md`
- Updated the bad/good examples to show the actual problematic scenario (hook dependency arrays, not memo prop comparison)