### PR TITLE
fix(react-best-practices): warn about Set/Map recreation in function scope

### DIFF
--- a/skills/react-best-practices/rules/js-set-map-lookups.md
+++ b/skills/react-best-practices/rules/js-set-map-lookups.md
@@ -22,3 +22,25 @@ items.filter(item => allowedIds.includes(item.id))
 const allowedIds = new Set(['a', 'b', 'c', ...])
 items.filter(item => allowedIds.has(item.id))
 ```
+
+### Common Pitfall: Recreating Set/Map Inside Functions
+
+Creating a Set inside a function that runs repeatedly negates the benefit - Set construction is O(n), so you pay O(n) on every call instead of once.
+
+**Incorrect (recreated every call):**
+
+```typescript
+function isAllowed(id: string) {
+  const allowedIds = new Set(['a', 'b', 'c', ...])
+  return allowedIds.has(id)
+}
+```
+
+**Correct (created once at module level):**
+
+```typescript
+const allowedIds = new Set(['a', 'b', 'c', ...])
+
+function isAllowed(id: string) {
+  return allowedIds.has(id)
+}


### PR DESCRIPTION
## Summary

Adds a warning about the common pitfall of recreating Set/Map inside functions called repeatedly, which negates the O(1) lookup benefit.

## Why this matters

The current rule shows converting arrays to Set for O(1) lookups but doesn't warn about a common pitfall: creating the Set inside a function body that runs on every call ([#54](https://github.com/vercel-labs/agent-skills/issues/54)). This means Set construction (O(n)) runs every time, negating the performance benefit. An AI agent or junior developer following the rule literally could produce this anti-pattern.

## Changes

- Added a "Common Pitfall" section showing the anti-pattern of Set recreation inside functions
- Added the correct pattern of hoisting Set to module level
- Kept existing rule content unchanged (additive change only)

## Testing

Reviewed rule formatting for consistency with other rule files in the repo.

Fixes #54

This contribution was developed with AI assistance (Claude Code).