### PR TITLE
Add auth pages & middleware guidance for Next.js route protection

### DIFF
--- a/skills/react-best-practices/SKILL.md
+++ b/skills/react-best-practices/SKILL.md
@@ -116,6 +116,13 @@ Reference these guidelines when:
 - `advanced-init-once` - Initialize app once per app load
 - `advanced-use-latest` - useLatest for stable callback refs
 
+### Auth Pages & Middleware
+
+When implementing authentication with middleware-based route protection:
+- **Always exclude auth-related pages** (`/login`, `/reset-password`, `/signup`, etc.) from the middleware auth gate so they remain accessible without a session.
+- **Hide app chrome** (nav bars, sidebars) on auth pages — these pages are standalone and should not render authenticated UI.
+- **Always include a password reset flow** when using email/password auth. Users who forget their password need a self-service recovery path. See the Supabase skill for the full implementation checklist.
+
 ## How to Use
 
 Read individual rule files for detailed explanations and code examples:


### PR DESCRIPTION
## Summary
- Adds an "Auth Pages & Middleware" subsection to the React best practices skill
- Covers three rules: exclude auth pages from middleware gate, hide app chrome on auth pages, always include password reset flow
- Cross-references the Supabase skill for the full implementation checklist

## Motivation
Middleware-based auth gates are a common Next.js pattern, but it's easy to forget to exclude auth-related pages (reset-password, signup) or to accidentally render authenticated UI on those pages. This guidance catches those mistakes.

## Test plan
- [ ] Install the updated skill and verify Claude references these rules when implementing auth middleware
- [ ] Confirm the section renders correctly in SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)