### PR TITLE
fix(react-best-practices): add TypeScript warning for barrel import workarounds

### DIFF
--- a/skills/react-best-practices/rules/bundle-barrel-imports.md
+++ b/skills/react-best-practices/rules/bundle-barrel-imports.md
@@ -24,35 +24,36 @@ import { Button, TextField } from '@mui/material'
 // Loads 2,225 modules, takes ~4.2s extra in dev
 ```
 
-**Correct (imports only what you need):**
-
-```tsx
-import Check from 'lucide-react/dist/esm/icons/check'
-import X from 'lucide-react/dist/esm/icons/x'
-import Menu from 'lucide-react/dist/esm/icons/menu'
-// Loads only 3 modules (~2KB vs ~1MB)
-
-import Button from '@mui/material/Button'
-import TextField from '@mui/material/TextField'
-// Loads only what you use
-```
-
-**Alternative (Next.js 13.5+):**
+**Correct - Next.js 13.5+ (recommended):**
 
 ```js
-// next.config.js - use optimizePackageImports
+// next.config.js - automatically optimizes barrel imports at build time
 module.exports = {
   experimental: {
     optimizePackageImports: ['lucide-react', '@mui/material']
   }
 }
-
-// Then you can keep the ergonomic barrel imports:
-import { Check, X, Menu } from 'lucide-react'
-// Automatically transformed to direct imports at build time
 ```
 
-Direct imports provide 15-70% faster dev boot, 28% faster builds, 40% faster cold starts, and significantly faster HMR.
+```tsx
+// Keep the standard imports - Next.js transforms them to direct imports
+import { Check, X, Menu } from 'lucide-react'
+// Full TypeScript support, no manual path wrangling
+```
+
+This is the recommended approach because it preserves TypeScript type safety and editor autocompletion while still eliminating the barrel import cost.
+
+**Correct - Direct imports (non-Next.js projects):**
+
+```tsx
+import Button from '@mui/material/Button'
+import TextField from '@mui/material/TextField'
+// Loads only what you use
+```
+
+> **TypeScript warning:** Some libraries (notably `lucide-react`) don't ship `.d.ts` files for their deep import paths. Importing from `lucide-react/dist/esm/icons/check` resolves to an implicit `any` type, causing errors under `strict` or `noImplicitAny`. Prefer `optimizePackageImports` when available, or verify the library exports types for its subpaths before using direct imports.
+
+These optimizations provide 15-70% faster dev boot, 28% faster builds, 40% faster cold starts, and significantly faster HMR.
 
 Libraries commonly affected: `lucide-react`, `@mui/material`, `@mui/icons-material`, `@tabler/icons-react`, `react-icons`, `@headlessui/react`, `@radix-ui/react-*`, `lodash`, `ramda`, `date-fns`, `rxjs`, `react-use`.
 


### PR DESCRIPTION
## Summary

Restructures the barrel imports rule to promote `optimizePackageImports` as the primary recommendation and adds a TypeScript warning for direct imports.

## Why this matters

The current rule recommends direct imports like `import Check from 'lucide-react/dist/esm/icons/check'`, but lucide-react doesn't ship `.d.ts` files for individual icons. This creates implicit "any" type errors in TypeScript projects ([#99](https://github.com/vercel-labs/agent-skills/issues/99)). @shuding [noted](https://github.com/vercel-labs/agent-skills/issues/99#issuecomment-3796979119) that lucide-react may be a bad example for this rule.

## Changes

- Promoted `optimizePackageImports` (Next.js 13.5+) as the recommended approach since it preserves type safety
- Added a TypeScript warning to the direct import section explaining the `.d.ts` limitation
- Kept direct imports as a valid alternative for non-Next.js projects

## Testing

Reviewed rule formatting for consistency with other rule files in the repo.

Fixes #99

This contribution was developed with AI assistance (Claude Code).