### PR TITLE
feat: package agent-skills as a Cursor plugin

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "vercel-agent-skills",
+  "displayName": "Vercel Agent Skills",
+  "version": "1.0.0",
+  "description": "Collection of Vercel-authored skills for React, React Native, web design reviews, and deploy workflows.",
+  "author": {
+    "name": "Vercel"
+  },
+  "publisher": "Vercel",
+  "homepage": "https://github.com/vercel-labs/agent-skills",
+  "repository": "https://github.com/vercel-labs/agent-skills",
+  "license": "MIT",
+  "keywords": [
+    "cursor",
+    "plugin",
+    "skills",
+    "react",
+    "nextjs",
+    "react-native",
+    "vercel"
+  ],
+  "category": "developer-tools",
+  "tags": [
+    "frontend",
+    "performance",
+    "deployment"
+  ],
+  "skills": "./skills/"
+}

--- a/README.md
+++ b/README.md
@@ -116,8 +116,18 @@ Claim URL:   https://vercel.com/claim-deployment?code=...
 
 ## Installation
 
+### Agent Skills CLI
+
 ```bash
 npx skills add vercel-labs/agent-skills
+```
+
+### Cursor plugin
+
+Install with:
+
+```bash
+/add-plugin vercel-agent-skills
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- add `.cursor-plugin/plugin.json` to package this repository as a single Cursor plugin (`vercel-agent-skills`)
- document Cursor plugin installation in `README.md` while keeping Agent Skills CLI installation first
- keep the existing skills layout unchanged and expose skills via `./skills/`

## Test plan
- [x] Validate plugin manifest JSON: `python3 -m json.tool .cursor-plugin/plugin.json`
- [ ] Install locally in Cursor via `/add-plugin vercel-agent-skills`

Made with [Cursor](https://cursor.com)