### PR TITLE
fix(react-native-skills): add platform notes for iOS-only ScrollView props

### DIFF
--- a/skills/react-native-skills/rules/ui-safe-area-scroll.md
+++ b/skills/react-native-skills/rules/ui-safe-area-scroll.md
@@ -9,6 +9,8 @@ tags: safe-area, scrollview, layout
 
 Use `contentInsetAdjustmentBehavior="automatic"` on the root ScrollView instead of wrapping content in SafeAreaView or manual padding. This lets iOS handle safe area insets natively with proper scroll behavior.
 
+> **Platform note:** `contentInsetAdjustmentBehavior` is an iOS-only prop. On Android, it is silently ignored.
+
 **Incorrect (SafeAreaView wrapper):**
 
 ```tsx
@@ -63,3 +65,31 @@ function MyScreen() {
 ```
 
 The native approach handles dynamic safe areas (keyboard, toolbars) and allows content to scroll behind the status bar naturally.
+
+### Cross-platform alternative
+
+For cross-platform projects, combine `contentInsetAdjustmentBehavior` on iOS with `react-native-safe-area-context` padding on Android:
+
+```tsx
+import { Platform, ScrollView, View, Text } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+
+function MyScreen() {
+  const insets = useSafeAreaInsets()
+
+  return (
+    <ScrollView
+      contentInsetAdjustmentBehavior="automatic"
+      contentContainerStyle={Platform.select({
+        android: { paddingTop: insets.top },
+      })}
+    >
+      <View>
+        <Text>Content</Text>
+      </View>
+    </ScrollView>
+  )
+}
+```
+
+On iOS, `contentInsetAdjustmentBehavior` handles safe areas natively. On Android, the `contentContainerStyle` padding provides equivalent spacing.

--- a/skills/react-native-skills/rules/ui-scrollview-content-inset.md
+++ b/skills/react-native-skills/rules/ui-scrollview-content-inset.md
@@ -9,8 +9,10 @@ tags: scrollview, layout, contentInset, performance
 
 When adding space to the top or bottom of a ScrollView that may change
 (keyboard, toolbars, dynamic content), use `contentInset` instead of padding.
-Changing `contentInset` doesn't trigger layout recalculation—it adjusts the
+Changing `contentInset` doesn't trigger layout recalculation - it adjusts the
 scroll area without re-rendering content.
+
+> **Platform note:** `contentInset` and `scrollIndicatorInsets` are iOS-only props. On Android, use `contentContainerStyle` padding instead (see cross-platform example below).
 
 **Incorrect (padding causes layout recalculation):**
 
@@ -43,3 +45,31 @@ function Feed({ bottomOffset }: { bottomOffset: number }) {
 
 Use `scrollIndicatorInsets` alongside `contentInset` to keep the scroll
 indicator aligned. For static spacing that never changes, padding is fine.
+
+### Cross-platform alternative
+
+For cross-platform projects, use `Platform.select` to apply `contentInset` on iOS and `contentContainerStyle` padding on Android:
+
+```tsx
+import { Platform, ScrollView } from 'react-native'
+
+function Feed({ bottomOffset }: { bottomOffset: number }) {
+  return (
+    <ScrollView
+      {...Platform.select({
+        ios: {
+          contentInset: { bottom: bottomOffset },
+          scrollIndicatorInsets: { bottom: bottomOffset },
+        },
+        android: {
+          contentContainerStyle: { paddingBottom: bottomOffset },
+        },
+      })}
+    >
+      {children}
+    </ScrollView>
+  )
+}
+```
+
+On Android, `contentContainerStyle` padding is the standard approach for dynamic scroll spacing.


### PR DESCRIPTION
## Summary

Adds platform notes and cross-platform guidance to two react-native-skills rules that recommend iOS-only ScrollView props without mentioning their platform limitations.

## Why this matters

Two rules suggest iOS-only APIs as universal solutions ([#144](https://github.com/vercel-labs/agent-skills/issues/144)):
- `ui-safe-area-scroll.md` recommends `contentInsetAdjustmentBehavior` (iOS-only)
- `ui-scrollview-content-inset.md` recommends `contentInset` and `scrollIndicatorInsets` (iOS-only)

An AI agent following these rules on a cross-platform project would generate code that silently does nothing on Android.

## Changes

- Added iOS-only platform notes to both rule files
- Added cross-platform alternatives using `Platform.select` and `react-native-safe-area-context`
- Kept existing iOS-specific guidance intact (additive changes only)

## Testing

Reviewed rule formatting for consistency with other rule files in the repo.

cc @nandorojo

Fixes #144

This contribution was developed with AI assistance (Claude Code).