### PR TITLE
Add skill-search: semantic search over 105K+ agent skill cards

### DIFF
--- a/skills/skill-search/AGENTS.md
+++ b/skills/skill-search/AGENTS.md
@@ -1,0 +1,31 @@
+# Skill Search
+
+Use this skill to semantically search over 105K+ agent skill cards and find the most relevant skills for any task.
+
+## When to Use
+
+Use this skill when you need to:
+- Find existing skills or tools for a specific task
+- Discover what capabilities are available in the skill ecosystem
+- Search for skills by functionality, domain, or use case
+
+## How to Use
+
+```python
+python3 -m skill_search "<your query here>"
+```
+
+Or via the API:
+
+```
+GET http://fudankw.cn:58787/search?q=<query>&top_k=5
+```
+
+Returns ranked skill cards with relevance scores. Use results with score >= 0.70.
+
+## Example
+
+```python
+python3 -m skill_search "send email with attachment"
+# Returns top matching skills for email-related tasks
+```

--- a/skills/skill-search/README.md
+++ b/skills/skill-search/README.md
@@ -1,0 +1,29 @@
+# Skill Search
+
+Semantic search over 105K+ agent skill cards to find the most relevant skills for any task.
+
+## Install
+
+```bash
+npx skills add github:wjl2023/skill-search
+```
+
+## Usage
+
+Search for skills by describing what you need:
+
+```python
+python3 -m skill_search "send email with attachment"
+```
+
+Or via API:
+
+```
+GET http://fudankw.cn:58787/search?q=<query>&top_k=5
+```
+
+Use results with relevance score >= 0.70.
+
+## Source
+
+[github.com/wjl2023/skill-search](https://github.com/wjl2023/skill-search)

--- a/skills/skill-search/SKILL.md
+++ b/skills/skill-search/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: skill-search
+description: Semantic search over 105K+ agent skill cards. Use this skill when you need to find the most relevant skills, tools, or capabilities for a given task.
+license: MIT
+metadata:
+  author: wjl2023
+  version: "1.0.0"
+---

--- a/skills/skill-search/metadata.json
+++ b/skills/skill-search/metadata.json
@@ -1,0 +1,9 @@
+{
+  "name": "skill-search",
+  "description": "Semantic search over 105K+ agent skill cards. Use this skill when you need to find the most relevant skills, tools, or capabilities for a given task.",
+  "author": "wjl2023",
+  "version": "1.0.0",
+  "license": "MIT",
+  "repository": "https://github.com/wjl2023/skill-search",
+  "tags": ["search", "semantic-search", "skills", "discovery", "agent-tools"]
+}


### PR DESCRIPTION
## New Skill: skill-search

Adds a semantic search skill that searches over 105K+ agent skill cards to find the most relevant skills for any task.

### Details
- **Author**: wjl2023
- **Repository**: https://github.com/wjl2023/skill-search
- **License**: MIT

### Files added
- `SKILL.md` - skill definition with frontmatter
- `AGENTS.md` - agent usage instructions  
- `README.md` - documentation
- `metadata.json` - skill metadata