### PR TITLE
Add vercel-react-view-transitions skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,28 @@ React Native best practices optimized for AI agents. Contains 16 rules across 7 
 - Architecture (Medium) - monorepo structure, imports
 - Platform (Medium) - iOS/Android specific patterns
 
+### react-view-transitions
+
+Implement smooth, native-feeling animations using React's View Transition API. Covers the `<ViewTransition>` component, `addTransitionType`, transition types, and Next.js integration including the `transitionTypes` prop on `next/link`.
+
+**Use when:**
+- Adding page transitions or route animations
+- Animating enter/exit of components
+- Creating shared element transitions (list-to-detail morphing)
+- Implementing directional (forward/back) navigation animations
+- Integrating view transitions in Next.js App Router
+- Animating list reorder or Suspense fallback reveals
+
+**Topics covered:**
+- `<ViewTransition>` component (enter, exit, update, share triggers)
+- `addTransitionType` for directional/context-specific animations
+- View Transition Classes and CSS pseudo-elements
+- Shared element transitions with the `name` prop
+- JavaScript animations via Web Animations API
+- Next.js `transitionTypes` prop on `next/link`
+- Ready-to-use CSS animation recipes (fade, slide, scale, flip)
+- Accessibility (`prefers-reduced-motion`)
+
 ### composition-patterns
 
 React composition patterns that scale. Helps avoid boolean prop proliferation through compound components, state lifting, and internal composition.

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -337,7 +337,17 @@ Triggering the reorder inside `startTransition` will smoothly animate each item 
 
 ### Animate Suspense Fallback to Content
 
-The production pattern is to give the fallback an **exit-only** animation and the content an **enter-only** animation with `default="none"`. This is more intentional than a blanket crossfade and prevents the content VT from re-animating on every subsequent route navigation:
+Wrap `<Suspense>` in `<ViewTransition>` to cross-fade from fallback to loaded content:
+
+```jsx
+<ViewTransition>
+  <Suspense fallback={<Skeleton />}>
+    <AsyncContent />
+  </Suspense>
+</ViewTransition>
+```
+
+For directional motion, give the fallback and content separate VTs with explicit triggers. Use `default="none"` on the content VT to prevent it from re-animating on unrelated transitions:
 
 ```jsx
 <Suspense
@@ -351,18 +361,6 @@ The production pattern is to give the fallback an **exit-only** animation and th
     <AsyncContent />
   </ViewTransition>
 </Suspense>
-```
-
-The skeleton slides down when content replaces it (`exit`). The content slides up when it first appears (`enter`). `default="none"` on the content VT ensures it stays silent during unrelated transitions (e.g., link navigations that trigger the layout-level VT).
-
-For a simple crossfade without directional motion, wrap the whole `<Suspense>` instead:
-
-```jsx
-<ViewTransition>
-  <Suspense fallback={<Skeleton />}>
-    <AsyncContent />
-  </Suspense>
-</ViewTransition>
 ```
 
 ### Opt Out of Nested Animations

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -44,7 +44,7 @@ When in doubt, use a bare `<ViewTransition>` (default cross-fade) or `default="n
 
 ## Availability
 
-- `<ViewTransition>` and `addTransitionType` require `react@canary` or `react@experimental`. Check `react --version` — if these APIs are not available, install canary: `npm install react@canary react-dom@canary`.
+- `<ViewTransition>` and `addTransitionType` require `react@canary` or `react@experimental`. They are **not** in stable React (including 19.x). Before implementing, verify the project uses canary — check `package.json` for `"react": "canary"` or run `npm ls react`. If on stable, install canary: `npm install react@canary react-dom@canary`.
 - Browser support: Chromium 111+, with Firefox and Safari adding support. The API gracefully degrades — unsupported browsers skip the animation and apply the DOM change instantly.
 
 ---
@@ -204,7 +204,7 @@ The `default` key inside the object is the fallback when no type matches. If any
 
 React adds transition types as browser view transition types, enabling pure CSS scoping with `:root:active-view-transition-type(type-name)`. **Caveat:** `::view-transition-old(*)` / `::view-transition-new(*)` match **all** named elements — the wildcard can override specific class-based animations. Prefer class-based props for per-component animations; reserve `:active-view-transition-type()` for global rules.
 
-The `types` array is also available as the second argument in event callbacks (`onEnter`, `onExit`, etc.).
+The `types` array is also available as the second argument in event callbacks (`onEnter`, `onExit`, etc.) — see `references/patterns.md`.
 
 ### Types and Suspense: When Types Are Available
 
@@ -259,56 +259,7 @@ Rules for shared element transitions:
 
 ## View Transition Events (JavaScript Animations)
 
-For imperative control, use the `onEnter`, `onExit`, `onUpdate`, and `onShare` callbacks:
-
-```jsx
-<ViewTransition
-  onEnter={(instance, types) => {
-    const anim = instance.new.animate(
-      [{ transform: 'scale(0.8)', opacity: 0 }, { transform: 'scale(1)', opacity: 1 }],
-      { duration: 300, easing: 'ease-out' }
-    );
-    return () => anim.cancel();
-  }}
-  onExit={(instance, types) => {
-    const anim = instance.old.animate(
-      [{ transform: 'scale(1)', opacity: 1 }, { transform: 'scale(0.8)', opacity: 0 }],
-      { duration: 200, easing: 'ease-in' }
-    );
-    return () => anim.cancel();
-  }}
->
-  <Component />
-</ViewTransition>
-```
-
-The `instance` object provides:
-- `instance.old` — the `::view-transition-old` pseudo-element
-- `instance.new` — the `::view-transition-new` pseudo-element
-- `instance.group` — the `::view-transition-group` pseudo-element
-- `instance.imagePair` — the `::view-transition-image-pair` pseudo-element
-- `instance.name` — the `view-transition-name` string
-
-Always return a cleanup function that cancels the animation so the browser can properly handle interruptions.
-
-Only one event fires per `<ViewTransition>` per Transition. `onShare` takes precedence over `onEnter` and `onExit`.
-
-### Using Types in Event Callbacks
-
-The `types` array is available as the second argument to all event callbacks:
-
-```jsx
-<ViewTransition
-  onEnter={(instance, types) => {
-    const duration = types.includes('fast') ? 150 : 500;
-    const anim = instance.new.animate(
-      [{ opacity: 0 }, { opacity: 1 }],
-      { duration, easing: 'ease-out' }
-    );
-    return () => anim.cancel();
-  }}
->
-```
+For imperative control with `onEnter`, `onExit`, `onUpdate`, `onShare` callbacks and the `instance` object (`.old`, `.new`, `.group`, `.imagePair`, `.name`), see `references/patterns.md`. Always return a cleanup function from event handlers. Only one event fires per `<ViewTransition>` per Transition — `onShare` takes precedence over `onEnter`/`onExit`.
 
 ---
 
@@ -354,9 +305,21 @@ Use a `key` prop on `<ViewTransition>` to force an enter/exit animation when a v
 
 When the key changes, React unmounts and remounts the `<ViewTransition>`, which triggers exit on the old instance and enter on the new one. This is useful for animating content swaps driven by URL parameters, tab switches, or any state change where the content identity changes but the component type stays the same.
 
+**Caution with Suspense:** If the `<ViewTransition>` wraps a `<Suspense>`, changing the key remounts the entire Suspense boundary, re-triggering the data fetch. Only use `key` on `<ViewTransition>` outside of Suspense, or accept the refetch.
+
 ### Animate Suspense Fallback to Content
 
-Wrap `<Suspense>` in a bare `<ViewTransition>` for a simple cross-fade, or give fallback and content separate `<ViewTransition>`s for directional motion. Use `default="none"` on the content to prevent re-animation on revalidation:
+The simplest approach: wrap `<Suspense>` in a single `<ViewTransition>` for a zero-config cross-fade from skeleton to content:
+
+```jsx
+<ViewTransition>
+  <Suspense fallback={<Skeleton />}>
+    <Content />
+  </Suspense>
+</ViewTransition>
+```
+
+For directional motion, give the fallback and content separate `<ViewTransition>`s. Use `default="none"` on the content to prevent re-animation on revalidation:
 
 ```jsx
 <Suspense
@@ -374,6 +337,8 @@ Wrap `<Suspense>` in a bare `<ViewTransition>` for a simple cross-fade, or give 
 
 **Why `exit` on the fallback and `enter` on the content?** When Suspense resolves, two things happen simultaneously in one transition: the fallback unmounts (exit) and the content mounts (enter). The fallback slides down and fades out while the content slides up and fades in — creating a smooth handoff. The staggered CSS timing (`enter` delays by the `exit` duration) ensures the skeleton leaves before new content arrives.
 
+**Skeleton dimensions should closely match the content.** If the skeleton renders 3 single-line items but the content renders 5 two-line items, the size difference between the old/new snapshots produces a jarring stagger rather than a smooth transition.
+
 ### Opt Out of Nested Animations
 
 Wrap children in `<ViewTransition update="none">` to prevent them from animating when a parent changes:
@@ -388,121 +353,7 @@ Wrap children in `<ViewTransition update="none">` to prevent them from animating
 </ViewTransition>
 ```
 
-### Isolate Elements from Parent Animations
-
-#### Persistent Layout Elements (Headers, Sidebars)
-
-Sticky headers, navbars, and sidebars that persist across navigations get captured in the page content's transition snapshot. When a directional slide animates the page, the header slides away with it — which looks broken.
-
-Fix: give persistent elements their own `viewTransitionName` and disable animation on their transition group:
-
-```jsx
-<header style={{ viewTransitionName: "dashboard-header" }}>
-  {/* header content */}
-</header>
-```
-
-```css
-::view-transition-group(dashboard-header) {
-  animation: none;
-  z-index: 100;
-}
-```
-
-This isolates the header into its own transition group that stays static during page slides. The element won't be included in the page content's old/new snapshot.
-
-#### Floating Elements (Popovers, Tooltips)
-
-Popovers, tooltips, and dropdowns can also get captured in a parent's view transition snapshot, causing them to ghost or animate unexpectedly. The same pattern applies — give them their own `viewTransitionName`:
-
-```jsx
-<SelectPopover style={{ viewTransitionName: 'popover' }}>
-  {options}
-</SelectPopover>
-```
-
-```css
-::view-transition-group(popover) {
-  z-index: 100;
-}
-```
-
-For a global fix that ensures all view transition groups render above normal content, use the wildcard selector:
-
-```css
-::view-transition-group(*) {
-  z-index: 100;
-}
-```
-
-### Reusable Animated Collapse
-
-For apps with many expand/collapse interactions, extract a reusable wrapper instead of repeating the conditional-render-with-`<ViewTransition>` pattern:
-
-```jsx
-import { ViewTransition } from 'react';
-
-function AnimatedCollapse({ open, children }) {
-  if (!open) return null;
-  return (
-    <ViewTransition enter="expand-in" exit="collapse-out">
-      {children}
-    </ViewTransition>
-  );
-}
-```
-
-Use it with `startTransition` on the toggle:
-
-```jsx
-<button onClick={() => startTransition(() => setOpen(o => !o))}>Toggle</button>
-<AnimatedCollapse open={open}>
-  <SectionContent />
-</AnimatedCollapse>
-```
-
-### Preserve State with Activity
-
-Use `<Activity>` with `<ViewTransition>` to animate show/hide while preserving component state:
-
-```jsx
-import { Activity, ViewTransition, startTransition } from 'react';
-
-<Activity mode={isVisible ? 'visible' : 'hidden'}>
-  <ViewTransition enter="slide-in" exit="slide-out">
-    <Sidebar />
-  </ViewTransition>
-</Activity>
-```
-
-### Exclude Elements from a Transition with `useOptimistic`
-
-When a `startTransition` changes both a control (e.g. a button label) and content (e.g. list order), use `useOptimistic` for the control. The optimistic value updates before React's transition snapshot, so it won't animate. The committed state drives the content, which changes within the transition and animates:
-
-```tsx
-const [sort, setSort] = useState('newest');
-const [optimisticSort, setOptimisticSort] = useOptimistic(sort);
-
-function cycleSort() {
-  const nextSort = getNextSort(optimisticSort);
-  startTransition(() => {
-    setOptimisticSort(nextSort);  // updates before snapshot — no animation
-    setSort(nextSort);            // changes within transition — animates
-  });
-}
-
-// Button uses optimisticSort (instant, excluded from animation)
-<button>Sort: {LABELS[optimisticSort]}</button>
-
-// List uses committed sort (changes between snapshots, animates)
-{items.sort(comparators[sort]).map(item => (
-  <ViewTransition key={item.id}>
-    <ItemCard item={item} />
-  </ViewTransition>
-))}
-```
-
-`useOptimistic` values resolve before the transition snapshot. Any DOM driven by optimistic state is already in its final form when the "before" snapshot is taken, so it doesn't participate in the `<ViewTransition>`. Only DOM driven by committed state (via `setState`) changes between snapshots and animates.
+For more patterns (isolate persistent/floating elements, reusable animated collapse, preserve state with `<Activity>`, exclude elements with `useOptimistic`), see `references/patterns.md`.
 
 ---
 
@@ -594,7 +445,6 @@ Next.js supports React View Transitions. `<ViewTransition>` works out of the box
 To also animate `<Link>` navigations, enable the experimental flag in `next.config.js` (or `next.config.ts`):
 
 ```js
-/** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
     viewTransition: true,
@@ -604,6 +454,8 @@ module.exports = nextConfig;
 ```
 
 **What this flag does:** It wraps every `<Link>` navigation in `document.startViewTransition`, so all mounted `<ViewTransition>` components participate in every link click. Without this flag, only `startTransition`/`Suspense`-triggered transitions animate. This makes the composition rules in "How Multiple `<ViewTransition>`s Interact" especially important: use `default="none"` on layout-level `<ViewTransition>`s to avoid competing animations.
+
+For a detailed guide including App Router patterns and Server Component considerations, see `references/nextjs.md`.
 
 Key points:
 - The `<ViewTransition>` component is imported from `react` directly — no Next.js-specific import.
@@ -617,7 +469,710 @@ Key points:
 <Link href="/products/1" transitionTypes={['transition-to-detail']}>View Product</Link>
 ```
 
-### Layout-Level ViewTransition
+For full examples with shared element transitions and directional animations, see `references/nextjs.md`.
+
+---
+
+## Accessibility
+
+Always respect `prefers-reduced-motion`. React does not disable animations automatically for this preference. Add this to your global CSS:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(*),
+  ::view-transition-new(*),
+  ::view-transition-group(*) {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+  }
+}
+```
+
+Or disable specific animations conditionally in JavaScript events by checking the media query.
+
+---
+
+# Patterns and Guidelines
+
+## Searchable Grid with `useDeferredValue`
+
+A client-side searchable grid where the filtered results cross-fade as the user types. `useDeferredValue` makes the filter update a transition, which activates the wrapping `<ViewTransition>`:
+
+```tsx
+'use client';
+
+import { useDeferredValue, useState, ViewTransition, Suspense } from 'react';
+
+export default function SearchableGrid({ itemsPromise }) {
+  const [search, setSearch] = useState('');
+  const deferredSearch = useDeferredValue(search);
+
+  return (
+    <>
+      <input
+        value={search}
+        onChange={(e) => setSearch(e.currentTarget.value)}
+        placeholder="Search..."
+      />
+      <ViewTransition>
+        <Suspense fallback={<GridSkeleton />}>
+          <ItemGrid itemsPromise={itemsPromise} search={deferredSearch} />
+        </Suspense>
+      </ViewTransition>
+    </>
+  );
+}
+```
+
+## Card Expand/Collapse with `startTransition`
+
+Toggle between a card grid and a detail view using `startTransition` to animate the swap. Add a shared element `name` to morph the card into the detail view:
+
+```tsx
+'use client';
+
+import { useState, useRef, startTransition, ViewTransition } from 'react';
+
+export default function ItemGrid({ items }) {
+  const [expandedId, setExpandedId] = useState(null);
+  const scrollRef = useRef(0);
+
+  return expandedId ? (
+    <ViewTransition enter="slide-in" name={`item-${expandedId}`}>
+      <ItemDetail
+        item={items.find(i => i.id === expandedId)}
+        onClose={() => {
+          startTransition(() => {
+            setExpandedId(null);
+            setTimeout(() => window.scrollTo({ behavior: 'smooth', top: scrollRef.current }), 100);
+          });
+        }}
+      />
+    </ViewTransition>
+  ) : (
+    <div className="grid grid-cols-3 gap-4">
+      {items.map(item => (
+        <ViewTransition key={item.id} name={`item-${item.id}`}>
+          <ItemCard
+            item={item}
+            onSelect={() => {
+              scrollRef.current = window.scrollY;
+              startTransition(() => setExpandedId(item.id));
+            }}
+          />
+        </ViewTransition>
+      ))}
+    </div>
+  );
+}
+```
+
+The shared `name={`item-${id}`}` on both the card and detail `<ViewTransition>` creates a shared element pair — the card morphs into the detail view. The `scrollRef` saves and restores scroll position so users return to where they were in the grid. See `css-recipes.md` for the slide-up/slide-down CSS.
+
+## Type-Safe Transition Helpers
+
+For larger apps, define type-safe transition IDs and transition maps to prevent ID clashes and keep animation configurations consistent. Use `as const` arrays for transition IDs, types, and animation classes, then derive types from them:
+
+```tsx
+import { ViewTransition } from 'react';
+
+const transitionTypes = ['default', 'transition-to-detail', 'transition-to-list', 'transition-backwards', 'transition-forwards'] as const;
+const animationTypes = ['auto', 'none', 'animate-slide-from-left', 'animate-slide-from-right', 'animate-slide-to-left', 'animate-slide-to-right'] as const;
+
+type TransitionType = (typeof transitionTypes)[number];
+type AnimationType = (typeof animationTypes)[number];
+type TransitionMap = { default: AnimationType } & Partial<Record<Exclude<TransitionType, 'default'>, AnimationType>>;
+
+export function HorizontalTransition({ children, enter, exit }: {
+  children: React.ReactNode;
+  enter: TransitionMap;
+  exit: TransitionMap;
+}) {
+  return <ViewTransition enter={enter} exit={exit}>{children}</ViewTransition>;
+}
+```
+
+These wrappers enforce that only valid transition IDs and animation classes are used, catching mistakes at compile time.
+
+## Shared Elements Across Routes in Next.js
+
+See `nextjs.md` (Shared Elements Across Routes) for complete examples using `transitionTypes` on `next/link` combined with shared element `<ViewTransition name={...}>` for list-to-detail image morph animations.
+
+## Isolate Elements from Parent Animations
+
+### Persistent Layout Elements (Headers, Sidebars)
+
+Sticky headers, navbars, and sidebars that persist across navigations get captured in the page content's transition snapshot. When a directional slide animates the page, the header slides away with it — which looks broken.
+
+Fix: give persistent elements their own `viewTransitionName` and disable animation on their transition group:
+
+```jsx
+<header style={{ viewTransitionName: "dashboard-header" }}>
+  {/* header content */}
+</header>
+```
+
+```css
+::view-transition-group(dashboard-header) {
+  animation: none;
+  z-index: 100;
+}
+```
+
+This isolates the header into its own transition group that stays static during page slides. The element won't be included in the page content's old/new snapshot.
+
+### Floating Elements (Popovers, Tooltips)
+
+Popovers, tooltips, and dropdowns can also get captured in a parent's view transition snapshot, causing them to ghost or animate unexpectedly. The same pattern applies — give them their own `viewTransitionName`:
+
+```jsx
+<SelectPopover style={{ viewTransitionName: 'popover' }}>
+  {options}
+</SelectPopover>
+```
+
+```css
+::view-transition-group(popover) {
+  z-index: 100;
+}
+```
+
+For a global fix that ensures all view transition groups render above normal content, use the wildcard selector:
+
+```css
+::view-transition-group(*) {
+  z-index: 100;
+}
+```
+
+## Reusable Animated Collapse
+
+For apps with many expand/collapse interactions, extract a reusable wrapper instead of repeating the conditional-render-with-`<ViewTransition>` pattern:
+
+```jsx
+import { ViewTransition } from 'react';
+
+function AnimatedCollapse({ open, children }) {
+  if (!open) return null;
+  return (
+    <ViewTransition enter="expand-in" exit="collapse-out">
+      {children}
+    </ViewTransition>
+  );
+}
+```
+
+Use it with `startTransition` on the toggle:
+
+```jsx
+<button onClick={() => startTransition(() => setOpen(o => !o))}>Toggle</button>
+<AnimatedCollapse open={open}>
+  <SectionContent />
+</AnimatedCollapse>
+```
+
+## Preserve State with Activity
+
+Use `<Activity>` with `<ViewTransition>` to animate show/hide while preserving component state:
+
+```jsx
+import { Activity, ViewTransition, startTransition } from 'react';
+
+<Activity mode={isVisible ? 'visible' : 'hidden'}>
+  <ViewTransition enter="slide-in" exit="slide-out">
+    <Sidebar />
+  </ViewTransition>
+</Activity>
+```
+
+## Exclude Elements from a Transition with `useOptimistic`
+
+When a `startTransition` changes both a control (e.g. a button label) and content (e.g. list order), use `useOptimistic` for the control. The optimistic value updates before React's transition snapshot, so it won't animate. The committed state drives the content, which changes within the transition and animates:
+
+```tsx
+const [sort, setSort] = useState('newest');
+const [optimisticSort, setOptimisticSort] = useOptimistic(sort);
+
+function cycleSort() {
+  const nextSort = getNextSort(optimisticSort);
+  startTransition(() => {
+    setOptimisticSort(nextSort);  // updates before snapshot — no animation
+    setSort(nextSort);            // changes within transition — animates
+  });
+}
+
+// Button uses optimisticSort (instant, excluded from animation)
+<button>Sort: {LABELS[optimisticSort]}</button>
+
+// List uses committed sort (changes between snapshots, animates)
+{items.sort(comparators[sort]).map(item => (
+  <ViewTransition key={item.id}>
+    <ItemCard item={item} />
+  </ViewTransition>
+))}
+```
+
+`useOptimistic` values resolve before the transition snapshot. Any DOM driven by optimistic state is already in its final form when the "before" snapshot is taken, so it doesn't participate in the `<ViewTransition>`. Only DOM driven by committed state (via `setState`) changes between snapshots and animates.
+
+---
+
+## View Transition Events (JavaScript Animations)
+
+For imperative control, use the `onEnter`, `onExit`, `onUpdate`, and `onShare` callbacks:
+
+```jsx
+<ViewTransition
+  onEnter={(instance, types) => {
+    const anim = instance.new.animate(
+      [{ transform: 'scale(0.8)', opacity: 0 }, { transform: 'scale(1)', opacity: 1 }],
+      { duration: 300, easing: 'ease-out' }
+    );
+    return () => anim.cancel();
+  }}
+  onExit={(instance, types) => {
+    const anim = instance.old.animate(
+      [{ transform: 'scale(1)', opacity: 1 }, { transform: 'scale(0.8)', opacity: 0 }],
+      { duration: 200, easing: 'ease-in' }
+    );
+    return () => anim.cancel();
+  }}
+>
+  <Component />
+</ViewTransition>
+```
+
+The `instance` object provides:
+- `instance.old` — the `::view-transition-old` pseudo-element
+- `instance.new` — the `::view-transition-new` pseudo-element
+- `instance.group` — the `::view-transition-group` pseudo-element
+- `instance.imagePair` — the `::view-transition-image-pair` pseudo-element
+- `instance.name` — the `view-transition-name` string
+
+Always return a cleanup function that cancels the animation so the browser can properly handle interruptions.
+
+Only one event fires per `<ViewTransition>` per Transition. `onShare` takes precedence over `onEnter` and `onExit`.
+
+### Using Types in Event Callbacks
+
+The `types` array is available as the second argument to all event callbacks:
+
+```jsx
+<ViewTransition
+  onEnter={(instance, types) => {
+    const duration = types.includes('fast') ? 150 : 500;
+    const anim = instance.new.animate(
+      [{ opacity: 0 }, { opacity: 1 }],
+      { duration, easing: 'ease-out' }
+    );
+    return () => anim.cancel();
+  }}
+>
+```
+
+---
+
+## Animation Timing Guidelines
+
+Match duration to the interaction type — direct user actions need fast feedback, while ambient reveals can be slower:
+
+| Interaction | Duration | Rationale |
+|------------|----------|-----------|
+| Direct toggle (expand/collapse, show/hide) | 100–200ms | Responds to a click — must feel instant |
+| Route transition (directional slide) | 150–250ms | Brief spatial cue, shouldn't delay navigation |
+| Suspense reveal (skeleton → content) | 200–400ms | Soft reveal, content is "arriving" |
+| Shared element morph | 300–500ms | Users watch the morph — give it room to breathe |
+
+These are starting points. Test on low-end devices — animations that feel smooth on a fast machine can feel sluggish on mobile.
+
+---
+
+## Troubleshooting
+
+**ViewTransition not activating:**
+- Ensure the `<ViewTransition>` comes before any DOM node in the component (not wrapped in a `<div>`).
+- Ensure the state update is inside `startTransition`, not a plain `setState`.
+
+**"Two ViewTransition components with the same name" error:**
+- Each `name` must be globally unique across the entire app at any point in time. Add item IDs: `` name={`hero-${item.id}`} ``.
+
+**Back button skips animation:**
+- The legacy `popstate` event requires synchronous completion, conflicting with view transitions. Upgrade your router to use the Navigation API for back-button animations.
+
+**Animations from `flushSync` are skipped:**
+- `flushSync` completes synchronously, which prevents view transitions from running. Use `startTransition` instead.
+
+**Enter/exit not firing in a client component (only updates animate):**
+- `startTransition(() => setState(...))` triggers a Transition, but if the new content isn't behind a `<Suspense>` boundary, React treats the swap as an **update** to the existing tree — not an enter/exit. The `<ViewTransition>` sees its children change but never fully unmounts/remounts, so only `update` animations fire. To get true enter/exit, either conditionally render the `<ViewTransition>` itself (so it mounts/unmounts with the content), or wrap the async content in `<Suspense>` so React can treat the reveal as an insertion.
+
+**Competing / double animations on navigation:**
+- Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level one cross-fades the whole page while a page-level one slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level `<ViewTransition>`, or remove it entirely if pages manage their own animations.
+
+**List reorder not animating with `useOptimistic`:**
+- If the optimistic value drives the list sort order, items are already in their final positions before the transition snapshot — there's nothing to animate. Use the optimistic value only for controls (labels, icons) and the committed state (`useState`) for the list sort order.
+
+**TypeScript error: "Property 'default' is missing in type 'ViewTransitionClassPerType'":**
+- When passing an object to `enter`/`exit`/`update`/`share`, TypeScript requires a `default` key in the object. This applies even if the component-level `default` prop is set. Always include `default: 'none'` (or `'auto'`) in type-keyed objects.
+
+**Hash fragments cause scroll jumps during view transitions:**
+- Links with URL hash fragments (e.g., `/page#section`) trigger the browser's native scroll-to-anchor behavior during the navigation transition. This interferes with directional slide animations — the page scrolls to the anchor while simultaneously sliding horizontally, producing a diagonal jump. If you need to link to a specific section on a detail page, navigate without the hash and handle scroll/expansion programmatically after navigation completes.
+
+**Batching:**
+- If multiple updates occur while an animation is running, React batches them into one. For example: if you navigate A→B, then B→C, then C→D during the first animation, the next animation will go B→D.
+
+---
+
+# CSS Animation Recipes for View Transitions
+
+Ready-to-use CSS snippets for common view transition animations. Use these class names with `<ViewTransition>` props.
+
+## Table of Contents
+
+1. [Timing Variables](#timing-variables)
+2. [Fade](#fade)
+3. [Slide (Vertical)](#slide-vertical)
+4. [Directional Navigation (Forward / Back)](#directional-navigation)
+5. [Shared Element Morph](#shared-element-morph)
+6. [Scale](#scale)
+7. [Reduced Motion](#reduced-motion)
+
+---
+
+## Timing Variables
+
+Define timing as CSS custom properties so durations are adjustable in one place. Use staggered timing — the enter animation delays by the exit duration so the old content leaves before the new content appears:
+
+```css
+:root {
+  --duration-exit: 150ms;
+  --duration-enter: 210ms;
+  --duration-move: 400ms;
+}
+```
+
+All recipes below reference these variables.
+
+### Shared Keyframes
+
+These reusable keyframes are used across multiple recipes:
+
+```css
+@keyframes fade {
+  from { filter: blur(3px); opacity: 0; }
+  to { filter: blur(0); opacity: 1; }
+}
+
+@keyframes slide {
+  from { translate: var(--slide-offset); }
+  to { translate: 0; }
+}
+
+@keyframes slide-y {
+  from { transform: translateY(var(--slide-y-offset, 10px)); }
+  to { transform: translateY(0); }
+}
+```
+
+The `slide` keyframe uses a CSS variable for direction — set `--slide-offset: -60px` for left, `60px` for right. The same keyframe with `animation-direction: reverse` handles the exit.
+
+---
+
+## Fade
+
+```css
+::view-transition-old(.fade-out) {
+  animation: var(--duration-exit) ease-in fade reverse;
+}
+::view-transition-new(.fade-in) {
+  animation: var(--duration-enter) ease-out var(--duration-exit) both fade;
+}
+```
+
+Usage:
+```jsx
+<ViewTransition enter="fade-in" exit="fade-out" />
+```
+
+---
+
+## Slide (Vertical)
+
+Slide down on exit, slide up on enter — the most common pattern for Suspense fallback-to-content transitions. Uses staggered timing with a fade:
+
+```css
+::view-transition-old(.slide-down) {
+  animation:
+    var(--duration-exit) ease-out both fade reverse,
+    var(--duration-exit) ease-out both slide-y reverse;
+}
+::view-transition-new(.slide-up) {
+  animation:
+    var(--duration-enter) ease-in var(--duration-exit) both fade,
+    var(--duration-move) ease-in both slide-y;
+}
+```
+
+Usage:
+```jsx
+<Suspense
+  fallback={
+    <ViewTransition exit="slide-down">
+      <Skeleton />
+    </ViewTransition>
+  }
+>
+  <ViewTransition default="none" enter="slide-up">
+    <Content />
+  </ViewTransition>
+</Suspense>
+```
+
+---
+
+## Directional Navigation
+
+### Separate Enter/Exit Classes
+
+Used with the two-layer pattern where `enter` and `exit` map to different class names:
+
+```css
+::view-transition-new(.slide-from-right) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+::view-transition-old(.slide-to-left) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+
+::view-transition-new(.slide-from-left) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+::view-transition-old(.slide-to-right) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+```
+
+Usage with the two-layer pattern:
+```jsx
+<ViewTransition
+  enter={{ "nav-forward": "slide-from-right", default: "none" }}
+  exit={{ "nav-forward": "slide-to-left", default: "none" }}
+  default="none"
+>
+  {children}
+</ViewTransition>
+```
+
+### Single-Class Approach
+
+Alternatively, a single CSS class name targets both `::view-transition-old` and `::view-transition-new` with different animations. This keeps the JSX simple — `enter="nav-forward"` / `exit="nav-forward"`:
+
+```css
+::view-transition-old(.nav-forward) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+::view-transition-new(.nav-forward) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+
+::view-transition-old(.nav-back) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+::view-transition-new(.nav-back) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+```
+
+Usage with transition types:
+```jsx
+<ViewTransition
+  default="none"
+  enter={{
+    'nav-forward': 'nav-forward',
+    'nav-back': 'nav-back',
+    default: 'none',
+  }}
+  exit={{
+    'nav-forward': 'nav-forward',
+    'nav-back': 'nav-back',
+    default: 'none',
+  }}
+>
+  {children}
+</ViewTransition>
+```
+
+Triggering with `transitionTypes` on `next/link`:
+```jsx
+<Link href="/products/1" transitionTypes={['nav-forward']}>Next</Link>
+<Link href="/products" transitionTypes={['nav-back']}>Back</Link>
+```
+
+Or programmatically:
+```jsx
+startTransition(() => {
+  addTransitionType('nav-forward');
+  router.push('/next-page');
+});
+```
+
+---
+
+## Shared Element Morph
+
+For shared element transitions, control the morph duration on `::view-transition-group` and add a motion blur on `::view-transition-image-pair` to smooth fast-moving elements:
+
+```css
+::view-transition-group(.morph) {
+  animation-duration: var(--duration-move);
+}
+
+::view-transition-image-pair(.morph) {
+  animation-name: via-blur;
+}
+
+@keyframes via-blur {
+  30% { filter: blur(3px); }
+}
+```
+
+The blur at 30% creates a subtle motion-blur effect — fast-moving elements can be visually jarring, and this smooths the transition without adding perceptible delay.
+
+Usage:
+```jsx
+<ViewTransition name={`product-${id}`} share="morph">
+  <Image src={product.image} alt={product.name} />
+</ViewTransition>
+```
+
+---
+
+## Scale
+
+```css
+::view-transition-old(.scale-out) {
+  animation: var(--duration-exit) ease-in scale-down;
+}
+::view-transition-new(.scale-in) {
+  animation: var(--duration-enter) ease-out var(--duration-exit) both scale-up;
+}
+
+@keyframes scale-down {
+  from { transform: scale(1); opacity: 1; }
+  to { transform: scale(0.85); opacity: 0; }
+}
+@keyframes scale-up {
+  from { transform: scale(0.85); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+```
+
+Usage:
+```jsx
+<ViewTransition enter="scale-in" exit="scale-out" />
+```
+
+---
+
+## Persistent Element Isolation
+
+Prevent sticky headers, navbars, and sidebars from being captured in page content's transition snapshot. Give them a `viewTransitionName` in JSX, then disable animation on their group:
+
+```css
+::view-transition-group(dashboard-header) {
+  animation: none;
+  z-index: 100;
+}
+```
+
+---
+
+## Reduced Motion
+
+Always include this in your global stylesheet to respect user preferences:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(*),
+  ::view-transition-new(*),
+  ::view-transition-group(*) {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+  }
+}
+```
+
+---
+
+# View Transitions in Next.js
+
+## Table of Contents
+
+1. [Setup](#setup)
+2. [Layout-Level ViewTransition](#layout-level-viewtransition)
+3. [The transitionTypes Prop on next/link](#the-transitiontypes-prop-on-nextlink)
+4. [Programmatic Navigation with Transitions](#programmatic-navigation-with-transitions)
+5. [Transition Types for Navigation Direction](#transition-types-for-navigation-direction)
+6. [Shared Elements Across Routes](#shared-elements-across-routes)
+7. [Combining with Suspense and Loading States](#combining-with-suspense-and-loading-states)
+8. [Server Components Considerations](#server-components-considerations)
+
+---
+
+## Setup
+
+`<ViewTransition>` works in Next.js out of the box for `startTransition`- and `Suspense`-triggered updates — no config flag is needed for those.
+
+To also animate `<Link>` navigations, enable the experimental flag in `next.config.js` (or `next.config.ts`):
+
+```js
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    viewTransition: true,
+  },
+};
+module.exports = nextConfig;
+```
+
+**What this flag does at runtime:** It wraps every `<Link>` navigation in `document.startViewTransition`. This means all mounted `<ViewTransition>` components in the tree participate in every link navigation — not just transitions triggered by `startTransition` or `Suspense`.
+
+Implications:
+- Any `<ViewTransition>` with `default="auto"` (the implicit default) fires the browser's cross-fade on **every** `<Link>` navigation.
+- Combined with per-page `<ViewTransition>` components (Suspense reveals, item animations), this produces competing animations.
+- Without this flag, `<ViewTransition>` still works for all `startTransition`- and `Suspense`-triggered updates — only `<Link>` navigations won't participate.
+
+The `<ViewTransition>` component is currently available in `react@canary` and `react@experimental` only:
+
+```bash
+npm install react@canary react-dom@canary
+```
+
+---
+
+## Layout-Level ViewTransition
 
 **If your pages already have `<ViewTransition>` components (Suspense reveals, item reorder, shared elements), do NOT add a layout-level `<ViewTransition>` wrapping `{children}` with `default="auto"`.** Both levels fire simultaneously inside a single `document.startViewTransition` — the layout cross-fades the entire old page while the new page's own animations run at the same time. The result is competing, broken-looking animations.
 
@@ -667,7 +1222,58 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 }
 ```
 
-### Programmatic Navigation with Transitions
+This ensures the layout doesn't fire the default cross-fade on every navigation, while still allowing per-page `<ViewTransition>` components to work independently.
+
+---
+
+## The `transitionTypes` Prop on `next/link`
+
+`next/link` supports a native `transitionTypes` prop. This eliminates the need for custom wrapper components that intercept navigation with `onNavigate` + `startTransition` + `addTransitionType` + `router.push()`.
+
+### Before (manual wrapper, requires `'use client'`)
+
+```tsx
+'use client';
+
+import { addTransitionType, startTransition } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+export function TransitionLink({ type, ...props }: { type: string } & React.ComponentProps<typeof Link>) {
+  const router = useRouter();
+
+  return (
+    <Link
+      onNavigate={(event) => {
+        event.preventDefault();
+        startTransition(() => {
+          addTransitionType(type);
+          router.push(props.href as string);
+        });
+      }}
+      {...props}
+    />
+  );
+}
+```
+
+### After (native prop, no wrapper needed, works in Server Components)
+
+```tsx
+import Link from 'next/link';
+
+<Link href="/products/1" transitionTypes={['transition-to-detail']}>
+  View Product
+</Link>
+```
+
+The `transitionTypes` prop accepts an array of strings. These types are passed to the View Transition system the same way `addTransitionType` would. `<ViewTransition>` components in the tree respond to these types identically.
+
+This is the recommended approach for link-based navigation transitions. Reserve manual `startTransition` + `addTransitionType` for programmatic navigation (buttons, form submissions, etc.) where `next/link` isn't used.
+
+---
+
+## Programmatic Navigation with Transitions
 
 Use `startTransition` with Next.js's `router.push()` to trigger view transitions from code:
 
@@ -695,11 +1301,15 @@ export function NavigateButton({ href }: { href: string }) {
 }
 ```
 
-### Transition Types for Navigation Direction
+Wrapping `router.push()` in `startTransition` is what activates the `<ViewTransition>` boundaries in the tree.
+
+---
+
+## Transition Types for Navigation Direction
 
 Directional transitions animate forward/backward navigation with horizontal slides. They can coexist with Suspense reveals on the same page when properly isolated — see the two-layer pattern below.
 
-Using `transitionTypes` on `next/link` (preferred):
+### Using `transitionTypes` on `next/link` (preferred)
 
 ```tsx
 import Link from 'next/link';
@@ -713,6 +1323,40 @@ import Link from 'next/link';
 <Link href="/products" transitionTypes={['transition-backwards']}>
   ← Back
 </Link>
+```
+
+### Using `startTransition` + `addTransitionType` (for programmatic navigation)
+
+```tsx
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { startTransition, addTransitionType } from 'react';
+
+export function NavigateButton({
+  href,
+  direction = 'forward',
+  children,
+}: {
+  href: string;
+  direction?: 'forward' | 'back';
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+
+  return (
+    <button
+      onClick={() => {
+        startTransition(() => {
+          addTransitionType(`navigation-${direction}`);
+          router.push(href);
+        });
+      }}
+    >
+      {children}
+    </button>
+  );
+}
 ```
 
 Place a `<ViewTransition>` with type-keyed `enter`/`exit` on each **page** (not in a layout — layouts persist and don't trigger enter/exit on navigation):
@@ -736,7 +1380,7 @@ Place a `<ViewTransition>` with type-keyed `enter`/`exit` on each **page** (not 
 </ViewTransition>
 ```
 
-#### Two-Layer Pattern: Directional Nav + Suspense Reveals
+### Two-Layer Pattern: Directional Nav + Suspense Reveals
 
 Directional nav slides and Suspense content reveals can coexist on the same page because they fire at **different moments**: the nav slide fires during navigation (when the `transitionTypes` type is present), and the Suspense reveal fires later when streamed data loads (a separate transition with no type). `default="none"` on both layers prevents cross-interference:
 
@@ -769,9 +1413,13 @@ export default function DetailPage() {
 }
 ```
 
+The outer `<ViewTransition>` only fires when `nav-forward` is present — it stays silent during Suspense resolves (no type, `default: "none"`). The inner `<ViewTransition>`s use simple string props — they fire on Suspense resolve regardless of type.
+
 Place the outer wrapper in each **page component**, not in `layout.tsx` (layouts persist, enter/exit won't fire).
 
-### Shared Elements Across Routes
+---
+
+## Shared Elements Across Routes
 
 Animate a thumbnail expanding into a full image across route transitions. Use `transitionTypes` on the link to tag the navigation direction:
 
@@ -825,11 +1473,14 @@ export default function ProductDetail({ product }) {
 
 Only one `<ViewTransition>` with a given name can be mounted at a time. Since Next.js unmounts the old page and mounts the new page within the same transition, the two `product-${product.id}` boundaries form a shared element pair and the image morphs from its thumbnail size to its full size.
 
-### Combining with Suspense and Loading States
+---
+
+## Combining with Suspense and Loading States
 
 Next.js `loading.tsx` files create `<Suspense>` boundaries. Wrap them with `<ViewTransition>` for smooth fallback-to-content reveals. Place the Suspense `<ViewTransition>` in the page, not alongside a layout-level one:
 
 ```tsx
+// In a page or page-level component — NOT in a layout that also has a ViewTransition on {children}
 <Suspense
   fallback={
     <ViewTransition exit="slide-down">
@@ -843,11 +1494,15 @@ Next.js `loading.tsx` files create `<Suspense>` boundaries. Wrap them with `<Vie
 </Suspense>
 ```
 
+The skeleton slides out, then the content slides in. `default="none"` on the content prevents it from re-animating on unrelated transitions.
+
 **Do not combine this with a layout-level `<ViewTransition>` that has `default="auto"`.** Both fire during the same transition — the layout cross-fades while the Suspense boundary slides up, producing competing animations. Use `default="none"` on layout-level `<ViewTransition>`s, or remove them entirely.
 
 Directional navigation transitions (via `transitionTypes`) can coexist with Suspense reveals when placed as an outer wrapper in the page component with `default="none"` and type-keyed enter/exit — they fire at different moments (see "Two-Layer Pattern" in Transition Types for Navigation Direction).
 
-### Server Components Considerations
+---
+
+## Server Components Considerations
 
 - `<ViewTransition>` can be used in both Server and Client Components — it renders no DOM of its own.
 - `<Link>` with `transitionTypes` works in Server Components — no `'use client'` directive needed for link-based transitions.
@@ -855,249 +1510,3 @@ Directional navigation transitions (via `transitionTypes`) can coexist with Susp
 - `startTransition` for programmatic navigation must be called from a Client Component.
 - Navigation via `<Link>` from `next/link` triggers transitions automatically when the experimental flag is enabled.
 - Prefer `transitionTypes` on `<Link>` over custom wrapper components. Only use manual `startTransition` + `addTransitionType` + `router.push()` for non-link interactions (buttons, form submissions, etc.).
-
----
-
-## Accessibility
-
-Always respect `prefers-reduced-motion`. React does not disable animations automatically for this preference. Add this to your global CSS:
-
-```css
-@media (prefers-reduced-motion: reduce) {
-  ::view-transition-old(*),
-  ::view-transition-new(*),
-  ::view-transition-group(*) {
-    animation-duration: 0s !important;
-    animation-delay: 0s !important;
-  }
-}
-```
-
-Or disable specific animations conditionally in JavaScript events by checking the media query.
-
----
-
-## Appendix: CSS Animation Recipes
-
-Ready-to-use CSS snippets for common view transition animations. Use these class names with `<ViewTransition>` props.
-
-### Timing Variables
-
-Define timing as CSS custom properties so durations are adjustable in one place. Use staggered timing — the enter animation delays by the exit duration so the old content leaves before the new content appears:
-
-```css
-:root {
-  --duration-exit: 150ms;
-  --duration-enter: 210ms;
-  --duration-move: 400ms;
-}
-```
-
-### Shared Keyframes
-
-```css
-@keyframes fade {
-  from { filter: blur(3px); opacity: 0; }
-  to { filter: blur(0); opacity: 1; }
-}
-
-@keyframes slide {
-  from { translate: var(--slide-offset); }
-  to { translate: 0; }
-}
-
-@keyframes slide-y {
-  from { transform: translateY(var(--slide-y-offset, 10px)); }
-  to { transform: translateY(0); }
-}
-```
-
-### Fade
-
-```css
-::view-transition-old(.fade-out) {
-  animation: var(--duration-exit) ease-in fade reverse;
-}
-::view-transition-new(.fade-in) {
-  animation: var(--duration-enter) ease-out var(--duration-exit) both fade;
-}
-```
-
-### Slide (Vertical)
-
-```css
-::view-transition-old(.slide-down) {
-  animation:
-    var(--duration-exit) ease-out both fade reverse,
-    var(--duration-exit) ease-out both slide-y reverse;
-}
-::view-transition-new(.slide-up) {
-  animation:
-    var(--duration-enter) ease-in var(--duration-exit) both fade,
-    var(--duration-move) ease-in both slide-y;
-}
-```
-
-### Directional Navigation — Separate Enter/Exit Classes
-
-```css
-::view-transition-new(.slide-from-right) {
-  --slide-offset: 60px;
-  animation:
-    var(--duration-enter) ease-out var(--duration-exit) both fade,
-    var(--duration-move) ease-in-out both slide;
-}
-::view-transition-old(.slide-to-left) {
-  --slide-offset: -60px;
-  animation:
-    var(--duration-exit) ease-in both fade reverse,
-    var(--duration-move) ease-in-out both slide reverse;
-}
-
-::view-transition-new(.slide-from-left) {
-  --slide-offset: -60px;
-  animation:
-    var(--duration-enter) ease-out var(--duration-exit) both fade,
-    var(--duration-move) ease-in-out both slide;
-}
-::view-transition-old(.slide-to-right) {
-  --slide-offset: 60px;
-  animation:
-    var(--duration-exit) ease-in both fade reverse,
-    var(--duration-move) ease-in-out both slide reverse;
-}
-```
-
-### Directional Navigation — Single-Class Approach
-
-```css
-::view-transition-old(.nav-forward) {
-  --slide-offset: -60px;
-  animation:
-    var(--duration-exit) ease-in both fade reverse,
-    var(--duration-move) ease-in-out both slide reverse;
-}
-::view-transition-new(.nav-forward) {
-  --slide-offset: 60px;
-  animation:
-    var(--duration-enter) ease-out var(--duration-exit) both fade,
-    var(--duration-move) ease-in-out both slide;
-}
-
-::view-transition-old(.nav-back) {
-  --slide-offset: 60px;
-  animation:
-    var(--duration-exit) ease-in both fade reverse,
-    var(--duration-move) ease-in-out both slide reverse;
-}
-::view-transition-new(.nav-back) {
-  --slide-offset: -60px;
-  animation:
-    var(--duration-enter) ease-out var(--duration-exit) both fade,
-    var(--duration-move) ease-in-out both slide;
-}
-```
-
-### Shared Element Morph
-
-```css
-::view-transition-group(.morph) {
-  animation-duration: var(--duration-move);
-}
-
-::view-transition-image-pair(.morph) {
-  animation-name: via-blur;
-}
-
-@keyframes via-blur {
-  30% { filter: blur(3px); }
-}
-```
-
-### Scale
-
-```css
-::view-transition-old(.scale-out) {
-  animation: var(--duration-exit) ease-in scale-down;
-}
-::view-transition-new(.scale-in) {
-  animation: var(--duration-enter) ease-out var(--duration-exit) both scale-up;
-}
-
-@keyframes scale-down {
-  from { transform: scale(1); opacity: 1; }
-  to { transform: scale(0.85); opacity: 0; }
-}
-@keyframes scale-up {
-  from { transform: scale(0.85); opacity: 0; }
-  to { transform: scale(1); opacity: 1; }
-}
-```
-
-### Persistent Element Isolation
-
-```css
-::view-transition-group(dashboard-header) {
-  animation: none;
-  z-index: 100;
-}
-```
-
-### Reduced Motion
-
-```css
-@media (prefers-reduced-motion: reduce) {
-  ::view-transition-old(*),
-  ::view-transition-new(*),
-  ::view-transition-group(*) {
-    animation-duration: 0s !important;
-    animation-delay: 0s !important;
-  }
-}
-```
-
----
-
-## Appendix: Animation Timing Guidelines
-
-| Interaction | Duration | Rationale |
-|------------|----------|-----------|
-| Direct toggle (expand/collapse, show/hide) | 100–200ms | Responds to a click — must feel instant |
-| Route transition (directional slide) | 150–250ms | Brief spatial cue, shouldn't delay navigation |
-| Suspense reveal (skeleton → content) | 200–400ms | Soft reveal, content is "arriving" |
-| Shared element morph | 300–500ms | Users watch the morph — give it room to breathe |
-
----
-
-## Troubleshooting
-
-**ViewTransition not activating:**
-- Ensure the `<ViewTransition>` comes before any DOM node in the component (not wrapped in a `<div>`).
-- Ensure the state update is inside `startTransition`, not a plain `setState`.
-
-**"Two ViewTransition components with the same name" error:**
-- Each `name` must be globally unique across the entire app at any point in time. Add item IDs: `` name={`hero-${item.id}`} ``.
-
-**Back button skips animation:**
-- The legacy `popstate` event requires synchronous completion, conflicting with view transitions. Upgrade your router to use the Navigation API for back-button animations.
-
-**Animations from `flushSync` are skipped:**
-- `flushSync` completes synchronously, which prevents view transitions from running. Use `startTransition` instead.
-
-**Enter/exit not firing in a client component (only updates animate):**
-- `startTransition(() => setState(...))` triggers a Transition, but if the new content isn't behind a `<Suspense>` boundary, React treats the swap as an **update** to the existing tree — not an enter/exit. The `<ViewTransition>` sees its children change but never fully unmounts/remounts, so only `update` animations fire. To get true enter/exit, either conditionally render the `<ViewTransition>` itself (so it mounts/unmounts with the content), or wrap the async content in `<Suspense>` so React can treat the reveal as an insertion.
-
-**Competing / double animations on navigation:**
-- Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level one cross-fades the whole page while a page-level one slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level `<ViewTransition>`, or remove it entirely if pages manage their own animations.
-
-**List reorder not animating with `useOptimistic`:**
-- If the optimistic value drives the list sort order, items are already in their final positions before the transition snapshot — there's nothing to animate. Use the optimistic value only for controls (labels, icons) and the committed state (`useState`) for the list sort order.
-
-**TypeScript error: "Property 'default' is missing in type 'ViewTransitionClassPerType'":**
-- When passing an object to `enter`/`exit`/`update`/`share`, TypeScript requires a `default` key in the object. This applies even if the component-level `default` prop is set. Always include `default: 'none'` (or `'auto'`) in type-keyed objects.
-
-**Hash fragments cause scroll jumps during view transitions:**
-- Links with URL hash fragments (e.g., `/page#section`) trigger the browser's native scroll-to-anchor behavior during the navigation transition. This interferes with directional slide animations — the page scrolls to the anchor while simultaneously sliding horizontally, producing a diagonal jump. If you need to link to a specific section on a detail page, navigate without the hash and handle scroll/expansion programmatically after navigation completes.
-
-**Batching:**
-- If multiple updates occur while an animation is running, React batches them into one. For example: if you navigate A→B, then B→C, then C→D during the first animation, the next animation will go B→D.

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -334,6 +334,8 @@ Wrap each item (not a wrapper div) in `<ViewTransition>` with a stable `key`:
 
 Triggering the reorder inside `startTransition` will smoothly animate each item to its new position. Avoid wrapper `<div>`s between the list and `<ViewTransition>` — they block the reorder animation.
 
+**How it works:** `startTransition` doesn't need async work to animate. The View Transition API captures a "before" snapshot of the DOM, then React applies the state update, and the API captures an "after" snapshot. As long as items change position between snapshots, the animation runs — even for purely synchronous local state changes like sorting.
+
 ### Animate Suspense Fallback to Content
 
 Wrap `<Suspense>` in `<ViewTransition>` to cross-fade from fallback to loaded content:
@@ -433,6 +435,37 @@ import { Activity, ViewTransition, startTransition } from 'react';
   </ViewTransition>
 </Activity>
 ```
+
+### Exclude Elements from a Transition with `useOptimistic`
+
+When a `startTransition` changes both a control (e.g. a button label) and content (e.g. list order), use `useOptimistic` for the control. The optimistic value updates before React's transition snapshot, so it won't animate. The committed state drives the content, which changes within the transition and animates:
+
+```tsx
+const [sort, setSort] = useState('newest');
+const [optimisticSort, setOptimisticSort] = useOptimistic(sort);
+
+function cycleSort() {
+  const nextSort = getNextSort(optimisticSort);
+  startTransition(() => {
+    setOptimisticSort(nextSort);  // updates before snapshot — no animation
+    setSort(nextSort);            // changes within transition — animates
+  });
+}
+
+// Button uses optimisticSort (instant, excluded from animation)
+<button>Sort: {LABELS[optimisticSort]}</button>
+
+// List uses committed sort (changes between snapshots, animates)
+{items.sort(comparators[sort]).map(item => (
+  <ViewTransition key={item.id}>
+    <ItemCard item={item} />
+  </ViewTransition>
+))}
+```
+
+`useOptimistic` values resolve before the transition snapshot. Any DOM driven by optimistic state is already in its final form when the "before" snapshot is taken, so it doesn't participate in the ViewTransition. Only DOM driven by committed state (via `setState`) changes between snapshots and animates.
+
+**Note:** Always add `prefers-reduced-motion` handling to your global CSS — see the Accessibility section below.
 
 ---
 
@@ -719,6 +752,9 @@ Or disable specific animations conditionally in JavaScript events by checking th
 
 **Competing / double animations on navigation:**
 - Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level VT cross-fades the whole page while a page-level VT slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level VT, or remove it entirely if pages manage their own animations. See "How Multiple ViewTransitions Interact" above.
+
+**List reorder not animating with `useOptimistic`:**
+- If the optimistic value drives the list sort order, items are already in their final positions before the transition snapshot — there's nothing to animate. Use the optimistic value only for controls (labels, icons) and the committed state (`useState`) for the list sort order.
 
 **TypeScript error: "Property 'default' is missing in type 'ViewTransitionClassPerType'":**
 - When passing an object to `enter`/`exit`/`update`/`share`, TypeScript requires a `default` key in the object. This applies even if the component-level `default` prop is set. Always include `default: 'none'` (or `'auto'`) in type-keyed objects.

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -197,6 +197,8 @@ React also adds all transition types as browser view transition types, enabling 
 }
 ```
 
+**Caveat:** `::view-transition-old(*)` and `::view-transition-new(*)` match **all** named view transition elements, not just the one you intend. If a Suspense `<ViewTransition>` has its own class-based animation (e.g., `enter="slide-up"`), the wildcard `*` selector can override it depending on CSS specificity. The class-based approach via `<ViewTransition>` props is safer because it only affects the specific boundary. Prefer class-based props for per-component animations and reserve `:active-view-transition-type()` for global, app-wide rules where you want all elements to animate the same way.
+
 ### Using Types with View Transition Events
 
 The `types` array is also available in event callbacks:
@@ -427,9 +429,9 @@ Without `default="none"`, a `<ViewTransition>` with `default="auto"` (the implic
 
 Pick the level that carries the most meaning for your app:
 
-- **App with per-page Suspense reveals and shared elements:** Don't add a layout-level `<ViewTransition>` on `{children}`. The pages already manage their own transitions. A layout-level cross-fade on top will double-animate.
+- **App with per-page Suspense reveals and shared elements:** Don't add a layout-level `<ViewTransition>` on `{children}`. The pages already manage their own transitions. A layout-level cross-fade on top will double-animate. This includes directional (forward/back) navigation — even with `default="none"`, a layout-level slide fires simultaneously with per-page Suspense slide-ups, producing a diagonal movement.
 - **Simple app with no per-page animations:** A layout-level `<ViewTransition>` with `default="auto"` on `{children}` gives you free cross-fades between routes.
-- **Mixed:** Use `default="none"` at the layout level and only activate it for specific `transitionTypes` (e.g., directional navigation). This way it stays silent during per-page Suspense transitions.
+- **Directional navigation only (no per-page VTs):** Use `default="none"` at the layout level and only activate it for specific `transitionTypes`. This works well when pages have no `<ViewTransition>` components of their own.
 
 The exception is **shared element transitions** — these intentionally span levels (one side unmounts while the other mounts) and don't conflict with other VTs because the `share` trigger takes precedence over `enter`/`exit`.
 
@@ -616,7 +618,7 @@ export default function ItemGrid({ items }) {
 }
 ```
 
-The shared `name={`item-${id}`}` on both the card and detail `<ViewTransition>` creates a shared element pair — the card morphs into the detail view. The `scrollRef` saves and restores scroll position so users return to where they were in the grid. See Appendix: CSS Animation Recipes for the slide-up/slide-down CSS.
+The shared `name={`item-${id}`}` on both the card and detail `<ViewTransition>` creates a shared element pair — the card morphs into the detail view. The `scrollRef` saves and restores scroll position so users return to where they were in the grid. See `css-recipes.md` for the slide-up/slide-down CSS.
 
 ## Type-Safe Transition Helpers
 
@@ -1031,12 +1033,14 @@ npm install react@canary react-dom@canary
 
 ---
 
-## Basic Route Transitions
+## Layout-Level ViewTransition
 
-The simplest approach is wrapping your page content in `<ViewTransition>` inside a layout:
+**If your pages already have `<ViewTransition>` components (Suspense reveals, item reorder, shared elements), do NOT add a layout-level `<ViewTransition>` wrapping `{children}` with `default="auto"`.** Both levels fire simultaneously inside a single `document.startViewTransition` — the layout cross-fades the entire old page while the new page's own animations run at the same time. The result is competing, broken-looking animations.
+
+This is the most common view transition mistake in Next.js. Every developer tries this first:
 
 ```tsx
-// app/layout.tsx
+// app/layout.tsx — ONLY use this if pages have NO per-page ViewTransitions
 import { ViewTransition } from 'react';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -1053,17 +1057,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 }
 ```
 
-When users navigate between routes using `<Link>`, Next.js triggers a transition internally. The `<ViewTransition>` wrapping `{children}` detects the content swap and animates it with the default cross-fade.
+This works for simple apps where pages have **no** `<ViewTransition>` components of their own. The layout detects the content swap on navigation and applies the default cross-fade.
 
-> **Warning:** This is an either/or choice with per-page animations. If your pages already have their own `<ViewTransition>` components (Suspense reveals, item reorder, shared elements), a layout-level VT on `{children}` produces double-animation — the layout cross-fades the entire old page while the new page's own entrance animations run simultaneously. Both levels get independent `view-transition-name`s, and the browser animates them in parallel, not sequentially.
->
-> Use this pattern only in apps where pages have **no** per-page view transitions. Otherwise, either remove the layout-level VT or set `default="none"` on it.
+**But the moment any page adds its own `<ViewTransition>` (a Suspense slide-up, an item reorder, a shared element), remove the layout-level one or set `default="none"` on it.** Otherwise both levels animate in parallel, not sequentially.
 
----
-
-## Layout-Level ViewTransition
-
-For more control, place `<ViewTransition>` at different levels of the layout hierarchy:
+For apps that need layout-level control, use `default="none"` and only activate for specific `transitionTypes`:
 
 ```tsx
 // app/dashboard/layout.tsx
@@ -1073,17 +1071,31 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   return (
     <div className="dashboard">
       <Sidebar />
-      <ViewTransition enter="slide-up" exit="fade-out">
-        <main>{children}</main>
-      </ViewTransition>
+      <main>
+        <ViewTransition
+          default="none"
+          enter={{
+            'nav-forward': 'nav-forward',
+            'nav-back': 'nav-back',
+            default: 'none',
+          }}
+          exit={{
+            'nav-forward': 'nav-forward',
+            'nav-back': 'nav-back',
+            default: 'none',
+          }}
+        >
+          {children}
+        </ViewTransition>
+      </main>
     </div>
   );
 }
 ```
 
-Only the `<main>` content animates when navigating between dashboard sub-routes. The sidebar stays static.
+Only the content area animates, only when explicit navigation types are present, and the sidebar stays static.
 
-> **Caution:** The same composition rule applies here — if the pages rendered inside `{children}` have their own `<ViewTransition>` components (Suspense boundaries, item animations), both levels will fire simultaneously. Use `default="none"` on the layout VT and only activate it for specific `transitionTypes` to avoid conflicts.
+**Even with `default="none"`, a layout-level directional slide will fire simultaneously with any per-page Suspense `<ViewTransition>`s.** If a page has `<ViewTransition enter="slide-up">` on a Suspense boundary, and the layout slides in from the right, both run at once — producing a diagonal movement. If your pages use Suspense reveals with `<ViewTransition>`, directional layout transitions usually hurt more than they help — the Suspense slide-up/slide-down already communicates "new content loading."
 
 ---
 
@@ -1220,36 +1232,9 @@ export function NavigateButton({
 }
 ```
 
-Configure `<ViewTransition>` to respond to these types. Use `default="none"` so the layout VT stays silent during per-page Suspense transitions and only fires for explicit navigation types:
+Configure `<ViewTransition>` in the layout to respond to these types. See the Layout-Level ViewTransition section above for the `default="none"` pattern with type-keyed `enter`/`exit` maps.
 
-```tsx
-// app/layout.tsx
-import { ViewTransition } from 'react';
-
-export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <html lang="en">
-      <body>
-        <ViewTransition
-          default="none"
-          enter={{
-            'navigation-forward': 'slide-in-from-right',
-            'navigation-back': 'slide-in-from-left',
-            default: 'none',
-          }}
-          exit={{
-            'navigation-forward': 'slide-out-to-left',
-            'navigation-back': 'slide-out-to-right',
-            default: 'none',
-          }}
-        >
-          {children}
-        </ViewTransition>
-      </body>
-    </html>
-  );
-}
-```
+**When to skip directional nav transitions:** If your pages already use Suspense reveals with `<ViewTransition>` (priority #2 in the Hierarchy of Animation Intent), adding route-level directional transitions (priority #5) usually hurts more than it helps. The Suspense slide-up/slide-down already communicates "new content loading" — adding a horizontal slide on top produces a diagonal movement where both animations fight for attention. Prefer shared element transitions (#1) or just let Suspense handle it.
 
 ---
 
@@ -1311,30 +1296,26 @@ Only one `<ViewTransition>` with a given name can be mounted at a time. Since Ne
 
 ## Combining with Suspense and Loading States
 
-Next.js `loading.tsx` files create `<Suspense>` boundaries. Wrap them with `<ViewTransition>` for smooth fallback-to-content reveals:
+Next.js `loading.tsx` files create `<Suspense>` boundaries. Wrap them with `<ViewTransition>` for smooth fallback-to-content reveals. Place the Suspense `<ViewTransition>` in the page, not alongside a layout-level one:
 
 ```tsx
-// app/dashboard/layout.tsx
-import { ViewTransition } from 'react';
-import { Suspense } from 'react';
-
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="dashboard">
-      <Sidebar />
-      <ViewTransition>
-        <Suspense fallback={<DashboardSkeleton />}>
-          {children}
-        </Suspense>
-      </ViewTransition>
-    </div>
-  );
-}
+// In a page or page-level component — NOT in a layout that also has a ViewTransition on {children}
+<Suspense
+  fallback={
+    <ViewTransition exit="slide-down">
+      <DashboardSkeleton />
+    </ViewTransition>
+  }
+>
+  <ViewTransition default="none" enter="slide-up">
+    <DashboardContent />
+  </ViewTransition>
+</Suspense>
 ```
 
-The skeleton cross-fades into the actual content once it loads.
+The skeleton slides out, then the content slides in. `default="none"` on the content prevents it from re-animating on unrelated transitions.
 
-> **Important:** If you also have a layout-level `<ViewTransition>` wrapping `{children}` with `default="auto"`, it will fire simultaneously with this Suspense VT on every navigation, producing a double-animation. Either remove the layout-level VT, or set `default="none"` on it so it only responds to explicit `transitionTypes`.
+**Do not combine this with a layout-level `<ViewTransition>` that has `default="auto"`.** Both will fire simultaneously — the layout cross-fades the whole page while the Suspense boundary slides up content, producing a broken double-animation. If you need both, set `default="none"` on the layout-level one and only activate it for specific `transitionTypes`.
 
 ---
 

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -361,6 +361,32 @@ Wrap children in `<ViewTransition update="none">` to prevent them from animating
 </ViewTransition>
 ```
 
+### Reusable Animated Collapse
+
+For apps with many expand/collapse interactions, extract a reusable wrapper instead of repeating the conditional-render-with-VT pattern:
+
+```jsx
+import { ViewTransition } from 'react';
+
+function AnimatedCollapse({ open, children }) {
+  if (!open) return null;
+  return (
+    <ViewTransition enter="expand-in" exit="collapse-out">
+      {children}
+    </ViewTransition>
+  );
+}
+```
+
+Use it with `startTransition` on the toggle — never with native `<details>`/`<summary>` (which bypasses React state):
+
+```jsx
+<button onClick={() => startTransition(() => setOpen(o => !o))}>Toggle</button>
+<AnimatedCollapse open={open}>
+  <SectionContent />
+</AnimatedCollapse>
+```
+
 ### Preserve State with Activity
 
 Use `<Activity>` with `<ViewTransition>` to animate show/hide while preserving component state:
@@ -416,6 +442,16 @@ Pick the level that carries the most meaning for your app:
 - **Mixed:** Use `default="none"` at the layout level and only activate it for specific `transitionTypes` (e.g., directional navigation). This way it stays silent during per-page Suspense transitions.
 
 The exception is **shared element transitions** — these intentionally span levels (one side unmounts while the other mounts) and don't conflict with other VTs because the `share` trigger takes precedence over `enter`/`exit`.
+
+### Multi-Level Coordination Checklist
+
+When combining directional layout VTs with per-page Suspense VTs, set `default="none"` at **every** level — not just the layout:
+
+1. **Layout VT** (`{children}`): `default="none"` — only fires for explicit `transitionTypes` (e.g., directional navigation)
+2. **Suspense fallback VTs** (skeleton → content): `default="none"` + explicit `exit` — they only need the exit animation (slide-down when content replaces skeleton). Without `default="none"`, the fallback VT would also cross-fade during route transitions triggered by `<Link>`
+3. **Content/item VTs** (per-item, expand/collapse): `default="none"` + explicit `enter`/`exit` — they only fire for their specific `startTransition` triggers
+
+This ensures each VT stays silent except for its intended trigger, even when `viewTransition: true` makes every `<Link>` navigation activate all mounted VTs.
 
 ---
 
@@ -642,11 +678,29 @@ Or disable specific animations conditionally in JavaScript events by checking th
 **Enter/exit not firing in a client component (only updates animate):**
 - `startTransition(() => setState(...))` triggers a Transition, but if the new content isn't behind a `<Suspense>` boundary, React treats the swap as an **update** to the existing tree — not an enter/exit. The `<ViewTransition>` sees its children change but never fully unmounts/remounts, so only `update` animations fire. To get true enter/exit, either conditionally render the `<ViewTransition>` itself (so it mounts/unmounts with the content), or wrap the async content in `<Suspense>` so React can treat the reveal as an insertion.
 
+**ViewTransition not firing on `<details>` toggle:**
+- Native `<details>`/`<summary>` elements are browser-controlled — their open/close state bypasses React entirely, so `startTransition` never wraps the toggle and `<ViewTransition>` never fires. Convert to controlled state with `useState` + `startTransition` + a `<button>` for animated expand/collapse (see the "Reusable Animated Collapse" pattern above).
+
 **Competing / double animations on navigation:**
 - Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level VT cross-fades the whole page while a page-level VT slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level VT, or remove it entirely if pages manage their own animations. See "How Multiple ViewTransitions Interact" above.
 
 **Batching:**
 - If multiple updates occur while an animation is running, React batches them into one. For example: if you navigate A→B, then B→C, then C→D during the first animation, the next animation will go B→D.
+
+---
+
+## Animation Timing Guidelines
+
+Match duration to the interaction type — direct user actions need fast feedback, while ambient reveals can be slower:
+
+| Interaction | Duration | Rationale |
+|------------|----------|-----------|
+| Direct toggle (expand/collapse, show/hide) | 100–200ms | Responds to a click — must feel instant |
+| Route transition (directional slide) | 150–250ms | Brief spatial cue, shouldn't delay navigation |
+| Suspense reveal (skeleton → content) | 200–400ms | Soft reveal, content is "arriving" |
+| Shared element morph | 300–500ms | Users watch the morph — give it room to breathe |
+
+These are starting points. Test on low-end devices — animations that feel smooth on a fast machine can feel sluggish on mobile.
 
 ---
 

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -23,14 +23,6 @@ From highest value to lowest — start from the top and only move down if your a
 
 Route-level transitions (#5) are the lowest priority because the URL change already signals a context switch. A blanket cross-fade on every navigation says nothing — it's visual noise. Prefer specific, intentional animations (#1–#4) over ambient page transitions.
 
-### Should This Element Use ViewTransition?
-
-- **Persistent across navigations?** (nav bar, sidebar, header) → Skip VT. Use plain `<Suspense>` if needed.
-- **Expand/collapse that needs to feel spatial?** → Animated collapse with VT + `startTransition`.
-- **Simple show/hide with no spatial meaning?** → Conditional render, no VT.
-- **Already inside a parent VT?** → Check if `default="none"` is needed to avoid double-animation.
-- **Content that changes on route navigation?** → VT with `default="none"` + explicit triggers.
-
 **Rule of thumb:** at any given moment, only one level of the tree should be visually transitioning. If your pages already manage their own Suspense reveals or shared element morphs, adding a layout-level route transition on top produces double-animation where both levels fight for attention.
 
 ---
@@ -489,21 +481,6 @@ Pick the level that carries the most meaning for your app:
 
 The exception is **shared element transitions** — these intentionally span levels (one side unmounts while the other mounts) and don't conflict with other VTs because the `share` trigger takes precedence over `enter`/`exit`.
 
-### Multi-Level Coordination Checklist
-
-When combining directional layout VTs with per-page Suspense VTs, set `default="none"` at **every** level — not just the layout:
-
-1. **Layout VT** (`{children}`): `default="none"` — only fires for explicit `transitionTypes` (e.g., directional navigation)
-2. **Suspense fallback VTs** (skeleton → content): `default="none"` + explicit `exit` — they only need the exit animation (slide-down when content replaces skeleton). Without `default="none"`, the fallback VT would also cross-fade during route transitions triggered by `<Link>`
-3. **Content/item VTs** (per-item, expand/collapse): `default="none"` + explicit `enter`/`exit` — they only fire for their specific `startTransition` triggers
-
-This ensures each VT stays silent except for its intended trigger, even when `viewTransition: true` makes every `<Link>` navigation activate all mounted VTs.
-
-Note: `default="none"` on content VTs is also critical when the content itself contains `<Link>` elements with `transitionTypes`. Without it, clicking a typed link inside the content would cause the content's own VT to re-animate (cross-fade) alongside the layout-level directional slide.
-
-### Persistent Layout Chrome
-
-Nav bars, headers, sidebars, and other layout elements that load once and don't change across navigations should generally **not** be wrapped in `<ViewTransition>`. Even if they're behind `<Suspense>` for initial data loading (auth checks, etc.), the one-time skeleton-to-content swap is barely perceptible. Wrapping them in VT causes them to re-animate on every `<Link>` navigation when `viewTransition: true` is enabled. Use plain `<Suspense fallback={<Skeleton />}>` without VT for these.
 
 ---
 
@@ -731,9 +708,6 @@ Or disable specific animations conditionally in JavaScript events by checking th
 
 **TypeScript error: "Property 'default' is missing in type 'ViewTransitionClassPerType'":**
 - When passing an object to `enter`/`exit`/`update`/`share`, TypeScript requires a `default` key in the object. This applies even if the component-level `default` prop is set. Always include `default: 'none'` (or `'auto'`) in type-keyed objects.
-
-**Orphaned CSS after removing ViewTransition:**
-- When removing `<ViewTransition>` components, remember to clean up corresponding `::view-transition-old(...)` / `::view-transition-new(...)` rules and `@keyframes` definitions. These don't cause build errors so they're easy to forget.
 
 **Batching:**
 - If multiple updates occur while an animation is running, React batches them into one. For example: if you navigate A→B, then B→C, then C→D during the first animation, the next animation will go B→D.

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -421,15 +421,19 @@ Prevent unintended animations by disabling the default trigger on ViewTransition
   enter={{
     'navigation-forward': 'slide-in-from-right',
     'navigation-back': 'slide-in-from-left',
+    default: 'none',
   }}
   exit={{
     'navigation-forward': 'slide-out-to-left',
     'navigation-back': 'slide-out-to-right',
+    default: 'none',
   }}
 >
   {children}
 </ViewTransition>
 ```
+
+**TypeScript note:** When passing an object to `enter`/`exit`, the `ViewTransitionClassPerType` type requires a `default` key. Always include `default: 'none'` (or `'auto'`) in the object — omitting it causes a type error even if the component-level `default` prop is set.
 
 Without `default="none"`, a `<ViewTransition>` with `default="auto"` (the implicit default) fires the browser's cross-fade on **every** transition — including ones triggered by child Suspense boundaries, `useDeferredValue` updates, or `startTransition` calls within the page.
 
@@ -962,10 +966,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           enter={{
             'navigation-forward': 'slide-in-from-right',
             'navigation-back': 'slide-in-from-left',
+            default: 'none',
           }}
           exit={{
             'navigation-forward': 'slide-out-to-left',
             'navigation-back': 'slide-out-to-right',
+            default: 'none',
           }}
         >
           {children}

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -1,8 +1,31 @@
 # React View Transitions — Complete Reference
 
+
 React's View Transition API lets you animate between UI states using the browser's native `document.startViewTransition` under the hood. React manages the lifecycle automatically — you declare *what* to animate with `<ViewTransition>`, trigger *when* to animate through `startTransition` / `useDeferredValue` / `Suspense`, and control *how* to animate with CSS classes or JavaScript via the Web Animations API.
 
 The API adds ~3KB to your bundle, runs on the browser's compositor thread for 60fps animations, and gracefully falls back to instant state changes in unsupported browsers.
+
+## When to Animate (and When Not To)
+
+Every `<ViewTransition>` should answer: **what spatial relationship or continuity does this animation communicate to the user?** If you can't articulate it, don't add it.
+
+### Hierarchy of Animation Intent
+
+From highest value to lowest — start from the top and only move down if your app doesn't already have animations at that level:
+
+| Priority | Pattern | What it communicates | Example |
+|----------|---------|---------------------|---------|
+| 1 | **Shared element** (`name`) | "This is the same thing — I'm going deeper" | List thumbnail morphs into detail hero |
+| 2 | **Suspense reveal** | "Data loaded, here's the real content" | Skeleton cross-fades into loaded page |
+| 3 | **List identity** (per-item `key`) | "Same items, new arrangement" | Cards reorder during sort/filter |
+| 4 | **State change** (`enter`/`exit`) | "Something appeared or disappeared" | Panel slides in on toggle |
+| 5 | **Route change** (layout-level) | "Going to a new place" | Cross-fade between pages |
+
+Route-level transitions (#5) are the lowest priority because the URL change already signals a context switch. A blanket cross-fade on every navigation says nothing — it's visual noise. Prefer specific, intentional animations (#1–#4) over ambient page transitions.
+
+**Rule of thumb:** at any given moment, only one level of the tree should be visually transitioning. If your pages already manage their own Suspense reveals or shared element morphs, adding a layout-level route transition on top produces double-animation where both levels fight for attention.
+
+---
 
 ## Availability
 
@@ -354,6 +377,48 @@ import { Activity, ViewTransition, startTransition } from 'react';
 
 ---
 
+## How Multiple ViewTransitions Interact
+
+When a transition fires, **every** `<ViewTransition>` in the tree that matches the trigger participates simultaneously. Each gets its own `view-transition-name`, and the browser animates all of them inside a single `document.startViewTransition` call. They run in parallel, not sequentially.
+
+This means a layout-level VT (whole-page cross-fade) + a page-level VT (Suspense slide-up) + per-item VTs (list reorder) all fire at once. The result is usually competing animations that look broken.
+
+### Use `default="none"` Liberally
+
+Prevent unintended animations by disabling the default trigger on ViewTransitions that should only fire for specific types:
+
+```jsx
+// Only animates when 'navigation-forward' or 'navigation-back' types are present.
+// Silent on all other transitions (Suspense reveals, state changes, etc.)
+<ViewTransition
+  default="none"
+  enter={{
+    'navigation-forward': 'slide-in-from-right',
+    'navigation-back': 'slide-in-from-left',
+  }}
+  exit={{
+    'navigation-forward': 'slide-out-to-left',
+    'navigation-back': 'slide-out-to-right',
+  }}
+>
+  {children}
+</ViewTransition>
+```
+
+Without `default="none"`, a `<ViewTransition>` with `default="auto"` (the implicit default) fires the browser's cross-fade on **every** transition — including ones triggered by child Suspense boundaries, `useDeferredValue` updates, or `startTransition` calls within the page.
+
+### Choosing One Level
+
+Pick the level that carries the most meaning for your app:
+
+- **App with per-page Suspense reveals and shared elements:** Don't add a layout-level VT on `{children}`. The pages already manage their own transitions. A layout-level cross-fade on top will double-animate.
+- **Simple app with no per-page animations:** A layout-level VT with `default="auto"` on `{children}` gives you free cross-fades between routes.
+- **Mixed:** Use `default="none"` at the layout level and only activate it for specific `transitionTypes` (e.g., directional navigation). This way it stays silent during per-page Suspense transitions.
+
+The exception is **shared element transitions** — these intentionally span levels (one side unmounts while the other mounts) and don't conflict with other VTs because the `share` trigger takes precedence over `enter`/`exit`.
+
+---
+
 ## Next.js Integration
 
 Next.js supports React View Transitions. Enable it in `next.config.js` (or `next.config.ts`):
@@ -367,10 +432,18 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
+**What this flag does:** It wraps every `<Link>` navigation in `document.startViewTransition`, which means all mounted `<ViewTransition>` components in the tree participate in every link navigation — not just ones triggered by `startTransition` or Suspense. This is important:
+
+- If you have a layout-level VT with `default: "auto"`, it fires on **every** `<Link>` navigation — even ones you didn't intend to animate.
+- Combined with per-page VTs (Suspense reveals, item animations), you get competing animations.
+- Without this flag, only `Suspense`-triggered and `startTransition`-triggered transitions fire.
+
+If your pages manage their own per-page transitions, either (a) don't use a layout-level `<ViewTransition>` on `{children}`, or (b) set `default="none"` on it so it only activates for explicit `transitionTypes`.
+
+For a detailed guide on Next.js integration, including App Router patterns and Server Component considerations, see the Next.js Integration section below.
+
 Key points:
 - The `<ViewTransition>` component is imported from `react` directly — no Next.js-specific import.
-- The `experimental.viewTransition` flag enables deeper integration with Next.js features beyond what `<ViewTransition>` provides on its own.
-- Wrap page content in `<ViewTransition>` inside the layout to animate route transitions.
 - Works with the App Router and `startTransition` + `router.push()` for programmatic navigation.
 
 ### The `transitionTypes` prop on `next/link`
@@ -393,7 +466,9 @@ import Link from 'next/link';
 
 The `transitionTypes` prop accepts an array of strings — the same types you would pass to `addTransitionType`. This removes the need for `'use client'`, `useRouter`, and custom link components when all you need is to tag a navigation with a transition type. The `<ViewTransition>` components in the tree respond to these types the same way they respond to manual `addTransitionType` calls.
 
-See the Next.js section below for full examples of `transitionTypes` with shared element transitions and directional animations across routes.
+**Composition note:** `transitionTypes` on `<Link>` works best when you have a single `<ViewTransition>` at the layout level with `default="none"` (so it only fires for your specific types) and no per-page Suspense VTs competing. If your pages have their own Suspense transitions, use `transitionTypes` at the page level (e.g., to distinguish sources of `startTransition` within a client component) rather than at the layout level, or the layout slide and the page's Suspense reveal will both fire simultaneously.
+
+For full examples of `transitionTypes` with shared element transitions and directional animations across routes, see the Next.js Integration section below.
 
 ---
 
@@ -528,7 +603,7 @@ These wrappers enforce that only valid transition IDs and animation classes are 
 
 ### Shared Elements Across Routes in Next.js
 
-See the Next.js Shared Elements Across Routes section below for complete examples using `transitionTypes` on `next/link` combined with shared element `<ViewTransition name={...}>` for list-to-detail image morph animations.
+See the Next.js Integration section below.
 
 ---
 
@@ -564,6 +639,9 @@ Or disable specific animations conditionally in JavaScript events by checking th
 **Animations from `flushSync` are skipped:**
 - `flushSync` completes synchronously, which prevents view transitions from running. Use `startTransition` instead.
 
+**Competing / double animations on navigation:**
+- Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level VT cross-fades the whole page while a page-level VT slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level VT, or remove it entirely if pages manage their own animations. See "How Multiple ViewTransitions Interact" above.
+
 **Batching:**
 - If multiple updates occur while an animation is running, React batches them into one. For example: if you navigate A→B, then B→C, then C→D during the first animation, the next animation will go B→D.
 
@@ -571,12 +649,12 @@ Or disable specific animations conditionally in JavaScript events by checking th
 
 ## CSS Recipe Reference
 
-Ready-to-use CSS animation recipes follow below.
-
+For ready-to-use CSS animation recipes (slide, fade, scale, flip, and combined patterns), see the CSS Animation Recipes section below.
 
 ---
 
-# View Transitions in Next.js
+# Next.js Integration — Detailed Reference
+
 
 ## Table of Contents
 
@@ -606,7 +684,14 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-This flag enables deeper integration with Next.js features beyond what React's `<ViewTransition>` component provides on its own. The `<ViewTransition>` component itself is available from `react` in canary/experimental channels or React 19.2+.
+**What this flag does at runtime:** It wraps every `<Link>` navigation in `document.startViewTransition`. This means all mounted `<ViewTransition>` components in the tree participate in every link navigation — not just transitions triggered by `startTransition` or `Suspense`.
+
+Implications:
+- Any `<ViewTransition>` with `default="auto"` (the implicit default) fires the browser's cross-fade on **every** `<Link>` navigation.
+- Combined with per-page `<ViewTransition>` components (Suspense reveals, item animations), this produces competing animations.
+- Without this flag, only `Suspense`-triggered and `startTransition`-triggered transitions fire.
+
+The `<ViewTransition>` component itself is available from `react` in canary/experimental channels or React 19.2+.
 
 Install React canary if you're not yet on 19.2+:
 
@@ -640,6 +725,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
 When users navigate between routes using `<Link>`, Next.js triggers a transition internally. The `<ViewTransition>` wrapping `{children}` detects the content swap and animates it with the default cross-fade.
 
+> **Warning:** This is an either/or choice with per-page animations. If your pages already have their own `<ViewTransition>` components (Suspense reveals, item reorder, shared elements), a layout-level VT on `{children}` produces double-animation — the layout cross-fades the entire old page while the new page's own entrance animations run simultaneously. Both levels get independent `view-transition-name`s, and the browser animates them in parallel, not sequentially.
+>
+> Use this pattern only in apps where pages have **no** per-page view transitions. Otherwise, either remove the layout-level VT or set `default="none"` on it.
+
 ---
 
 ## Layout-Level ViewTransition
@@ -663,6 +752,8 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 ```
 
 Only the `<main>` content animates when navigating between dashboard sub-routes. The sidebar stays static.
+
+> **Caution:** The same composition rule applies here — if the pages rendered inside `{children}` have their own `<ViewTransition>` components (Suspense boundaries, item animations), both levels will fire simultaneously. Use `default="none"` on the layout VT and only activate it for specific `transitionTypes` to avoid conflicts.
 
 ---
 
@@ -799,7 +890,7 @@ export function NavigateButton({
 }
 ```
 
-Configure `<ViewTransition>` to respond to these types:
+Configure `<ViewTransition>` to respond to these types. Use `default="none"` so the layout VT stays silent during per-page Suspense transitions and only fires for explicit navigation types:
 
 ```tsx
 // app/layout.tsx
@@ -810,15 +901,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <body>
         <ViewTransition
+          default="none"
           enter={{
             'navigation-forward': 'slide-in-from-right',
             'navigation-back': 'slide-in-from-left',
-            default: 'auto',
           }}
           exit={{
             'navigation-forward': 'slide-out-to-left',
             'navigation-back': 'slide-out-to-right',
-            default: 'auto',
           }}
         >
           {children}
@@ -912,6 +1002,8 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 
 The skeleton cross-fades into the actual content once it loads.
 
+> **Important:** If you also have a layout-level `<ViewTransition>` wrapping `{children}` with `default="auto"`, it will fire simultaneously with this Suspense VT on every navigation, producing a double-animation. Either remove the layout-level VT, or set `default="none"` on it so it only responds to explicit `transitionTypes`.
+
 ---
 
 ## Server Components Considerations
@@ -923,10 +1015,10 @@ The skeleton cross-fades into the actual content once it loads.
 - Navigation via `<Link>` from `next/link` triggers transitions automatically when the experimental flag is enabled.
 - Prefer `transitionTypes` on `<Link>` over custom wrapper components. Only use manual `startTransition` + `addTransitionType` + `router.push()` for non-link interactions (buttons, form submissions, etc.).
 
-
 ---
 
-# CSS Animation Recipes for View Transitions
+# CSS Animation Recipes — Complete Collection
+
 
 Ready-to-use CSS snippets for common view transition animations. Use these class names with `<ViewTransition>` props.
 

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -23,6 +23,14 @@ From highest value to lowest — start from the top and only move down if your a
 
 Route-level transitions (#5) are the lowest priority because the URL change already signals a context switch. A blanket cross-fade on every navigation says nothing — it's visual noise. Prefer specific, intentional animations (#1–#4) over ambient page transitions.
 
+### Should This Element Use ViewTransition?
+
+- **Persistent across navigations?** (nav bar, sidebar, header) → Skip VT. Use plain `<Suspense>` if needed.
+- **Expand/collapse that needs to feel spatial?** → Animated collapse with VT + `startTransition`.
+- **Simple show/hide with no spatial meaning?** → `<details>` or conditional render, no VT.
+- **Already inside a parent VT?** → Check if `default="none"` is needed to avoid double-animation.
+- **Content that changes on route navigation?** → VT with `default="none"` + explicit triggers.
+
 **Rule of thumb:** at any given moment, only one level of the tree should be visually transitioning. If your pages already manage their own Suspense reveals or shared element morphs, adding a layout-level route transition on top produces double-animation where both levels fight for attention.
 
 ---
@@ -491,6 +499,12 @@ When combining directional layout VTs with per-page Suspense VTs, set `default="
 
 This ensures each VT stays silent except for its intended trigger, even when `viewTransition: true` makes every `<Link>` navigation activate all mounted VTs.
 
+Note: `default="none"` on content VTs is also critical when the content itself contains `<Link>` elements with `transitionTypes`. Without it, clicking a typed link inside the content would cause the content's own VT to re-animate (cross-fade) alongside the layout-level directional slide.
+
+### Persistent Layout Chrome
+
+Nav bars, headers, sidebars, and other layout elements that load once and don't change across navigations should generally **not** be wrapped in `<ViewTransition>`. Even if they're behind `<Suspense>` for initial data loading (auth checks, etc.), the one-time skeleton-to-content swap is barely perceptible. Wrapping them in VT causes them to re-animate on every `<Link>` navigation when `viewTransition: true` is enabled. Use plain `<Suspense fallback={<Skeleton />}>` without VT for these.
+
 ---
 
 ## Next.js Integration
@@ -548,18 +562,16 @@ For full examples of `transitionTypes` with shared element transitions and direc
 
 ## Real-World Patterns
 
-These patterns are drawn from production Next.js apps using View Transitions.
+### Searchable Grid with `useDeferredValue`
 
-### List-to-Detail with `useDeferredValue` and `ViewTransition`
-
-A common pattern is a client-side searchable grid where items expand into a detail view. Wrap each item in `<ViewTransition>` and use `useDeferredValue` to trigger animated updates as the user types:
+A client-side searchable grid where the filtered results cross-fade as the user types. `useDeferredValue` makes the filter update a transition, which activates the wrapping `<ViewTransition>`:
 
 ```tsx
 'use client';
 
 import { useDeferredValue, useState, ViewTransition, Suspense } from 'react';
 
-export default function TalksExplorer({ talksPromise }) {
+export default function SearchableGrid({ itemsPromise }) {
   const [search, setSearch] = useState('');
   const deferredSearch = useDeferredValue(search);
 
@@ -568,19 +580,17 @@ export default function TalksExplorer({ talksPromise }) {
       <input
         value={search}
         onChange={(e) => setSearch(e.currentTarget.value)}
-        placeholder="Search talks..."
+        placeholder="Search..."
       />
       <ViewTransition>
         <Suspense fallback={<GridSkeleton />}>
-          <TalksGrid talksPromise={talksPromise} search={deferredSearch} />
+          <ItemGrid itemsPromise={itemsPromise} search={deferredSearch} />
         </Suspense>
       </ViewTransition>
     </>
   );
 }
 ```
-
-When `deferredSearch` updates (deferred from the search input), React treats it as a transition and the `<ViewTransition>` wrapping the `<Suspense>` boundary cross-fades between the old and new grid content.
 
 ### Card Expand/Collapse with `startTransition`
 
@@ -591,29 +601,29 @@ Toggle between a card grid and a detail view using `startTransition` to animate 
 
 import { useState, startTransition, ViewTransition } from 'react';
 
-export default function TalksGrid({ talks }) {
-  const [expandedTalkId, setExpandedTalkId] = useState(null);
+export default function ItemGrid({ items }) {
+  const [expandedId, setExpandedId] = useState(null);
 
-  return expandedTalkId ? (
+  return expandedId ? (
     <ViewTransition enter="slide-up" exit="slide-down">
-      <TalkDetails
-        talk={talks.find(t => t.id === expandedTalkId)}
-        closeAction={() => {
+      <ItemDetail
+        item={items.find(i => i.id === expandedId)}
+        onClose={() => {
           startTransition(() => {
-            setExpandedTalkId(null);
+            setExpandedId(null);
           });
         }}
       />
     </ViewTransition>
   ) : (
     <div className="grid grid-cols-3 gap-4">
-      {talks.map(talk => (
-        <ViewTransition key={talk.id}>
-          <TalkCard
-            talk={talk}
+      {items.map(item => (
+        <ViewTransition key={item.id}>
+          <ItemCard
+            item={item}
             onSelect={() => {
               startTransition(() => {
-                setExpandedTalkId(talk.id);
+                setExpandedId(item.id);
               });
             }}
           />
@@ -717,10 +727,16 @@ Or disable specific animations conditionally in JavaScript events by checking th
 - `startTransition(() => setState(...))` triggers a Transition, but if the new content isn't behind a `<Suspense>` boundary, React treats the swap as an **update** to the existing tree — not an enter/exit. The `<ViewTransition>` sees its children change but never fully unmounts/remounts, so only `update` animations fire. To get true enter/exit, either conditionally render the `<ViewTransition>` itself (so it mounts/unmounts with the content), or wrap the async content in `<Suspense>` so React can treat the reveal as an insertion.
 
 **ViewTransition not firing on `<details>` toggle:**
-- Native `<details>`/`<summary>` elements are browser-controlled — their open/close state bypasses React entirely, so `startTransition` never wraps the toggle and `<ViewTransition>` never fires. Convert to controlled state with `useState` + `startTransition` + a `<button>` for animated expand/collapse (see the "Reusable Animated Collapse" pattern above).
+- Native `<details>`/`<summary>` is browser-controlled — open/close bypasses React, so `startTransition` never wraps the toggle and `<ViewTransition>` never fires. This is a trade-off: `<details>` is simpler and more accessible out of the box, but can't be animated with VT. If you need animated expand/collapse, use controlled state with `useState` + `startTransition`. If you don't need the animation, `<details>` is the simpler choice.
 
 **Competing / double animations on navigation:**
 - Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level VT cross-fades the whole page while a page-level VT slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level VT, or remove it entirely if pages manage their own animations. See "How Multiple ViewTransitions Interact" above.
+
+**TypeScript error: "Property 'default' is missing in type 'ViewTransitionClassPerType'":**
+- When passing an object to `enter`/`exit`/`update`/`share`, TypeScript requires a `default` key in the object. This applies even if the component-level `default` prop is set. Always include `default: 'none'` (or `'auto'`) in type-keyed objects.
+
+**Orphaned CSS after removing ViewTransition:**
+- When removing `<ViewTransition>` components (e.g., switching animated collapse to `<details>`), remember to clean up corresponding `::view-transition-old(...)` / `::view-transition-new(...)` rules and `@keyframes` definitions. These don't cause build errors so they're easy to forget.
 
 **Batching:**
 - If multiple updates occur while an animation is running, React batches them into one. For example: if you navigate A→B, then B→C, then C→D during the first animation, the next animation will go B→D.

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -1,8 +1,6 @@
 # React View Transitions — Complete Reference
 
-React's View Transition API lets you animate between UI states using the browser's native `document.startViewTransition` under the hood. React manages the lifecycle automatically — you declare *what* to animate with `<ViewTransition>`, trigger *when* to animate through `startTransition` / `useDeferredValue` / `Suspense`, and control *how* to animate with CSS classes or JavaScript via the Web Animations API.
-
-The API adds ~3KB to your bundle, runs on the browser's compositor thread for 60fps animations, and gracefully falls back to instant state changes in unsupported browsers.
+React's View Transition API lets you animate between UI states using the browser's native `document.startViewTransition` under the hood. Declare *what* to animate with `<ViewTransition>`, trigger *when* with `startTransition` / `useDeferredValue` / `Suspense`, and control *how* with CSS classes or the Web Animations API. Unsupported browsers skip the animation and apply the DOM change instantly.
 
 ## When to Animate (and When Not To)
 
@@ -28,9 +26,8 @@ Route-level transitions (#5) are the lowest priority because the URL change alre
 
 ## Availability
 
-- `<ViewTransition>` and `addTransitionType` are currently available in `react@canary` and `react@experimental` only — they are **not yet in a stable release**.
-- Install with `npm install react@canary react-dom@canary` (or `@experimental`).
-- Browser support: Chromium-based browsers have full support. Firefox and Safari are adding support. The API gracefully degrades — unsupported browsers skip the animation and apply the DOM change instantly.
+- `<ViewTransition>` and `addTransitionType` require `react@canary` or `react@experimental`. Check `react --version` — if these APIs are not available, install canary: `npm install react@canary react-dom@canary`.
+- Browser support: Chromium 111+, with Firefox and Safari adding support. The API gracefully degrades — unsupported browsers skip the animation and apply the DOM change instantly.
 
 ---
 
@@ -93,11 +90,9 @@ function Item() {
 
 ## Styling Animations with View Transition Classes
 
-Rather than using `view-transition-name` in CSS directly, React recommends providing a **View Transition Class** to the activation props. React applies this class to the child elements when the animation activates.
-
 ### Props
 
-Each prop controls a different trigger. Values can be:
+Each prop controls a different animation trigger. Values can be:
 
 - `"auto"` — use the browser default cross-fade
 - `"none"` — disable this animation type
@@ -348,7 +343,7 @@ Wrap `<Suspense>` in `<ViewTransition>` to cross-fade from fallback to loaded co
 </ViewTransition>
 ```
 
-For directional motion, give the fallback and content separate VTs with explicit triggers. Use `default="none"` on the content VT to prevent it from re-animating on unrelated transitions:
+For directional motion, give the fallback and content separate `<ViewTransition>`s with explicit triggers. Use `default="none"` on the content one to prevent it from re-animating on unrelated transitions:
 
 ```jsx
 <Suspense
@@ -378,102 +373,15 @@ Wrap children in `<ViewTransition update="none">` to prevent them from animating
 </ViewTransition>
 ```
 
-### Isolate Floating Elements from Parent Animations
-
-Popovers, tooltips, and dropdowns can get captured in a parent's view transition snapshot, causing them to ghost or animate unexpectedly. Give them their own `viewTransitionName` to isolate them into a separate transition group:
-
-```jsx
-<SelectPopover style={{ viewTransitionName: 'popover' }}>
-  {options}
-</SelectPopover>
-```
-
-```css
-::view-transition-group(popover) {
-  z-index: 100;
-}
-```
-
-This creates an independent transition group that renders above other transitioning elements. The element won't be included in its parent's old/new snapshot.
-
-### Reusable Animated Collapse
-
-For apps with many expand/collapse interactions, extract a reusable wrapper instead of repeating the conditional-render-with-VT pattern:
-
-```jsx
-import { ViewTransition } from 'react';
-
-function AnimatedCollapse({ open, children }) {
-  if (!open) return null;
-  return (
-    <ViewTransition enter="expand-in" exit="collapse-out">
-      {children}
-    </ViewTransition>
-  );
-}
-```
-
-Use it with `startTransition` on the toggle:
-
-```jsx
-<button onClick={() => startTransition(() => setOpen(o => !o))}>Toggle</button>
-<AnimatedCollapse open={open}>
-  <SectionContent />
-</AnimatedCollapse>
-```
-
-### Preserve State with Activity
-
-Use `<Activity>` with `<ViewTransition>` to animate show/hide while preserving component state:
-
-```jsx
-import { Activity, ViewTransition, startTransition } from 'react';
-
-<Activity mode={isVisible ? 'visible' : 'hidden'}>
-  <ViewTransition enter="slide-in" exit="slide-out">
-    <Sidebar />
-  </ViewTransition>
-</Activity>
-```
-
-### Exclude Elements from a Transition with `useOptimistic`
-
-When a `startTransition` changes both a control (e.g. a button label) and content (e.g. list order), use `useOptimistic` for the control. The optimistic value updates before React's transition snapshot, so it won't animate. The committed state drives the content, which changes within the transition and animates:
-
-```tsx
-const [sort, setSort] = useState('newest');
-const [optimisticSort, setOptimisticSort] = useOptimistic(sort);
-
-function cycleSort() {
-  const nextSort = getNextSort(optimisticSort);
-  startTransition(() => {
-    setOptimisticSort(nextSort);  // updates before snapshot — no animation
-    setSort(nextSort);            // changes within transition — animates
-  });
-}
-
-// Button uses optimisticSort (instant, excluded from animation)
-<button>Sort: {LABELS[optimisticSort]}</button>
-
-// List uses committed sort (changes between snapshots, animates)
-{items.sort(comparators[sort]).map(item => (
-  <ViewTransition key={item.id}>
-    <ItemCard item={item} />
-  </ViewTransition>
-))}
-```
-
-`useOptimistic` values resolve before the transition snapshot. Any DOM driven by optimistic state is already in its final form when the "before" snapshot is taken, so it doesn't participate in the ViewTransition. Only DOM driven by committed state (via `setState`) changes between snapshots and animates.
-
-**Note:** Always add `prefers-reduced-motion` handling to your global CSS — see the Accessibility section below.
+For more patterns (isolate floating elements, reusable animated collapse, preserve state with `<Activity>`, exclude elements with `useOptimistic`), see the "Real-World Patterns" section above.
 
 ---
 
-## How Multiple ViewTransitions Interact
+## How Multiple `<ViewTransition>`s Interact
 
 When a transition fires, **every** `<ViewTransition>` in the tree that matches the trigger participates simultaneously. Each gets its own `view-transition-name`, and the browser animates all of them inside a single `document.startViewTransition` call. They run in parallel, not sequentially.
 
-This means a layout-level VT (whole-page cross-fade) + a page-level VT (Suspense slide-up) + per-item VTs (list reorder) all fire at once. The result is usually competing animations that look broken.
+This means a layout-level `<ViewTransition>` (whole-page cross-fade) + a page-level one (Suspense slide-up) + per-item ones (list reorder) all fire at once. The result is usually competing animations that look broken.
 
 ### Use `default="none"` Liberally
 
@@ -507,8 +415,8 @@ Without `default="none"`, a `<ViewTransition>` with `default="auto"` (the implic
 
 Pick the level that carries the most meaning for your app:
 
-- **App with per-page Suspense reveals and shared elements:** Don't add a layout-level VT on `{children}`. The pages already manage their own transitions. A layout-level cross-fade on top will double-animate.
-- **Simple app with no per-page animations:** A layout-level VT with `default="auto"` on `{children}` gives you free cross-fades between routes.
+- **App with per-page Suspense reveals and shared elements:** Don't add a layout-level `<ViewTransition>` on `{children}`. The pages already manage their own transitions. A layout-level cross-fade on top will double-animate.
+- **Simple app with no per-page animations:** A layout-level `<ViewTransition>` with `default="auto"` on `{children}` gives you free cross-fades between routes.
 - **Mixed:** Use `default="none"` at the layout level and only activate it for specific `transitionTypes` (e.g., directional navigation). This way it stays silent during per-page Suspense transitions.
 
 The exception is **shared element transitions** — these intentionally span levels (one side unmounts while the other mounts) and don't conflict with other VTs because the `share` trigger takes precedence over `enter`/`exit`.
@@ -528,15 +436,9 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-**What this flag does:** It wraps every `<Link>` navigation in `document.startViewTransition`, which means all mounted `<ViewTransition>` components in the tree participate in every link navigation — not just ones triggered by `startTransition` or Suspense. This is important:
+**What this flag does:** It wraps every `<Link>` navigation in `document.startViewTransition`, so all mounted `<ViewTransition>` components participate in every link click — not just `startTransition`/Suspense-triggered ones. This makes the composition rules in "How Multiple `<ViewTransition>`s Interact" especially important: use `default="none"` on layout-level `<ViewTransition>`s to avoid competing animations.
 
-- If you have a layout-level VT with `default: "auto"`, it fires on **every** `<Link>` navigation — even ones you didn't intend to animate.
-- Combined with per-page VTs (Suspense reveals, item animations), you get competing animations.
-- Without this flag, only `Suspense`-triggered and `startTransition`-triggered transitions fire.
-
-If your pages manage their own per-page transitions, either (a) don't use a layout-level `<ViewTransition>` on `{children}`, or (b) set `default="none"` on it so it only activates for explicit `transitionTypes`.
-
-For a detailed guide on Next.js integration, including App Router patterns and Server Component considerations, see the "View Transitions in Next.js" section below.
+For a detailed guide including App Router patterns and Server Component considerations, see the "View Transitions in Next.js" section below.
 
 Key points:
 - The `<ViewTransition>` component is imported from `react` directly — no Next.js-specific import.
@@ -544,7 +446,7 @@ Key points:
 
 ### The `transitionTypes` prop on `next/link`
 
-As of Next.js 16.2+, `next/link` supports a native `transitionTypes` prop that eliminates the need for custom `TransitionLink` wrapper components. Instead of intercepting navigation with `onNavigate`, `startTransition`, and `addTransitionType`, you pass transition types directly:
+`next/link` supports a native `transitionTypes` prop that eliminates the need for custom `TransitionLink` wrapper components. Instead of intercepting navigation with `onNavigate`, `startTransition`, and `addTransitionType`, you pass transition types directly:
 
 ```tsx
 import Link from 'next/link';
@@ -560,11 +462,9 @@ import Link from 'next/link';
 </Link>
 ```
 
-The `transitionTypes` prop accepts an array of strings — the same types you would pass to `addTransitionType`. This removes the need for `'use client'`, `useRouter`, and custom link components when all you need is to tag a navigation with a transition type. The `<ViewTransition>` components in the tree respond to these types the same way they respond to manual `addTransitionType` calls.
+The `transitionTypes` prop accepts an array of strings — the same types you would pass to `addTransitionType`. This removes the need for `'use client'`, `useRouter`, and custom link components when all you need is to tag a navigation with a transition type.
 
-**Composition note:** `transitionTypes` on `<Link>` works best when you have a single `<ViewTransition>` at the layout level with `default="none"` (so it only fires for your specific types) and no per-page Suspense VTs competing. If your pages have their own Suspense transitions, use `transitionTypes` at the page level (e.g., to distinguish sources of `startTransition` within a client component) rather than at the layout level, or the layout slide and the page's Suspense reveal will both fire simultaneously.
-
-For full examples of `transitionTypes` with shared element transitions and directional animations across routes, see the "View Transitions in Next.js" section below.
+For full examples with shared element transitions and directional animations, see the "View Transitions in Next.js" section below.
 
 ---
 
@@ -697,6 +597,93 @@ These wrappers enforce that only valid transition IDs and animation classes are 
 
 See the section above (Shared Elements Across Routes) for complete examples using `transitionTypes` on `next/link` combined with shared element `<ViewTransition name={...}>` for list-to-detail image morph animations.
 
+### Isolate Floating Elements from Parent Animations
+
+Popovers, tooltips, and dropdowns can get captured in a parent's view transition snapshot, causing them to ghost or animate unexpectedly. Give them their own `viewTransitionName` to isolate them into a separate transition group:
+
+```jsx
+<SelectPopover style={{ viewTransitionName: 'popover' }}>
+  {options}
+</SelectPopover>
+```
+
+```css
+::view-transition-group(popover) {
+  z-index: 100;
+}
+```
+
+This creates an independent transition group that renders above other transitioning elements. The element won't be included in its parent's old/new snapshot.
+
+### Reusable Animated Collapse
+
+For apps with many expand/collapse interactions, extract a reusable wrapper instead of repeating the conditional-render-with-`<ViewTransition>` pattern:
+
+```jsx
+import { ViewTransition } from 'react';
+
+function AnimatedCollapse({ open, children }) {
+  if (!open) return null;
+  return (
+    <ViewTransition enter="expand-in" exit="collapse-out">
+      {children}
+    </ViewTransition>
+  );
+}
+```
+
+Use it with `startTransition` on the toggle:
+
+```jsx
+<button onClick={() => startTransition(() => setOpen(o => !o))}>Toggle</button>
+<AnimatedCollapse open={open}>
+  <SectionContent />
+</AnimatedCollapse>
+```
+
+### Preserve State with Activity
+
+Use `<Activity>` with `<ViewTransition>` to animate show/hide while preserving component state:
+
+```jsx
+import { Activity, ViewTransition, startTransition } from 'react';
+
+<Activity mode={isVisible ? 'visible' : 'hidden'}>
+  <ViewTransition enter="slide-in" exit="slide-out">
+    <Sidebar />
+  </ViewTransition>
+</Activity>
+```
+
+### Exclude Elements from a Transition with `useOptimistic`
+
+When a `startTransition` changes both a control (e.g. a button label) and content (e.g. list order), use `useOptimistic` for the control. The optimistic value updates before React's transition snapshot, so it won't animate. The committed state drives the content, which changes within the transition and animates:
+
+```tsx
+const [sort, setSort] = useState('newest');
+const [optimisticSort, setOptimisticSort] = useOptimistic(sort);
+
+function cycleSort() {
+  const nextSort = getNextSort(optimisticSort);
+  startTransition(() => {
+    setOptimisticSort(nextSort);  // updates before snapshot — no animation
+    setSort(nextSort);            // changes within transition — animates
+  });
+}
+
+// Button uses optimisticSort (instant, excluded from animation)
+<button>Sort: {LABELS[optimisticSort]}</button>
+
+// List uses committed sort (changes between snapshots, animates)
+{items.sort(comparators[sort]).map(item => (
+  <ViewTransition key={item.id}>
+    <ItemCard item={item} />
+  </ViewTransition>
+))}
+```
+
+`useOptimistic` values resolve before the transition snapshot. Any DOM driven by optimistic state is already in its final form when the "before" snapshot is taken, so it doesn't participate in the `<ViewTransition>`. Only DOM driven by committed state (via `setState`) changes between snapshots and animates.
+
 ---
 
 ### Animation Timing Guidelines
@@ -751,7 +738,7 @@ Or disable specific animations conditionally in JavaScript events by checking th
 - `startTransition(() => setState(...))` triggers a Transition, but if the new content isn't behind a `<Suspense>` boundary, React treats the swap as an **update** to the existing tree — not an enter/exit. The `<ViewTransition>` sees its children change but never fully unmounts/remounts, so only `update` animations fire. To get true enter/exit, either conditionally render the `<ViewTransition>` itself (so it mounts/unmounts with the content), or wrap the async content in `<Suspense>` so React can treat the reveal as an insertion.
 
 **Competing / double animations on navigation:**
-- Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level VT cross-fades the whole page while a page-level VT slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level VT, or remove it entirely if pages manage their own animations. See "How Multiple ViewTransitions Interact" above.
+- Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level one cross-fades the whole page while a page-level one slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level `<ViewTransition>`, or remove it entirely if pages manage their own animations. See "How Multiple `<ViewTransition>`s Interact" above.
 
 **List reorder not animating with `useOptimistic`:**
 - If the optimistic value drives the list sort order, items are already in their final positions before the transition snapshot — there's nothing to animate. Use the optimistic value only for controls (labels, icons) and the committed state (`useState`) for the list sort order.

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -27,7 +27,7 @@ Route-level transitions (#5) are the lowest priority because the URL change alre
 
 - **Persistent across navigations?** (nav bar, sidebar, header) → Skip VT. Use plain `<Suspense>` if needed.
 - **Expand/collapse that needs to feel spatial?** → Animated collapse with VT + `startTransition`.
-- **Simple show/hide with no spatial meaning?** → `<details>` or conditional render, no VT.
+- **Simple show/hide with no spatial meaning?** → Conditional render, no VT.
 - **Already inside a parent VT?** → Check if `default="none"` is needed to avoid double-animation.
 - **Content that changes on route navigation?** → VT with `default="none"` + explicit triggers.
 
@@ -420,7 +420,7 @@ function AnimatedCollapse({ open, children }) {
 }
 ```
 
-Use it with `startTransition` on the toggle — never with native `<details>`/`<summary>` (which bypasses React state):
+Use it with `startTransition` on the toggle:
 
 ```jsx
 <button onClick={() => startTransition(() => setOpen(o => !o))}>Toggle</button>
@@ -726,9 +726,6 @@ Or disable specific animations conditionally in JavaScript events by checking th
 **Enter/exit not firing in a client component (only updates animate):**
 - `startTransition(() => setState(...))` triggers a Transition, but if the new content isn't behind a `<Suspense>` boundary, React treats the swap as an **update** to the existing tree — not an enter/exit. The `<ViewTransition>` sees its children change but never fully unmounts/remounts, so only `update` animations fire. To get true enter/exit, either conditionally render the `<ViewTransition>` itself (so it mounts/unmounts with the content), or wrap the async content in `<Suspense>` so React can treat the reveal as an insertion.
 
-**ViewTransition not firing on `<details>` toggle:**
-- Native `<details>`/`<summary>` is browser-controlled — open/close bypasses React, so `startTransition` never wraps the toggle and `<ViewTransition>` never fires. This is a trade-off: `<details>` is simpler and more accessible out of the box, but can't be animated with VT. If you need animated expand/collapse, use controlled state with `useState` + `startTransition`. If you don't need the animation, `<details>` is the simpler choice.
-
 **Competing / double animations on navigation:**
 - Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level VT cross-fades the whole page while a page-level VT slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level VT, or remove it entirely if pages manage their own animations. See "How Multiple ViewTransitions Interact" above.
 
@@ -736,7 +733,7 @@ Or disable specific animations conditionally in JavaScript events by checking th
 - When passing an object to `enter`/`exit`/`update`/`share`, TypeScript requires a `default` key in the object. This applies even if the component-level `default` prop is set. Always include `default: 'none'` (or `'auto'`) in type-keyed objects.
 
 **Orphaned CSS after removing ViewTransition:**
-- When removing `<ViewTransition>` components (e.g., switching animated collapse to `<details>`), remember to clean up corresponding `::view-transition-old(...)` / `::view-transition-new(...)` rules and `@keyframes` definitions. These don't cause build errors so they're easy to forget.
+- When removing `<ViewTransition>` components, remember to clean up corresponding `::view-transition-old(...)` / `::view-transition-new(...)` rules and `@keyframes` definitions. These don't cause build errors so they're easy to forget.
 
 **Batching:**
 - If multiple updates occur while an animation is running, React batches them into one. For example: if you navigate A→B, then B→C, then C→D during the first animation, the next animation will go B→D.

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -1,20 +1,4 @@
----
-name: vercel-react-view-transitions
-description:
-  Guide for implementing smooth, native-feeling animations using React's View
-  Transition API. Use when adding page transitions, animating route changes,
-  creating shared element animations, animating enter/exit of components,
-  list reorder, directional navigation animations, or integrating view
-  transitions in Next.js. Triggers on view transitions, ViewTransition,
-  addTransitionType, transition types, transitionTypes, or animating between
-  UI states in React without third-party animation libraries.
-license: MIT
-metadata:
-  author: vercel
-  version: '1.0.0'
----
-
-# React View Transitions
+# React View Transitions — Complete Reference
 
 React's View Transition API lets you animate between UI states using the browser's native `document.startViewTransition` under the hood. React manages the lifecycle automatically — you declare *what* to animate with `<ViewTransition>`, trigger *when* to animate through `startTransition` / `useDeferredValue` / `Suspense`, and control *how* to animate with CSS classes or JavaScript via the Web Animations API.
 
@@ -383,8 +367,6 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-For a detailed guide on Next.js integration, including App Router patterns and Server Component considerations, read `references/nextjs.md`.
-
 Key points:
 - The `<ViewTransition>` component is imported from `react` directly — no Next.js-specific import.
 - The `experimental.viewTransition` flag enables deeper integration with Next.js features beyond what `<ViewTransition>` provides on its own.
@@ -411,7 +393,7 @@ import Link from 'next/link';
 
 The `transitionTypes` prop accepts an array of strings — the same types you would pass to `addTransitionType`. This removes the need for `'use client'`, `useRouter`, and custom link components when all you need is to tag a navigation with a transition type. The `<ViewTransition>` components in the tree respond to these types the same way they respond to manual `addTransitionType` calls.
 
-For full examples of `transitionTypes` with shared element transitions and directional animations across routes, see `references/nextjs.md`.
+See the Next.js section below for full examples of `transitionTypes` with shared element transitions and directional animations across routes.
 
 ---
 
@@ -546,7 +528,7 @@ These wrappers enforce that only valid transition IDs and animation classes are 
 
 ### Shared Elements Across Routes in Next.js
 
-See `references/nextjs.md` (Shared Elements Across Routes) for complete examples using `transitionTypes` on `next/link` combined with shared element `<ViewTransition name={...}>` for list-to-detail image morph animations.
+See the Next.js Shared Elements Across Routes section below for complete examples using `transitionTypes` on `next/link` combined with shared element `<ViewTransition name={...}>` for list-to-detail image morph animations.
 
 ---
 
@@ -589,4 +571,661 @@ Or disable specific animations conditionally in JavaScript events by checking th
 
 ## CSS Recipe Reference
 
-For ready-to-use CSS animation recipes (slide, fade, scale, flip, and combined patterns), see `references/css-recipes.md`.
+Ready-to-use CSS animation recipes follow below.
+
+
+---
+
+# View Transitions in Next.js
+
+## Table of Contents
+
+1. [Setup](#setup)
+2. [Basic Route Transitions](#basic-route-transitions)
+3. [Layout-Level ViewTransition](#layout-level-viewtransition)
+4. [The transitionTypes Prop on next/link](#the-transitiontypes-prop-on-nextlink)
+5. [Programmatic Navigation with Transitions](#programmatic-navigation-with-transitions)
+6. [Transition Types for Navigation Direction](#transition-types-for-navigation-direction)
+7. [Shared Elements Across Routes](#shared-elements-across-routes)
+8. [Combining with Suspense and Loading States](#combining-with-suspense-and-loading-states)
+9. [Server Components Considerations](#server-components-considerations)
+
+---
+
+## Setup
+
+Enable the experimental flag in `next.config.js` (or `next.config.ts`):
+
+```js
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    viewTransition: true,
+  },
+};
+module.exports = nextConfig;
+```
+
+This flag enables deeper integration with Next.js features beyond what React's `<ViewTransition>` component provides on its own. The `<ViewTransition>` component itself is available from `react` in canary/experimental channels or React 19.2+.
+
+Install React canary if you're not yet on 19.2+:
+
+```bash
+npm install react@canary react-dom@canary
+```
+
+---
+
+## Basic Route Transitions
+
+The simplest approach is wrapping your page content in `<ViewTransition>` inside a layout:
+
+```tsx
+// app/layout.tsx
+import { ViewTransition } from 'react';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <nav>{/* navigation links */}</nav>
+        <ViewTransition>
+          {children}
+        </ViewTransition>
+      </body>
+    </html>
+  );
+}
+```
+
+When users navigate between routes using `<Link>`, Next.js triggers a transition internally. The `<ViewTransition>` wrapping `{children}` detects the content swap and animates it with the default cross-fade.
+
+---
+
+## Layout-Level ViewTransition
+
+For more control, place `<ViewTransition>` at different levels of the layout hierarchy:
+
+```tsx
+// app/dashboard/layout.tsx
+import { ViewTransition } from 'react';
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="dashboard">
+      <Sidebar />
+      <ViewTransition enter="slide-up" exit="fade-out">
+        <main>{children}</main>
+      </ViewTransition>
+    </div>
+  );
+}
+```
+
+Only the `<main>` content animates when navigating between dashboard sub-routes. The sidebar stays static.
+
+---
+
+## The `transitionTypes` Prop on `next/link`
+
+As of Next.js 16.2+, `next/link` supports a native `transitionTypes` prop. This eliminates the need for custom wrapper components that intercept navigation with `onNavigate` + `startTransition` + `addTransitionType` + `router.push()`.
+
+### Before (manual wrapper, requires `'use client'`)
+
+```tsx
+'use client';
+
+import { addTransitionType, startTransition } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+export function TransitionLink({ type, ...props }: { type: string } & React.ComponentProps<typeof Link>) {
+  const router = useRouter();
+
+  return (
+    <Link
+      onNavigate={(event) => {
+        event.preventDefault();
+        startTransition(() => {
+          addTransitionType(type);
+          router.push(props.href as string);
+        });
+      }}
+      {...props}
+    />
+  );
+}
+```
+
+### After (native prop, no wrapper needed, works in Server Components)
+
+```tsx
+import Link from 'next/link';
+
+<Link href="/products/1" transitionTypes={['transition-to-detail']}>
+  View Product
+</Link>
+```
+
+The `transitionTypes` prop accepts an array of strings. These types are passed to the View Transition system the same way `addTransitionType` would. `<ViewTransition>` components in the tree respond to these types identically.
+
+This is the recommended approach for link-based navigation transitions. Reserve manual `startTransition` + `addTransitionType` for programmatic navigation (buttons, form submissions, etc.) where `next/link` isn't used.
+
+---
+
+## Programmatic Navigation with Transitions
+
+Use `startTransition` with Next.js's `router.push()` to trigger view transitions from code:
+
+```tsx
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { startTransition, addTransitionType } from 'react';
+
+export function NavigateButton({ href }: { href: string }) {
+  const router = useRouter();
+
+  return (
+    <button
+      onClick={() => {
+        startTransition(() => {
+          addTransitionType('navigation-forward');
+          router.push(href);
+        });
+      }}
+    >
+      Go to {href}
+    </button>
+  );
+}
+```
+
+Wrapping `router.push()` in `startTransition` is what activates the `<ViewTransition>` boundaries in the tree.
+
+---
+
+## Transition Types for Navigation Direction
+
+A common pattern is to animate differently for forward vs. backward navigation.
+
+### Using `transitionTypes` on `next/link` (preferred)
+
+```tsx
+import Link from 'next/link';
+
+// Forward navigation
+<Link href="/products/1" transitionTypes={['transition-forwards']}>
+  Next →
+</Link>
+
+// Backward navigation
+<Link href="/products" transitionTypes={['transition-backwards']}>
+  ← Back
+</Link>
+```
+
+### Using `startTransition` + `addTransitionType` (for programmatic navigation)
+
+```tsx
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { startTransition, addTransitionType } from 'react';
+
+export function NavigateButton({
+  href,
+  direction = 'forward',
+  children,
+}: {
+  href: string;
+  direction?: 'forward' | 'back';
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+
+  return (
+    <button
+      onClick={() => {
+        startTransition(() => {
+          addTransitionType(`navigation-${direction}`);
+          router.push(href);
+        });
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+```
+
+Configure `<ViewTransition>` to respond to these types:
+
+```tsx
+// app/layout.tsx
+import { ViewTransition } from 'react';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <ViewTransition
+          enter={{
+            'navigation-forward': 'slide-in-from-right',
+            'navigation-back': 'slide-in-from-left',
+            default: 'auto',
+          }}
+          exit={{
+            'navigation-forward': 'slide-out-to-left',
+            'navigation-back': 'slide-out-to-right',
+            default: 'auto',
+          }}
+        >
+          {children}
+        </ViewTransition>
+      </body>
+    </html>
+  );
+}
+```
+
+---
+
+## Shared Elements Across Routes
+
+Animate a thumbnail expanding into a full image across route transitions. Use `transitionTypes` on the link to tag the navigation direction:
+
+```tsx
+// app/products/page.tsx (list page)
+import { ViewTransition } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+
+export default function ProductList({ products }) {
+  return (
+    <div className="grid grid-cols-3 gap-6">
+      {products.map((product) => (
+        <Link
+          key={product.id}
+          href={`/products/${product.id}`}
+          transitionTypes={['transition-to-detail']}
+        >
+          <ViewTransition name={`product-${product.id}`}>
+            <Image src={product.image} alt={product.name} width={400} height={300} />
+          </ViewTransition>
+          <p>{product.name}</p>
+        </Link>
+      ))}
+    </div>
+  );
+}
+```
+
+```tsx
+// app/products/[id]/page.tsx (detail page)
+import { ViewTransition } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+
+export default function ProductDetail({ product }) {
+  return (
+    <article>
+      <Link href="/products" transitionTypes={['transition-to-list']}>
+        ← Back to Products
+      </Link>
+      <ViewTransition name={`product-${product.id}`}>
+        <Image src={product.image} alt={product.name} width={800} height={600} />
+      </ViewTransition>
+      <h1>{product.name}</h1>
+      <p>{product.description}</p>
+    </article>
+  );
+}
+```
+
+Only one `<ViewTransition>` with a given name can be mounted at a time. Since Next.js unmounts the old page and mounts the new page within the same transition, the two `product-${product.id}` boundaries form a shared element pair and the image morphs from its thumbnail size to its full size.
+
+---
+
+## Combining with Suspense and Loading States
+
+Next.js `loading.tsx` files create `<Suspense>` boundaries. Wrap them with `<ViewTransition>` for smooth fallback-to-content reveals:
+
+```tsx
+// app/dashboard/layout.tsx
+import { ViewTransition } from 'react';
+import { Suspense } from 'react';
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="dashboard">
+      <Sidebar />
+      <ViewTransition>
+        <Suspense fallback={<DashboardSkeleton />}>
+          {children}
+        </Suspense>
+      </ViewTransition>
+    </div>
+  );
+}
+```
+
+The skeleton cross-fades into the actual content once it loads.
+
+---
+
+## Server Components Considerations
+
+- `<ViewTransition>` can be used in both Server and Client Components — it renders no DOM of its own.
+- `<Link>` with `transitionTypes` works in Server Components — no `'use client'` directive needed for link-based transitions.
+- `addTransitionType` must be called from a Client Component (inside an event handler with `startTransition`).
+- `startTransition` for programmatic navigation must be called from a Client Component.
+- Navigation via `<Link>` from `next/link` triggers transitions automatically when the experimental flag is enabled.
+- Prefer `transitionTypes` on `<Link>` over custom wrapper components. Only use manual `startTransition` + `addTransitionType` + `router.push()` for non-link interactions (buttons, form submissions, etc.).
+
+
+---
+
+# CSS Animation Recipes for View Transitions
+
+Ready-to-use CSS snippets for common view transition animations. Use these class names with `<ViewTransition>` props.
+
+## Table of Contents
+
+1. [Fade](#fade)
+2. [Slide](#slide)
+3. [Scale](#scale)
+4. [Slide + Fade Combined](#slide--fade-combined)
+5. [Directional Navigation (Forward / Back)](#directional-navigation)
+6. [Flip](#flip)
+7. [Reduced Motion](#reduced-motion)
+8. [Slow Cross-Fade](#slow-cross-fade)
+
+---
+
+## Fade
+
+```css
+::view-transition-old(.fade-out) {
+  animation: 200ms ease-out fade-to-hidden;
+}
+::view-transition-new(.fade-in) {
+  animation: 200ms ease-in fade-from-hidden;
+}
+
+@keyframes fade-to-hidden {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+@keyframes fade-from-hidden {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+```
+
+Usage:
+```jsx
+<ViewTransition enter="fade-in" exit="fade-out" />
+```
+
+---
+
+## Slide
+
+```css
+::view-transition-old(.slide-out-left) {
+  animation: 300ms ease-in-out slide-to-left;
+}
+::view-transition-new(.slide-in-from-right) {
+  animation: 300ms ease-in-out slide-from-right;
+}
+::view-transition-old(.slide-out-right) {
+  animation: 300ms ease-in-out slide-to-right;
+}
+::view-transition-new(.slide-in-from-left) {
+  animation: 300ms ease-in-out slide-from-left;
+}
+
+/* Vertical */
+::view-transition-old(.slide-out-up) {
+  animation: 300ms ease-in-out slide-to-top;
+}
+::view-transition-new(.slide-in-from-bottom) {
+  animation: 300ms ease-in-out slide-from-bottom;
+}
+::view-transition-old(.slide-out-down) {
+  animation: 300ms ease-in-out slide-to-bottom;
+}
+::view-transition-new(.slide-in-from-top) {
+  animation: 300ms ease-in-out slide-from-top;
+}
+
+@keyframes slide-to-left {
+  from { transform: translateX(0); }
+  to { transform: translateX(-100%); }
+}
+@keyframes slide-from-right {
+  from { transform: translateX(100%); }
+  to { transform: translateX(0); }
+}
+@keyframes slide-to-right {
+  from { transform: translateX(0); }
+  to { transform: translateX(100%); }
+}
+@keyframes slide-from-left {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(0); }
+}
+@keyframes slide-to-top {
+  from { transform: translateY(0); }
+  to { transform: translateY(-100%); }
+}
+@keyframes slide-from-bottom {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
+}
+@keyframes slide-to-bottom {
+  from { transform: translateY(0); }
+  to { transform: translateY(100%); }
+}
+@keyframes slide-from-top {
+  from { transform: translateY(-100%); }
+  to { transform: translateY(0); }
+}
+```
+
+Usage:
+```jsx
+<ViewTransition enter="slide-in-from-right" exit="slide-out-left" />
+```
+
+---
+
+## Scale
+
+```css
+::view-transition-old(.scale-out) {
+  animation: 250ms ease-in scale-down;
+}
+::view-transition-new(.scale-in) {
+  animation: 250ms ease-out scale-up;
+}
+
+@keyframes scale-down {
+  from { transform: scale(1); opacity: 1; }
+  to { transform: scale(0.85); opacity: 0; }
+}
+@keyframes scale-up {
+  from { transform: scale(0.85); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+```
+
+Usage:
+```jsx
+<ViewTransition enter="scale-in" exit="scale-out" />
+```
+
+---
+
+## Slide + Fade Combined
+
+```css
+::view-transition-old(.slide-fade-out) {
+  animation: 300ms ease-in-out slide-fade-exit;
+}
+::view-transition-new(.slide-fade-in) {
+  animation: 300ms ease-in-out slide-fade-enter;
+}
+
+@keyframes slide-fade-exit {
+  from { transform: translateY(0); opacity: 1; }
+  to { transform: translateY(-20px); opacity: 0; }
+}
+@keyframes slide-fade-enter {
+  from { transform: translateY(20px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+```
+
+Usage:
+```jsx
+<ViewTransition enter="slide-fade-in" exit="slide-fade-out" />
+```
+
+---
+
+## Directional Navigation
+
+A complete setup for forward/back page transitions using `addTransitionType`:
+
+```css
+/* Forward navigation: content slides left */
+::view-transition-old(.nav-forward-exit) {
+  animation: 350ms ease-in-out nav-slide-out-left;
+}
+::view-transition-new(.nav-forward-enter) {
+  animation: 350ms ease-in-out nav-slide-in-from-right;
+}
+
+/* Back navigation: content slides right */
+::view-transition-old(.nav-back-exit) {
+  animation: 350ms ease-in-out nav-slide-out-right;
+}
+::view-transition-new(.nav-back-enter) {
+  animation: 350ms ease-in-out nav-slide-in-from-left;
+}
+
+@keyframes nav-slide-out-left {
+  from { transform: translateX(0); opacity: 1; }
+  to { transform: translateX(-30%); opacity: 0; }
+}
+@keyframes nav-slide-in-from-right {
+  from { transform: translateX(30%); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+@keyframes nav-slide-out-right {
+  from { transform: translateX(0); opacity: 1; }
+  to { transform: translateX(30%); opacity: 0; }
+}
+@keyframes nav-slide-in-from-left {
+  from { transform: translateX(-30%); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+```
+
+Usage with transition types:
+```jsx
+<ViewTransition
+  enter={{
+    'navigation-forward': 'nav-forward-enter',
+    'navigation-back': 'nav-back-enter',
+    default: 'auto',
+  }}
+  exit={{
+    'navigation-forward': 'nav-forward-exit',
+    'navigation-back': 'nav-back-exit',
+    default: 'auto',
+  }}
+>
+  <Page />
+</ViewTransition>
+```
+
+Triggering:
+```jsx
+startTransition(() => {
+  addTransitionType('navigation-forward');
+  router.push('/next-page');
+});
+```
+
+---
+
+## Flip
+
+```css
+::view-transition-old(.flip-out) {
+  animation: 400ms ease-in flip-exit;
+  backface-visibility: hidden;
+}
+::view-transition-new(.flip-in) {
+  animation: 400ms ease-out flip-enter;
+  backface-visibility: hidden;
+}
+
+@keyframes flip-exit {
+  from { transform: rotateY(0deg); opacity: 1; }
+  to { transform: rotateY(-90deg); opacity: 0; }
+}
+@keyframes flip-enter {
+  from { transform: rotateY(90deg); opacity: 0; }
+  to { transform: rotateY(0deg); opacity: 1; }
+}
+```
+
+Usage:
+```jsx
+<ViewTransition enter="flip-in" exit="flip-out" />
+```
+
+---
+
+## Reduced Motion
+
+Always include this in your global stylesheet to respect user preferences:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(*),
+  ::view-transition-new(*),
+  ::view-transition-group(*) {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+  }
+}
+```
+
+---
+
+## Slow Cross-Fade
+
+Override the browser default timing for a slower, more cinematic cross-fade:
+
+```css
+::view-transition-old(.slow-fade) {
+  animation-duration: 600ms;
+  animation-timing-function: ease-in-out;
+}
+::view-transition-new(.slow-fade) {
+  animation-duration: 600ms;
+  animation-timing-function: ease-in-out;
+}
+```
+
+Usage:
+```jsx
+<ViewTransition default="slow-fade">
+  <Content />
+</ViewTransition>
+```

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -639,6 +639,9 @@ Or disable specific animations conditionally in JavaScript events by checking th
 **Animations from `flushSync` are skipped:**
 - `flushSync` completes synchronously, which prevents view transitions from running. Use `startTransition` instead.
 
+**Enter/exit not firing in a client component (only updates animate):**
+- `startTransition(() => setState(...))` triggers a Transition, but if the new content isn't behind a `<Suspense>` boundary, React treats the swap as an **update** to the existing tree — not an enter/exit. The `<ViewTransition>` sees its children change but never fully unmounts/remounts, so only `update` animations fire. To get true enter/exit, either conditionally render the `<ViewTransition>` itself (so it mounts/unmounts with the content), or wrap the async content in `<Suspense>` so React can treat the reveal as an insertion.
+
 **Competing / double animations on navigation:**
 - Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level VT cross-fades the whole page while a page-level VT slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level VT, or remove it entirely if pages manage their own animations. See "How Multiple ViewTransitions Interact" above.
 

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -331,6 +331,18 @@ Triggering the reorder inside `startTransition` will smoothly animate each item 
 
 **How it works:** `startTransition` doesn't need async work to animate. The View Transition API captures a "before" snapshot of the DOM, then React applies the state update, and the API captures an "after" snapshot. As long as items change position between snapshots, the animation runs — even for purely synchronous local state changes like sorting.
 
+### Force Re-Enter with `key`
+
+Use a `key` prop on `<ViewTransition>` to force an enter/exit animation when a value changes — even if the component itself doesn't unmount:
+
+```jsx
+<ViewTransition key={searchParams.toString()} enter="slide-up" exit="slide-down" default="none">
+  <ResultsGrid results={results} />
+</ViewTransition>
+```
+
+When the key changes, React unmounts and remounts the `<ViewTransition>`, which triggers exit on the old instance and enter on the new one. This is useful for animating content swaps driven by URL parameters, tab switches, or any state change where the content identity changes but the component type stays the same.
+
 ### Animate Suspense Fallback to Content
 
 Wrap `<Suspense>` in `<ViewTransition>` to cross-fade from fallback to loaded content:
@@ -373,7 +385,7 @@ Wrap children in `<ViewTransition update="none">` to prevent them from animating
 </ViewTransition>
 ```
 
-For more patterns (isolate floating elements, reusable animated collapse, preserve state with `<Activity>`, exclude elements with `useOptimistic`), see the "Real-World Patterns" section above.
+For more patterns (isolate floating elements, reusable animated collapse, preserve state with `<Activity>`, exclude elements with `useOptimistic`), see Appendix: Patterns and Guidelines below.
 
 ---
 
@@ -425,7 +437,9 @@ The exception is **shared element transitions** — these intentionally span lev
 
 ## Next.js Integration
 
-Next.js supports React View Transitions. Enable it in `next.config.js` (or `next.config.ts`):
+Next.js supports React View Transitions. `<ViewTransition>` works out of the box for `startTransition`- and `Suspense`-triggered updates — no config needed.
+
+To also animate `<Link>` navigations, enable the experimental flag in `next.config.js` (or `next.config.ts`):
 
 ```js
 const nextConfig = {
@@ -436,9 +450,9 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-**What this flag does:** It wraps every `<Link>` navigation in `document.startViewTransition`, so all mounted `<ViewTransition>` components participate in every link click — not just `startTransition`/Suspense-triggered ones. This makes the composition rules in "How Multiple `<ViewTransition>`s Interact" especially important: use `default="none"` on layout-level `<ViewTransition>`s to avoid competing animations.
+**What this flag does:** It wraps every `<Link>` navigation in `document.startViewTransition`, so all mounted `<ViewTransition>` components participate in every link click. Without this flag, only `startTransition`/`Suspense`-triggered transitions animate. This makes the composition rules in "How Multiple `<ViewTransition>`s Interact" especially important: use `default="none"` on layout-level `<ViewTransition>`s to avoid competing animations.
 
-For a detailed guide including App Router patterns and Server Component considerations, see the "View Transitions in Next.js" section below.
+For a detailed guide including App Router patterns and Server Component considerations, see Appendix: Next.js Integration Guide below.
 
 Key points:
 - The `<ViewTransition>` component is imported from `react` directly — no Next.js-specific import.
@@ -464,241 +478,13 @@ import Link from 'next/link';
 
 The `transitionTypes` prop accepts an array of strings — the same types you would pass to `addTransitionType`. This removes the need for `'use client'`, `useRouter`, and custom link components when all you need is to tag a navigation with a transition type.
 
-For full examples with shared element transitions and directional animations, see the "View Transitions in Next.js" section below.
+For full examples with shared element transitions and directional animations, see Appendix: Next.js Integration Guide below.
 
 ---
 
 ## Real-World Patterns
 
-### Searchable Grid with `useDeferredValue`
-
-A client-side searchable grid where the filtered results cross-fade as the user types. `useDeferredValue` makes the filter update a transition, which activates the wrapping `<ViewTransition>`:
-
-```tsx
-'use client';
-
-import { useDeferredValue, useState, ViewTransition, Suspense } from 'react';
-
-export default function SearchableGrid({ itemsPromise }) {
-  const [search, setSearch] = useState('');
-  const deferredSearch = useDeferredValue(search);
-
-  return (
-    <>
-      <input
-        value={search}
-        onChange={(e) => setSearch(e.currentTarget.value)}
-        placeholder="Search..."
-      />
-      <ViewTransition>
-        <Suspense fallback={<GridSkeleton />}>
-          <ItemGrid itemsPromise={itemsPromise} search={deferredSearch} />
-        </Suspense>
-      </ViewTransition>
-    </>
-  );
-}
-```
-
-### Card Expand/Collapse with `startTransition`
-
-Toggle between a card grid and a detail view using `startTransition` to animate the swap:
-
-```tsx
-'use client';
-
-import { useState, startTransition, ViewTransition } from 'react';
-
-export default function ItemGrid({ items }) {
-  const [expandedId, setExpandedId] = useState(null);
-
-  return expandedId ? (
-    <ViewTransition enter="slide-up" exit="slide-down">
-      <ItemDetail
-        item={items.find(i => i.id === expandedId)}
-        onClose={() => {
-          startTransition(() => {
-            setExpandedId(null);
-          });
-        }}
-      />
-    </ViewTransition>
-  ) : (
-    <div className="grid grid-cols-3 gap-4">
-      {items.map(item => (
-        <ViewTransition key={item.id}>
-          <ItemCard
-            item={item}
-            onSelect={() => {
-              startTransition(() => {
-                setExpandedId(item.id);
-              });
-            }}
-          />
-        </ViewTransition>
-      ))}
-    </div>
-  );
-}
-```
-
-The CSS for slide-up/slide-down enter/exit:
-
-```css
-::view-transition-old(.slide-down) {
-  animation: 150ms ease-out both fade-out, 150ms ease-out both slide-down;
-}
-::view-transition-new(.slide-up) {
-  animation: 210ms ease-in 150ms both fade-in, 400ms ease-in both slide-up;
-}
-
-@keyframes slide-up {
-  from { transform: translateY(10px); }
-  to { transform: translateY(0); }
-}
-@keyframes slide-down {
-  from { transform: translateY(0); }
-  to { transform: translateY(10px); }
-}
-@keyframes fade-in {
-  from { opacity: 0; }
-}
-@keyframes fade-out {
-  to { opacity: 0; }
-}
-```
-
-### Type-Safe Transition Helpers
-
-For larger apps, define type-safe transition IDs and transition maps to prevent ID clashes and keep animation configurations consistent. Use `as const` arrays for transition IDs, types, and animation classes, then derive types from them:
-
-```tsx
-import { ViewTransition } from 'react';
-
-const transitionTypes = ['default', 'transition-to-detail', 'transition-to-list', 'transition-backwards', 'transition-forwards'] as const;
-const animationTypes = ['auto', 'none', 'animate-slide-from-left', 'animate-slide-from-right', 'animate-slide-to-left', 'animate-slide-to-right'] as const;
-
-type TransitionType = (typeof transitionTypes)[number];
-type AnimationType = (typeof animationTypes)[number];
-type TransitionMap = { default: AnimationType } & Partial<Record<Exclude<TransitionType, 'default'>, AnimationType>>;
-
-export function HorizontalTransition({ children, enter, exit }: {
-  children: React.ReactNode;
-  enter: TransitionMap;
-  exit: TransitionMap;
-}) {
-  return <ViewTransition enter={enter} exit={exit}>{children}</ViewTransition>;
-}
-```
-
-These wrappers enforce that only valid transition IDs and animation classes are used, catching mistakes at compile time.
-
-### Shared Elements Across Routes in Next.js
-
-See the section above (Shared Elements Across Routes) for complete examples using `transitionTypes` on `next/link` combined with shared element `<ViewTransition name={...}>` for list-to-detail image morph animations.
-
-### Isolate Floating Elements from Parent Animations
-
-Popovers, tooltips, and dropdowns can get captured in a parent's view transition snapshot, causing them to ghost or animate unexpectedly. Give them their own `viewTransitionName` to isolate them into a separate transition group:
-
-```jsx
-<SelectPopover style={{ viewTransitionName: 'popover' }}>
-  {options}
-</SelectPopover>
-```
-
-```css
-::view-transition-group(popover) {
-  z-index: 100;
-}
-```
-
-This creates an independent transition group that renders above other transitioning elements. The element won't be included in its parent's old/new snapshot.
-
-### Reusable Animated Collapse
-
-For apps with many expand/collapse interactions, extract a reusable wrapper instead of repeating the conditional-render-with-`<ViewTransition>` pattern:
-
-```jsx
-import { ViewTransition } from 'react';
-
-function AnimatedCollapse({ open, children }) {
-  if (!open) return null;
-  return (
-    <ViewTransition enter="expand-in" exit="collapse-out">
-      {children}
-    </ViewTransition>
-  );
-}
-```
-
-Use it with `startTransition` on the toggle:
-
-```jsx
-<button onClick={() => startTransition(() => setOpen(o => !o))}>Toggle</button>
-<AnimatedCollapse open={open}>
-  <SectionContent />
-</AnimatedCollapse>
-```
-
-### Preserve State with Activity
-
-Use `<Activity>` with `<ViewTransition>` to animate show/hide while preserving component state:
-
-```jsx
-import { Activity, ViewTransition, startTransition } from 'react';
-
-<Activity mode={isVisible ? 'visible' : 'hidden'}>
-  <ViewTransition enter="slide-in" exit="slide-out">
-    <Sidebar />
-  </ViewTransition>
-</Activity>
-```
-
-### Exclude Elements from a Transition with `useOptimistic`
-
-When a `startTransition` changes both a control (e.g. a button label) and content (e.g. list order), use `useOptimistic` for the control. The optimistic value updates before React's transition snapshot, so it won't animate. The committed state drives the content, which changes within the transition and animates:
-
-```tsx
-const [sort, setSort] = useState('newest');
-const [optimisticSort, setOptimisticSort] = useOptimistic(sort);
-
-function cycleSort() {
-  const nextSort = getNextSort(optimisticSort);
-  startTransition(() => {
-    setOptimisticSort(nextSort);  // updates before snapshot — no animation
-    setSort(nextSort);            // changes within transition — animates
-  });
-}
-
-// Button uses optimisticSort (instant, excluded from animation)
-<button>Sort: {LABELS[optimisticSort]}</button>
-
-// List uses committed sort (changes between snapshots, animates)
-{items.sort(comparators[sort]).map(item => (
-  <ViewTransition key={item.id}>
-    <ItemCard item={item} />
-  </ViewTransition>
-))}
-```
-
-`useOptimistic` values resolve before the transition snapshot. Any DOM driven by optimistic state is already in its final form when the "before" snapshot is taken, so it doesn't participate in the `<ViewTransition>`. Only DOM driven by committed state (via `setState`) changes between snapshots and animates.
-
----
-
-### Animation Timing Guidelines
-
-Match duration to the interaction type — direct user actions need fast feedback, while ambient reveals can be slower:
-
-| Interaction | Duration | Rationale |
-|------------|----------|-----------|
-| Direct toggle (expand/collapse, show/hide) | 100–200ms | Responds to a click — must feel instant |
-| Route transition (directional slide) | 150–250ms | Brief spatial cue, shouldn't delay navigation |
-| Suspense reveal (skeleton → content) | 200–400ms | Soft reveal, content is "arriving" |
-| Shared element morph | 300–500ms | Users watch the morph — give it room to breathe |
-
-These are starting points. Test on low-end devices — animations that feel smooth on a fast machine can feel sluggish on mobile.
-
+For complete real-world patterns (searchable grids, card expand/collapse, type-safe transition helpers, shared elements across routes), see Appendix: Patterns and Guidelines below.
 
 ---
 
@@ -709,8 +495,10 @@ Always respect `prefers-reduced-motion`. React does not disable animations autom
 ```css
 @media (prefers-reduced-motion: reduce) {
   ::view-transition-old(*),
-  ::view-transition-new(*) {
+  ::view-transition-new(*),
+  ::view-transition-group(*) {
     animation-duration: 0s !important;
+    animation-delay: 0s !important;
   }
 }
 ```
@@ -751,28 +539,279 @@ Or disable specific animations conditionally in JavaScript events by checking th
 
 ---
 
-## CSS Animation Recipes for View Transitions
+---
+
+## Appendix: Patterns and Guidelines
+
+## Searchable Grid with `useDeferredValue`
+
+A client-side searchable grid where the filtered results cross-fade as the user types. `useDeferredValue` makes the filter update a transition, which activates the wrapping `<ViewTransition>`:
+
+```tsx
+'use client';
+
+import { useDeferredValue, useState, ViewTransition, Suspense } from 'react';
+
+export default function SearchableGrid({ itemsPromise }) {
+  const [search, setSearch] = useState('');
+  const deferredSearch = useDeferredValue(search);
+
+  return (
+    <>
+      <input
+        value={search}
+        onChange={(e) => setSearch(e.currentTarget.value)}
+        placeholder="Search..."
+      />
+      <ViewTransition>
+        <Suspense fallback={<GridSkeleton />}>
+          <ItemGrid itemsPromise={itemsPromise} search={deferredSearch} />
+        </Suspense>
+      </ViewTransition>
+    </>
+  );
+}
+```
+
+## Card Expand/Collapse with `startTransition`
+
+Toggle between a card grid and a detail view using `startTransition` to animate the swap. Add a shared element `name` to morph the card into the detail view:
+
+```tsx
+'use client';
+
+import { useState, useRef, startTransition, ViewTransition } from 'react';
+
+export default function ItemGrid({ items }) {
+  const [expandedId, setExpandedId] = useState(null);
+  const scrollRef = useRef(0);
+
+  return expandedId ? (
+    <ViewTransition enter="slide-in" name={`item-${expandedId}`}>
+      <ItemDetail
+        item={items.find(i => i.id === expandedId)}
+        onClose={() => {
+          startTransition(() => {
+            setExpandedId(null);
+            setTimeout(() => window.scrollTo({ behavior: 'smooth', top: scrollRef.current }), 100);
+          });
+        }}
+      />
+    </ViewTransition>
+  ) : (
+    <div className="grid grid-cols-3 gap-4">
+      {items.map(item => (
+        <ViewTransition key={item.id} name={`item-${item.id}`}>
+          <ItemCard
+            item={item}
+            onSelect={() => {
+              scrollRef.current = window.scrollY;
+              startTransition(() => setExpandedId(item.id));
+            }}
+          />
+        </ViewTransition>
+      ))}
+    </div>
+  );
+}
+```
+
+The shared `name={`item-${id}`}` on both the card and detail `<ViewTransition>` creates a shared element pair — the card morphs into the detail view. The `scrollRef` saves and restores scroll position so users return to where they were in the grid. See Appendix: CSS Animation Recipes for the slide-up/slide-down CSS.
+
+## Type-Safe Transition Helpers
+
+For larger apps, define type-safe transition IDs and transition maps to prevent ID clashes and keep animation configurations consistent. Use `as const` arrays for transition IDs, types, and animation classes, then derive types from them:
+
+```tsx
+import { ViewTransition } from 'react';
+
+const transitionTypes = ['default', 'transition-to-detail', 'transition-to-list', 'transition-backwards', 'transition-forwards'] as const;
+const animationTypes = ['auto', 'none', 'animate-slide-from-left', 'animate-slide-from-right', 'animate-slide-to-left', 'animate-slide-to-right'] as const;
+
+type TransitionType = (typeof transitionTypes)[number];
+type AnimationType = (typeof animationTypes)[number];
+type TransitionMap = { default: AnimationType } & Partial<Record<Exclude<TransitionType, 'default'>, AnimationType>>;
+
+export function HorizontalTransition({ children, enter, exit }: {
+  children: React.ReactNode;
+  enter: TransitionMap;
+  exit: TransitionMap;
+}) {
+  return <ViewTransition enter={enter} exit={exit}>{children}</ViewTransition>;
+}
+```
+
+These wrappers enforce that only valid transition IDs and animation classes are used, catching mistakes at compile time.
+
+## Shared Elements Across Routes in Next.js
+
+See Appendix: Next.js Integration Guide (Shared Elements Across Routes) for complete examples using `transitionTypes` on `next/link` combined with shared element `<ViewTransition name={...}>` for list-to-detail image morph animations.
+
+## Isolate Floating Elements from Parent Animations
+
+Popovers, tooltips, and dropdowns can get captured in a parent's view transition snapshot, causing them to ghost or animate unexpectedly. Give them their own `viewTransitionName` to isolate them into a separate transition group:
+
+```jsx
+<SelectPopover style={{ viewTransitionName: 'popover' }}>
+  {options}
+</SelectPopover>
+```
+
+```css
+::view-transition-group(popover) {
+  z-index: 100;
+}
+```
+
+This creates an independent transition group that renders above other transitioning elements. The element won't be included in its parent's old/new snapshot.
+
+For a global fix that ensures all view transition groups render above normal content, use the wildcard selector:
+
+```css
+::view-transition-group(*) {
+  z-index: 100;
+}
+```
+
+## Reusable Animated Collapse
+
+For apps with many expand/collapse interactions, extract a reusable wrapper instead of repeating the conditional-render-with-`<ViewTransition>` pattern:
+
+```jsx
+import { ViewTransition } from 'react';
+
+function AnimatedCollapse({ open, children }) {
+  if (!open) return null;
+  return (
+    <ViewTransition enter="expand-in" exit="collapse-out">
+      {children}
+    </ViewTransition>
+  );
+}
+```
+
+Use it with `startTransition` on the toggle:
+
+```jsx
+<button onClick={() => startTransition(() => setOpen(o => !o))}>Toggle</button>
+<AnimatedCollapse open={open}>
+  <SectionContent />
+</AnimatedCollapse>
+```
+
+## Preserve State with Activity
+
+Use `<Activity>` with `<ViewTransition>` to animate show/hide while preserving component state:
+
+```jsx
+import { Activity, ViewTransition, startTransition } from 'react';
+
+<Activity mode={isVisible ? 'visible' : 'hidden'}>
+  <ViewTransition enter="slide-in" exit="slide-out">
+    <Sidebar />
+  </ViewTransition>
+</Activity>
+```
+
+## Exclude Elements from a Transition with `useOptimistic`
+
+When a `startTransition` changes both a control (e.g. a button label) and content (e.g. list order), use `useOptimistic` for the control. The optimistic value updates before React's transition snapshot, so it won't animate. The committed state drives the content, which changes within the transition and animates:
+
+```tsx
+const [sort, setSort] = useState('newest');
+const [optimisticSort, setOptimisticSort] = useOptimistic(sort);
+
+function cycleSort() {
+  const nextSort = getNextSort(optimisticSort);
+  startTransition(() => {
+    setOptimisticSort(nextSort);  // updates before snapshot — no animation
+    setSort(nextSort);            // changes within transition — animates
+  });
+}
+
+// Button uses optimisticSort (instant, excluded from animation)
+<button>Sort: {LABELS[optimisticSort]}</button>
+
+// List uses committed sort (changes between snapshots, animates)
+{items.sort(comparators[sort]).map(item => (
+  <ViewTransition key={item.id}>
+    <ItemCard item={item} />
+  </ViewTransition>
+))}
+```
+
+`useOptimistic` values resolve before the transition snapshot. Any DOM driven by optimistic state is already in its final form when the "before" snapshot is taken, so it doesn't participate in the `<ViewTransition>`. Only DOM driven by committed state (via `setState`) changes between snapshots and animates.
+
+---
+
+## Animation Timing Guidelines
+
+Match duration to the interaction type — direct user actions need fast feedback, while ambient reveals can be slower:
+
+| Interaction | Duration | Rationale |
+|------------|----------|-----------|
+| Direct toggle (expand/collapse, show/hide) | 100–200ms | Responds to a click — must feel instant |
+| Route transition (directional slide) | 150–250ms | Brief spatial cue, shouldn't delay navigation |
+| Suspense reveal (skeleton → content) | 200–400ms | Soft reveal, content is "arriving" |
+| Shared element morph | 300–500ms | Users watch the morph — give it room to breathe |
+
+These are starting points. Test on low-end devices — animations that feel smooth on a fast machine can feel sluggish on mobile.
+
+---
+
+## Appendix: CSS Animation Recipes
 
 Ready-to-use CSS snippets for common view transition animations. Use these class names with `<ViewTransition>` props.
 
+---
 
-### Fade
+## Timing Variables
+
+Define timing as CSS custom properties so durations are adjustable in one place. Use staggered timing — the enter animation delays by the exit duration so the old content leaves before the new content appears:
+
+```css
+:root {
+  --duration-exit: 150ms;
+  --duration-enter: 210ms;
+  --duration-move: 400ms;
+}
+```
+
+All recipes below reference these variables.
+
+### Shared Keyframes
+
+These reusable keyframes are used across multiple recipes:
+
+```css
+@keyframes fade {
+  from { filter: blur(3px); opacity: 0; }
+  to { filter: blur(0); opacity: 1; }
+}
+
+@keyframes slide {
+  from { translate: var(--slide-offset); }
+  to { translate: 0; }
+}
+
+@keyframes slide-y {
+  from { transform: translateY(var(--slide-y-offset, 10px)); }
+  to { transform: translateY(0); }
+}
+```
+
+The `slide` keyframe uses a CSS variable for direction — set `--slide-offset: -60px` for left, `60px` for right. The same keyframe with `animation-direction: reverse` handles the exit.
+
+---
+
+## Fade
 
 ```css
 ::view-transition-old(.fade-out) {
-  animation: 200ms ease-out fade-to-hidden;
+  animation: var(--duration-exit) ease-in fade reverse;
 }
 ::view-transition-new(.fade-in) {
-  animation: 200ms ease-in fade-from-hidden;
-}
-
-@keyframes fade-to-hidden {
-  from { opacity: 1; }
-  to { opacity: 0; }
-}
-@keyframes fade-from-hidden {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  animation: var(--duration-enter) ease-out var(--duration-exit) both fade;
 }
 ```
 
@@ -783,85 +822,144 @@ Usage:
 
 ---
 
-### Slide
+## Slide (Vertical)
+
+Slide down on exit, slide up on enter — the most common pattern for Suspense fallback-to-content transitions. Uses staggered timing with a fade:
 
 ```css
-::view-transition-old(.slide-out-left) {
-  animation: 300ms ease-in-out slide-to-left;
+::view-transition-old(.slide-down) {
+  animation:
+    var(--duration-exit) ease-out both fade reverse,
+    var(--duration-exit) ease-out both slide-y reverse;
 }
-::view-transition-new(.slide-in-from-right) {
-  animation: 300ms ease-in-out slide-from-right;
-}
-::view-transition-old(.slide-out-right) {
-  animation: 300ms ease-in-out slide-to-right;
-}
-::view-transition-new(.slide-in-from-left) {
-  animation: 300ms ease-in-out slide-from-left;
-}
-
-/* Vertical */
-::view-transition-old(.slide-out-up) {
-  animation: 300ms ease-in-out slide-to-top;
-}
-::view-transition-new(.slide-in-from-bottom) {
-  animation: 300ms ease-in-out slide-from-bottom;
-}
-::view-transition-old(.slide-out-down) {
-  animation: 300ms ease-in-out slide-to-bottom;
-}
-::view-transition-new(.slide-in-from-top) {
-  animation: 300ms ease-in-out slide-from-top;
-}
-
-@keyframes slide-to-left {
-  from { transform: translateX(0); }
-  to { transform: translateX(-100%); }
-}
-@keyframes slide-from-right {
-  from { transform: translateX(100%); }
-  to { transform: translateX(0); }
-}
-@keyframes slide-to-right {
-  from { transform: translateX(0); }
-  to { transform: translateX(100%); }
-}
-@keyframes slide-from-left {
-  from { transform: translateX(-100%); }
-  to { transform: translateX(0); }
-}
-@keyframes slide-to-top {
-  from { transform: translateY(0); }
-  to { transform: translateY(-100%); }
-}
-@keyframes slide-from-bottom {
-  from { transform: translateY(100%); }
-  to { transform: translateY(0); }
-}
-@keyframes slide-to-bottom {
-  from { transform: translateY(0); }
-  to { transform: translateY(100%); }
-}
-@keyframes slide-from-top {
-  from { transform: translateY(-100%); }
-  to { transform: translateY(0); }
+::view-transition-new(.slide-up) {
+  animation:
+    var(--duration-enter) ease-in var(--duration-exit) both fade,
+    var(--duration-move) ease-in both slide-y;
 }
 ```
 
 Usage:
 ```jsx
-<ViewTransition enter="slide-in-from-right" exit="slide-out-left" />
+<Suspense
+  fallback={
+    <ViewTransition exit="slide-down">
+      <Skeleton />
+    </ViewTransition>
+  }
+>
+  <ViewTransition default="none" enter="slide-up">
+    <Content />
+  </ViewTransition>
+</Suspense>
 ```
 
 ---
 
-### Scale
+## Directional Navigation
+
+A single CSS class name targets both `::view-transition-old` and `::view-transition-new` with different animations. This keeps the JSX simple — `enter="nav-forward"` / `exit="nav-forward"`:
+
+```css
+::view-transition-old(.nav-forward) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+::view-transition-new(.nav-forward) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+
+::view-transition-old(.nav-back) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+::view-transition-new(.nav-back) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+```
+
+Usage with transition types:
+```jsx
+<ViewTransition
+  default="none"
+  enter={{
+    'nav-forward': 'nav-forward',
+    'nav-back': 'nav-back',
+    default: 'none',
+  }}
+  exit={{
+    'nav-forward': 'nav-forward',
+    'nav-back': 'nav-back',
+    default: 'none',
+  }}
+>
+  {children}
+</ViewTransition>
+```
+
+Triggering with `transitionTypes` on `next/link`:
+```jsx
+<Link href="/products/1" transitionTypes={['nav-forward']}>Next</Link>
+<Link href="/products" transitionTypes={['nav-back']}>Back</Link>
+```
+
+Or programmatically:
+```jsx
+startTransition(() => {
+  addTransitionType('nav-forward');
+  router.push('/next-page');
+});
+```
+
+---
+
+## Shared Element Morph
+
+For shared element transitions, control the morph duration on `::view-transition-group` and add a motion blur on `::view-transition-image-pair` to smooth fast-moving elements:
+
+```css
+::view-transition-group(.morph) {
+  animation-duration: var(--duration-move);
+}
+
+::view-transition-image-pair(.morph) {
+  animation-name: via-blur;
+}
+
+@keyframes via-blur {
+  30% { filter: blur(3px); }
+}
+```
+
+The blur at 30% creates a subtle motion-blur effect — fast-moving elements can be visually jarring, and this smooths the transition without adding perceptible delay.
+
+Usage:
+```jsx
+<ViewTransition name={`product-${id}`} share="morph">
+  <Image src={product.image} alt={product.name} />
+</ViewTransition>
+```
+
+---
+
+## Scale
 
 ```css
 ::view-transition-old(.scale-out) {
-  animation: 250ms ease-in scale-down;
+  animation: var(--duration-exit) ease-in scale-down;
 }
 ::view-transition-new(.scale-in) {
-  animation: 250ms ease-out scale-up;
+  animation: var(--duration-enter) ease-out var(--duration-exit) both scale-up;
 }
 
 @keyframes scale-down {
@@ -881,130 +979,7 @@ Usage:
 
 ---
 
-### Slide + Fade Combined
-
-```css
-::view-transition-old(.slide-fade-out) {
-  animation: 300ms ease-in-out slide-fade-exit;
-}
-::view-transition-new(.slide-fade-in) {
-  animation: 300ms ease-in-out slide-fade-enter;
-}
-
-@keyframes slide-fade-exit {
-  from { transform: translateY(0); opacity: 1; }
-  to { transform: translateY(-20px); opacity: 0; }
-}
-@keyframes slide-fade-enter {
-  from { transform: translateY(20px); opacity: 0; }
-  to { transform: translateY(0); opacity: 1; }
-}
-```
-
-Usage:
-```jsx
-<ViewTransition enter="slide-fade-in" exit="slide-fade-out" />
-```
-
----
-
-### Directional Navigation
-
-A complete setup for forward/back page transitions using `addTransitionType`:
-
-```css
-/* Forward navigation: content slides left */
-::view-transition-old(.nav-forward-exit) {
-  animation: 350ms ease-in-out nav-slide-out-left;
-}
-::view-transition-new(.nav-forward-enter) {
-  animation: 350ms ease-in-out nav-slide-in-from-right;
-}
-
-/* Back navigation: content slides right */
-::view-transition-old(.nav-back-exit) {
-  animation: 350ms ease-in-out nav-slide-out-right;
-}
-::view-transition-new(.nav-back-enter) {
-  animation: 350ms ease-in-out nav-slide-in-from-left;
-}
-
-@keyframes nav-slide-out-left {
-  from { transform: translateX(0); opacity: 1; }
-  to { transform: translateX(-30%); opacity: 0; }
-}
-@keyframes nav-slide-in-from-right {
-  from { transform: translateX(30%); opacity: 0; }
-  to { transform: translateX(0); opacity: 1; }
-}
-@keyframes nav-slide-out-right {
-  from { transform: translateX(0); opacity: 1; }
-  to { transform: translateX(30%); opacity: 0; }
-}
-@keyframes nav-slide-in-from-left {
-  from { transform: translateX(-30%); opacity: 0; }
-  to { transform: translateX(0); opacity: 1; }
-}
-```
-
-Usage with transition types:
-```jsx
-<ViewTransition
-  enter={{
-    'navigation-forward': 'nav-forward-enter',
-    'navigation-back': 'nav-back-enter',
-    default: 'auto',
-  }}
-  exit={{
-    'navigation-forward': 'nav-forward-exit',
-    'navigation-back': 'nav-back-exit',
-    default: 'auto',
-  }}
->
-  <Page />
-</ViewTransition>
-```
-
-Triggering:
-```jsx
-startTransition(() => {
-  addTransitionType('navigation-forward');
-  router.push('/next-page');
-});
-```
-
----
-
-### Flip
-
-```css
-::view-transition-old(.flip-out) {
-  animation: 400ms ease-in flip-exit;
-  backface-visibility: hidden;
-}
-::view-transition-new(.flip-in) {
-  animation: 400ms ease-out flip-enter;
-  backface-visibility: hidden;
-}
-
-@keyframes flip-exit {
-  from { transform: rotateY(0deg); opacity: 1; }
-  to { transform: rotateY(-90deg); opacity: 0; }
-}
-@keyframes flip-enter {
-  from { transform: rotateY(90deg); opacity: 0; }
-  to { transform: rotateY(0deg); opacity: 1; }
-}
-```
-
-Usage:
-```jsx
-<ViewTransition enter="flip-in" exit="flip-out" />
-```
-
----
-
-### Reduced Motion
+## Reduced Motion
 
 Always include this in your global stylesheet to respect user preferences:
 
@@ -1021,36 +996,15 @@ Always include this in your global stylesheet to respect user preferences:
 
 ---
 
-### Slow Cross-Fade
-
-Override the browser default timing for a slower, more cinematic cross-fade:
-
-```css
-::view-transition-old(.slow-fade) {
-  animation-duration: 600ms;
-  animation-timing-function: ease-in-out;
-}
-::view-transition-new(.slow-fade) {
-  animation-duration: 600ms;
-  animation-timing-function: ease-in-out;
-}
-```
-
-Usage:
-```jsx
-<ViewTransition default="slow-fade">
-  <Content />
-</ViewTransition>
-```
+## Appendix: Next.js Integration Guide
 
 ---
 
-## View Transitions in Next.js
+## Setup
 
+`<ViewTransition>` works in Next.js out of the box for `startTransition`- and `Suspense`-triggered updates — no config flag is needed for those.
 
-### Setup
-
-Enable the experimental flag in `next.config.js` (or `next.config.ts`):
+To also animate `<Link>` navigations, enable the experimental flag in `next.config.js` (or `next.config.ts`):
 
 ```js
 /** @type {import('next').NextConfig} */
@@ -1067,7 +1021,7 @@ module.exports = nextConfig;
 Implications:
 - Any `<ViewTransition>` with `default="auto"` (the implicit default) fires the browser's cross-fade on **every** `<Link>` navigation.
 - Combined with per-page `<ViewTransition>` components (Suspense reveals, item animations), this produces competing animations.
-- Without this flag, only `Suspense`-triggered and `startTransition`-triggered transitions fire.
+- Without this flag, `<ViewTransition>` still works for all `startTransition`- and `Suspense`-triggered updates — only `<Link>` navigations won't participate.
 
 The `<ViewTransition>` component is currently available in `react@canary` and `react@experimental` only:
 
@@ -1077,7 +1031,7 @@ npm install react@canary react-dom@canary
 
 ---
 
-### Basic Route Transitions
+## Basic Route Transitions
 
 The simplest approach is wrapping your page content in `<ViewTransition>` inside a layout:
 
@@ -1107,7 +1061,7 @@ When users navigate between routes using `<Link>`, Next.js triggers a transition
 
 ---
 
-### Layout-Level ViewTransition
+## Layout-Level ViewTransition
 
 For more control, place `<ViewTransition>` at different levels of the layout hierarchy:
 
@@ -1133,11 +1087,11 @@ Only the `<main>` content animates when navigating between dashboard sub-routes.
 
 ---
 
-### The `transitionTypes` Prop on `next/link`
+## The `transitionTypes` Prop on `next/link`
 
-As of Next.js 16.2+, `next/link` supports a native `transitionTypes` prop. This eliminates the need for custom wrapper components that intercept navigation with `onNavigate` + `startTransition` + `addTransitionType` + `router.push()`.
+`next/link` supports a native `transitionTypes` prop. This eliminates the need for custom wrapper components that intercept navigation with `onNavigate` + `startTransition` + `addTransitionType` + `router.push()`.
 
-#### Before (manual wrapper, requires `'use client'`)
+### Before (manual wrapper, requires `'use client'`)
 
 ```tsx
 'use client';
@@ -1164,7 +1118,7 @@ export function TransitionLink({ type, ...props }: { type: string } & React.Comp
 }
 ```
 
-#### After (native prop, no wrapper needed, works in Server Components)
+### After (native prop, no wrapper needed, works in Server Components)
 
 ```tsx
 import Link from 'next/link';
@@ -1180,7 +1134,7 @@ This is the recommended approach for link-based navigation transitions. Reserve 
 
 ---
 
-### Programmatic Navigation with Transitions
+## Programmatic Navigation with Transitions
 
 Use `startTransition` with Next.js's `router.push()` to trigger view transitions from code:
 
@@ -1212,11 +1166,11 @@ Wrapping `router.push()` in `startTransition` is what activates the `<ViewTransi
 
 ---
 
-### Transition Types for Navigation Direction
+## Transition Types for Navigation Direction
 
 A common pattern is to animate differently for forward vs. backward navigation.
 
-#### Using `transitionTypes` on `next/link` (preferred)
+### Using `transitionTypes` on `next/link` (preferred)
 
 ```tsx
 import Link from 'next/link';
@@ -1232,7 +1186,7 @@ import Link from 'next/link';
 </Link>
 ```
 
-#### Using `startTransition` + `addTransitionType` (for programmatic navigation)
+### Using `startTransition` + `addTransitionType` (for programmatic navigation)
 
 ```tsx
 'use client';
@@ -1299,7 +1253,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
 ---
 
-### Shared Elements Across Routes
+## Shared Elements Across Routes
 
 Animate a thumbnail expanding into a full image across route transitions. Use `transitionTypes` on the link to tag the navigation direction:
 
@@ -1355,7 +1309,7 @@ Only one `<ViewTransition>` with a given name can be mounted at a time. Since Ne
 
 ---
 
-### Combining with Suspense and Loading States
+## Combining with Suspense and Loading States
 
 Next.js `loading.tsx` files create `<Suspense>` boundaries. Wrap them with `<ViewTransition>` for smooth fallback-to-content reveals:
 
@@ -1384,7 +1338,7 @@ The skeleton cross-fades into the actual content once it loads.
 
 ---
 
-### Server Components Considerations
+## Server Components Considerations
 
 - `<ViewTransition>` can be used in both Server and Client Components — it renders no DOM of its own.
 - `<Link>` with `transitionTypes` works in Server Components — no `'use client'` directive needed for link-based transitions.

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -1,6 +1,5 @@
 # React View Transitions — Complete Reference
 
-
 React's View Transition API lets you animate between UI states using the browser's native `document.startViewTransition` under the hood. React manages the lifecycle automatically — you declare *what* to animate with `<ViewTransition>`, trigger *when* to animate through `startTransition` / `useDeferredValue` / `Suspense`, and control *how* to animate with CSS classes or JavaScript via the Web Animations API.
 
 The API adds ~3KB to your bundle, runs on the browser's compositor thread for 60fps animations, and gracefully falls back to instant state changes in unsupported browsers.
@@ -481,7 +480,6 @@ Pick the level that carries the most meaning for your app:
 
 The exception is **shared element transitions** — these intentionally span levels (one side unmounts while the other mounts) and don't conflict with other VTs because the `share` trigger takes precedence over `enter`/`exit`.
 
-
 ---
 
 ## Next.js Integration
@@ -505,7 +503,7 @@ module.exports = nextConfig;
 
 If your pages manage their own per-page transitions, either (a) don't use a layout-level `<ViewTransition>` on `{children}`, or (b) set `default="none"` on it so it only activates for explicit `transitionTypes`.
 
-For a detailed guide on Next.js integration, including App Router patterns and Server Component considerations, see the Next.js Integration section below.
+For a detailed guide on Next.js integration, including App Router patterns and Server Component considerations, see the "View Transitions in Next.js" section below.
 
 Key points:
 - The `<ViewTransition>` component is imported from `react` directly — no Next.js-specific import.
@@ -533,7 +531,7 @@ The `transitionTypes` prop accepts an array of strings — the same types you wo
 
 **Composition note:** `transitionTypes` on `<Link>` works best when you have a single `<ViewTransition>` at the layout level with `default="none"` (so it only fires for your specific types) and no per-page Suspense VTs competing. If your pages have their own Suspense transitions, use `transitionTypes` at the page level (e.g., to distinguish sources of `startTransition` within a client component) rather than at the layout level, or the layout slide and the page's Suspense reveal will both fire simultaneously.
 
-For full examples of `transitionTypes` with shared element transitions and directional animations across routes, see the Next.js Integration section below.
+For full examples of `transitionTypes` with shared element transitions and directional animations across routes, see the "View Transitions in Next.js" section below.
 
 ---
 
@@ -660,11 +658,27 @@ export function HorizontalTransition({ children, enter, exit }: {
 }
 ```
 
-These wrappers enforce that only valid transition IDs and animation classes are used, catching mistakes at compile time. See the Next.js App Router Playground (`vercel/next-app-router-playground`) for a complete example of this pattern.
+These wrappers enforce that only valid transition IDs and animation classes are used, catching mistakes at compile time.
 
 ### Shared Elements Across Routes in Next.js
 
-See the Next.js Integration section below.
+See the section above (Shared Elements Across Routes) for complete examples using `transitionTypes` on `next/link` combined with shared element `<ViewTransition name={...}>` for list-to-detail image morph animations.
+
+---
+
+### Animation Timing Guidelines
+
+Match duration to the interaction type — direct user actions need fast feedback, while ambient reveals can be slower:
+
+| Interaction | Duration | Rationale |
+|------------|----------|-----------|
+| Direct toggle (expand/collapse, show/hide) | 100–200ms | Responds to a click — must feel instant |
+| Route transition (directional slide) | 150–250ms | Brief spatial cue, shouldn't delay navigation |
+| Suspense reveal (skeleton → content) | 200–400ms | Soft reveal, content is "arriving" |
+| Shared element morph | 300–500ms | Users watch the morph — give it room to breathe |
+
+These are starting points. Test on low-end devices — animations that feel smooth on a fast machine can feel sluggish on mobile.
+
 
 ---
 
@@ -714,412 +728,12 @@ Or disable specific animations conditionally in JavaScript events by checking th
 
 ---
 
-## Animation Timing Guidelines
-
-Match duration to the interaction type — direct user actions need fast feedback, while ambient reveals can be slower:
-
-| Interaction | Duration | Rationale |
-|------------|----------|-----------|
-| Direct toggle (expand/collapse, show/hide) | 100–200ms | Responds to a click — must feel instant |
-| Route transition (directional slide) | 150–250ms | Brief spatial cue, shouldn't delay navigation |
-| Suspense reveal (skeleton → content) | 200–400ms | Soft reveal, content is "arriving" |
-| Shared element morph | 300–500ms | Users watch the morph — give it room to breathe |
-
-These are starting points. Test on low-end devices — animations that feel smooth on a fast machine can feel sluggish on mobile.
-
----
-
-## CSS Recipe Reference
-
-For ready-to-use CSS animation recipes (slide, fade, scale, flip, and combined patterns), see the CSS Animation Recipes section below.
-
----
-
-# Next.js Integration — Detailed Reference
-
-
-## Table of Contents
-
-1. [Setup](#setup)
-2. [Basic Route Transitions](#basic-route-transitions)
-3. [Layout-Level ViewTransition](#layout-level-viewtransition)
-4. [The transitionTypes Prop on next/link](#the-transitiontypes-prop-on-nextlink)
-5. [Programmatic Navigation with Transitions](#programmatic-navigation-with-transitions)
-6. [Transition Types for Navigation Direction](#transition-types-for-navigation-direction)
-7. [Shared Elements Across Routes](#shared-elements-across-routes)
-8. [Combining with Suspense and Loading States](#combining-with-suspense-and-loading-states)
-9. [Server Components Considerations](#server-components-considerations)
-
----
-
-## Setup
-
-Enable the experimental flag in `next.config.js` (or `next.config.ts`):
-
-```js
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    viewTransition: true,
-  },
-};
-module.exports = nextConfig;
-```
-
-**What this flag does at runtime:** It wraps every `<Link>` navigation in `document.startViewTransition`. This means all mounted `<ViewTransition>` components in the tree participate in every link navigation — not just transitions triggered by `startTransition` or `Suspense`.
-
-Implications:
-- Any `<ViewTransition>` with `default="auto"` (the implicit default) fires the browser's cross-fade on **every** `<Link>` navigation.
-- Combined with per-page `<ViewTransition>` components (Suspense reveals, item animations), this produces competing animations.
-- Without this flag, only `Suspense`-triggered and `startTransition`-triggered transitions fire.
-
-The `<ViewTransition>` component itself is available from `react` in canary/experimental channels or React 19.2+.
-
-Install React canary if you're not yet on 19.2+:
-
-```bash
-npm install react@canary react-dom@canary
-```
-
----
-
-## Basic Route Transitions
-
-The simplest approach is wrapping your page content in `<ViewTransition>` inside a layout:
-
-```tsx
-// app/layout.tsx
-import { ViewTransition } from 'react';
-
-export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <html lang="en">
-      <body>
-        <nav>{/* navigation links */}</nav>
-        <ViewTransition>
-          {children}
-        </ViewTransition>
-      </body>
-    </html>
-  );
-}
-```
-
-When users navigate between routes using `<Link>`, Next.js triggers a transition internally. The `<ViewTransition>` wrapping `{children}` detects the content swap and animates it with the default cross-fade.
-
-> **Warning:** This is an either/or choice with per-page animations. If your pages already have their own `<ViewTransition>` components (Suspense reveals, item reorder, shared elements), a layout-level VT on `{children}` produces double-animation — the layout cross-fades the entire old page while the new page's own entrance animations run simultaneously. Both levels get independent `view-transition-name`s, and the browser animates them in parallel, not sequentially.
->
-> Use this pattern only in apps where pages have **no** per-page view transitions. Otherwise, either remove the layout-level VT or set `default="none"` on it.
-
----
-
-## Layout-Level ViewTransition
-
-For more control, place `<ViewTransition>` at different levels of the layout hierarchy:
-
-```tsx
-// app/dashboard/layout.tsx
-import { ViewTransition } from 'react';
-
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="dashboard">
-      <Sidebar />
-      <ViewTransition enter="slide-up" exit="fade-out">
-        <main>{children}</main>
-      </ViewTransition>
-    </div>
-  );
-}
-```
-
-Only the `<main>` content animates when navigating between dashboard sub-routes. The sidebar stays static.
-
-> **Caution:** The same composition rule applies here — if the pages rendered inside `{children}` have their own `<ViewTransition>` components (Suspense boundaries, item animations), both levels will fire simultaneously. Use `default="none"` on the layout VT and only activate it for specific `transitionTypes` to avoid conflicts.
-
----
-
-## The `transitionTypes` Prop on `next/link`
-
-As of Next.js 16.2+, `next/link` supports a native `transitionTypes` prop. This eliminates the need for custom wrapper components that intercept navigation with `onNavigate` + `startTransition` + `addTransitionType` + `router.push()`.
-
-### Before (manual wrapper, requires `'use client'`)
-
-```tsx
-'use client';
-
-import { addTransitionType, startTransition } from 'react';
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-
-export function TransitionLink({ type, ...props }: { type: string } & React.ComponentProps<typeof Link>) {
-  const router = useRouter();
-
-  return (
-    <Link
-      onNavigate={(event) => {
-        event.preventDefault();
-        startTransition(() => {
-          addTransitionType(type);
-          router.push(props.href as string);
-        });
-      }}
-      {...props}
-    />
-  );
-}
-```
-
-### After (native prop, no wrapper needed, works in Server Components)
-
-```tsx
-import Link from 'next/link';
-
-<Link href="/products/1" transitionTypes={['transition-to-detail']}>
-  View Product
-</Link>
-```
-
-The `transitionTypes` prop accepts an array of strings. These types are passed to the View Transition system the same way `addTransitionType` would. `<ViewTransition>` components in the tree respond to these types identically.
-
-This is the recommended approach for link-based navigation transitions. Reserve manual `startTransition` + `addTransitionType` for programmatic navigation (buttons, form submissions, etc.) where `next/link` isn't used.
-
----
-
-## Programmatic Navigation with Transitions
-
-Use `startTransition` with Next.js's `router.push()` to trigger view transitions from code:
-
-```tsx
-'use client';
-
-import { useRouter } from 'next/navigation';
-import { startTransition, addTransitionType } from 'react';
-
-export function NavigateButton({ href }: { href: string }) {
-  const router = useRouter();
-
-  return (
-    <button
-      onClick={() => {
-        startTransition(() => {
-          addTransitionType('navigation-forward');
-          router.push(href);
-        });
-      }}
-    >
-      Go to {href}
-    </button>
-  );
-}
-```
-
-Wrapping `router.push()` in `startTransition` is what activates the `<ViewTransition>` boundaries in the tree.
-
----
-
-## Transition Types for Navigation Direction
-
-A common pattern is to animate differently for forward vs. backward navigation.
-
-### Using `transitionTypes` on `next/link` (preferred)
-
-```tsx
-import Link from 'next/link';
-
-// Forward navigation
-<Link href="/products/1" transitionTypes={['transition-forwards']}>
-  Next →
-</Link>
-
-// Backward navigation
-<Link href="/products" transitionTypes={['transition-backwards']}>
-  ← Back
-</Link>
-```
-
-### Using `startTransition` + `addTransitionType` (for programmatic navigation)
-
-```tsx
-'use client';
-
-import { useRouter } from 'next/navigation';
-import { startTransition, addTransitionType } from 'react';
-
-export function NavigateButton({
-  href,
-  direction = 'forward',
-  children,
-}: {
-  href: string;
-  direction?: 'forward' | 'back';
-  children: React.ReactNode;
-}) {
-  const router = useRouter();
-
-  return (
-    <button
-      onClick={() => {
-        startTransition(() => {
-          addTransitionType(`navigation-${direction}`);
-          router.push(href);
-        });
-      }}
-    >
-      {children}
-    </button>
-  );
-}
-```
-
-Configure `<ViewTransition>` to respond to these types. Use `default="none"` so the layout VT stays silent during per-page Suspense transitions and only fires for explicit navigation types:
-
-```tsx
-// app/layout.tsx
-import { ViewTransition } from 'react';
-
-export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <html lang="en">
-      <body>
-        <ViewTransition
-          default="none"
-          enter={{
-            'navigation-forward': 'slide-in-from-right',
-            'navigation-back': 'slide-in-from-left',
-            default: 'none',
-          }}
-          exit={{
-            'navigation-forward': 'slide-out-to-left',
-            'navigation-back': 'slide-out-to-right',
-            default: 'none',
-          }}
-        >
-          {children}
-        </ViewTransition>
-      </body>
-    </html>
-  );
-}
-```
-
----
-
-## Shared Elements Across Routes
-
-Animate a thumbnail expanding into a full image across route transitions. Use `transitionTypes` on the link to tag the navigation direction:
-
-```tsx
-// app/products/page.tsx (list page)
-import { ViewTransition } from 'react';
-import Link from 'next/link';
-import Image from 'next/image';
-
-export default function ProductList({ products }) {
-  return (
-    <div className="grid grid-cols-3 gap-6">
-      {products.map((product) => (
-        <Link
-          key={product.id}
-          href={`/products/${product.id}`}
-          transitionTypes={['transition-to-detail']}
-        >
-          <ViewTransition name={`product-${product.id}`}>
-            <Image src={product.image} alt={product.name} width={400} height={300} />
-          </ViewTransition>
-          <p>{product.name}</p>
-        </Link>
-      ))}
-    </div>
-  );
-}
-```
-
-```tsx
-// app/products/[id]/page.tsx (detail page)
-import { ViewTransition } from 'react';
-import Link from 'next/link';
-import Image from 'next/image';
-
-export default function ProductDetail({ product }) {
-  return (
-    <article>
-      <Link href="/products" transitionTypes={['transition-to-list']}>
-        ← Back to Products
-      </Link>
-      <ViewTransition name={`product-${product.id}`}>
-        <Image src={product.image} alt={product.name} width={800} height={600} />
-      </ViewTransition>
-      <h1>{product.name}</h1>
-      <p>{product.description}</p>
-    </article>
-  );
-}
-```
-
-Only one `<ViewTransition>` with a given name can be mounted at a time. Since Next.js unmounts the old page and mounts the new page within the same transition, the two `product-${product.id}` boundaries form a shared element pair and the image morphs from its thumbnail size to its full size.
-
----
-
-## Combining with Suspense and Loading States
-
-Next.js `loading.tsx` files create `<Suspense>` boundaries. Wrap them with `<ViewTransition>` for smooth fallback-to-content reveals:
-
-```tsx
-// app/dashboard/layout.tsx
-import { ViewTransition } from 'react';
-import { Suspense } from 'react';
-
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="dashboard">
-      <Sidebar />
-      <ViewTransition>
-        <Suspense fallback={<DashboardSkeleton />}>
-          {children}
-        </Suspense>
-      </ViewTransition>
-    </div>
-  );
-}
-```
-
-The skeleton cross-fades into the actual content once it loads.
-
-> **Important:** If you also have a layout-level `<ViewTransition>` wrapping `{children}` with `default="auto"`, it will fire simultaneously with this Suspense VT on every navigation, producing a double-animation. Either remove the layout-level VT, or set `default="none"` on it so it only responds to explicit `transitionTypes`.
-
----
-
-## Server Components Considerations
-
-- `<ViewTransition>` can be used in both Server and Client Components — it renders no DOM of its own.
-- `<Link>` with `transitionTypes` works in Server Components — no `'use client'` directive needed for link-based transitions.
-- `addTransitionType` must be called from a Client Component (inside an event handler with `startTransition`).
-- `startTransition` for programmatic navigation must be called from a Client Component.
-- Navigation via `<Link>` from `next/link` triggers transitions automatically when the experimental flag is enabled.
-- Prefer `transitionTypes` on `<Link>` over custom wrapper components. Only use manual `startTransition` + `addTransitionType` + `router.push()` for non-link interactions (buttons, form submissions, etc.).
-
----
-
-# CSS Animation Recipes — Complete Collection
-
+## CSS Animation Recipes for View Transitions
 
 Ready-to-use CSS snippets for common view transition animations. Use these class names with `<ViewTransition>` props.
 
-## Table of Contents
 
-1. [Fade](#fade)
-2. [Slide](#slide)
-3. [Scale](#scale)
-4. [Slide + Fade Combined](#slide--fade-combined)
-5. [Directional Navigation (Forward / Back)](#directional-navigation)
-6. [Flip](#flip)
-7. [Reduced Motion](#reduced-motion)
-8. [Slow Cross-Fade](#slow-cross-fade)
-
----
-
-## Fade
+### Fade
 
 ```css
 ::view-transition-old(.fade-out) {
@@ -1146,7 +760,7 @@ Usage:
 
 ---
 
-## Slide
+### Slide
 
 ```css
 ::view-transition-old(.slide-out-left) {
@@ -1217,7 +831,7 @@ Usage:
 
 ---
 
-## Scale
+### Scale
 
 ```css
 ::view-transition-old(.scale-out) {
@@ -1244,7 +858,7 @@ Usage:
 
 ---
 
-## Slide + Fade Combined
+### Slide + Fade Combined
 
 ```css
 ::view-transition-old(.slide-fade-out) {
@@ -1271,7 +885,7 @@ Usage:
 
 ---
 
-## Directional Navigation
+### Directional Navigation
 
 A complete setup for forward/back page transitions using `addTransitionType`:
 
@@ -1338,7 +952,7 @@ startTransition(() => {
 
 ---
 
-## Flip
+### Flip
 
 ```css
 ::view-transition-old(.flip-out) {
@@ -1367,7 +981,7 @@ Usage:
 
 ---
 
-## Reduced Motion
+### Reduced Motion
 
 Always include this in your global stylesheet to respect user preferences:
 
@@ -1384,7 +998,7 @@ Always include this in your global stylesheet to respect user preferences:
 
 ---
 
-## Slow Cross-Fade
+### Slow Cross-Fade
 
 Override the browser default timing for a slower, more cinematic cross-fade:
 
@@ -1405,3 +1019,355 @@ Usage:
   <Content />
 </ViewTransition>
 ```
+
+---
+
+## View Transitions in Next.js
+
+
+### Setup
+
+Enable the experimental flag in `next.config.js` (or `next.config.ts`):
+
+```js
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    viewTransition: true,
+  },
+};
+module.exports = nextConfig;
+```
+
+**What this flag does at runtime:** It wraps every `<Link>` navigation in `document.startViewTransition`. This means all mounted `<ViewTransition>` components in the tree participate in every link navigation — not just transitions triggered by `startTransition` or `Suspense`.
+
+Implications:
+- Any `<ViewTransition>` with `default="auto"` (the implicit default) fires the browser's cross-fade on **every** `<Link>` navigation.
+- Combined with per-page `<ViewTransition>` components (Suspense reveals, item animations), this produces competing animations.
+- Without this flag, only `Suspense`-triggered and `startTransition`-triggered transitions fire.
+
+The `<ViewTransition>` component itself is available from `react` in canary/experimental channels or React 19.2+.
+
+Install React canary if you're not yet on 19.2+:
+
+```bash
+npm install react@canary react-dom@canary
+```
+
+---
+
+### Basic Route Transitions
+
+The simplest approach is wrapping your page content in `<ViewTransition>` inside a layout:
+
+```tsx
+// app/layout.tsx
+import { ViewTransition } from 'react';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <nav>{/* navigation links */}</nav>
+        <ViewTransition>
+          {children}
+        </ViewTransition>
+      </body>
+    </html>
+  );
+}
+```
+
+When users navigate between routes using `<Link>`, Next.js triggers a transition internally. The `<ViewTransition>` wrapping `{children}` detects the content swap and animates it with the default cross-fade.
+
+> **Warning:** This is an either/or choice with per-page animations. If your pages already have their own `<ViewTransition>` components (Suspense reveals, item reorder, shared elements), a layout-level VT on `{children}` produces double-animation — the layout cross-fades the entire old page while the new page's own entrance animations run simultaneously. Both levels get independent `view-transition-name`s, and the browser animates them in parallel, not sequentially.
+>
+> Use this pattern only in apps where pages have **no** per-page view transitions. Otherwise, either remove the layout-level VT or set `default="none"` on it.
+
+---
+
+### Layout-Level ViewTransition
+
+For more control, place `<ViewTransition>` at different levels of the layout hierarchy:
+
+```tsx
+// app/dashboard/layout.tsx
+import { ViewTransition } from 'react';
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="dashboard">
+      <Sidebar />
+      <ViewTransition enter="slide-up" exit="fade-out">
+        <main>{children}</main>
+      </ViewTransition>
+    </div>
+  );
+}
+```
+
+Only the `<main>` content animates when navigating between dashboard sub-routes. The sidebar stays static.
+
+> **Caution:** The same composition rule applies here — if the pages rendered inside `{children}` have their own `<ViewTransition>` components (Suspense boundaries, item animations), both levels will fire simultaneously. Use `default="none"` on the layout VT and only activate it for specific `transitionTypes` to avoid conflicts.
+
+---
+
+### The `transitionTypes` Prop on `next/link`
+
+As of Next.js 16.2+, `next/link` supports a native `transitionTypes` prop. This eliminates the need for custom wrapper components that intercept navigation with `onNavigate` + `startTransition` + `addTransitionType` + `router.push()`.
+
+#### Before (manual wrapper, requires `'use client'`)
+
+```tsx
+'use client';
+
+import { addTransitionType, startTransition } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+export function TransitionLink({ type, ...props }: { type: string } & React.ComponentProps<typeof Link>) {
+  const router = useRouter();
+
+  return (
+    <Link
+      onNavigate={(event) => {
+        event.preventDefault();
+        startTransition(() => {
+          addTransitionType(type);
+          router.push(props.href as string);
+        });
+      }}
+      {...props}
+    />
+  );
+}
+```
+
+#### After (native prop, no wrapper needed, works in Server Components)
+
+```tsx
+import Link from 'next/link';
+
+<Link href="/products/1" transitionTypes={['transition-to-detail']}>
+  View Product
+</Link>
+```
+
+The `transitionTypes` prop accepts an array of strings. These types are passed to the View Transition system the same way `addTransitionType` would. `<ViewTransition>` components in the tree respond to these types identically.
+
+This is the recommended approach for link-based navigation transitions. Reserve manual `startTransition` + `addTransitionType` for programmatic navigation (buttons, form submissions, etc.) where `next/link` isn't used.
+
+---
+
+### Programmatic Navigation with Transitions
+
+Use `startTransition` with Next.js's `router.push()` to trigger view transitions from code:
+
+```tsx
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { startTransition, addTransitionType } from 'react';
+
+export function NavigateButton({ href }: { href: string }) {
+  const router = useRouter();
+
+  return (
+    <button
+      onClick={() => {
+        startTransition(() => {
+          addTransitionType('navigation-forward');
+          router.push(href);
+        });
+      }}
+    >
+      Go to {href}
+    </button>
+  );
+}
+```
+
+Wrapping `router.push()` in `startTransition` is what activates the `<ViewTransition>` boundaries in the tree.
+
+---
+
+### Transition Types for Navigation Direction
+
+A common pattern is to animate differently for forward vs. backward navigation.
+
+#### Using `transitionTypes` on `next/link` (preferred)
+
+```tsx
+import Link from 'next/link';
+
+// Forward navigation
+<Link href="/products/1" transitionTypes={['transition-forwards']}>
+  Next →
+</Link>
+
+// Backward navigation
+<Link href="/products" transitionTypes={['transition-backwards']}>
+  ← Back
+</Link>
+```
+
+#### Using `startTransition` + `addTransitionType` (for programmatic navigation)
+
+```tsx
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { startTransition, addTransitionType } from 'react';
+
+export function NavigateButton({
+  href,
+  direction = 'forward',
+  children,
+}: {
+  href: string;
+  direction?: 'forward' | 'back';
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+
+  return (
+    <button
+      onClick={() => {
+        startTransition(() => {
+          addTransitionType(`navigation-${direction}`);
+          router.push(href);
+        });
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+```
+
+Configure `<ViewTransition>` to respond to these types. Use `default="none"` so the layout VT stays silent during per-page Suspense transitions and only fires for explicit navigation types:
+
+```tsx
+// app/layout.tsx
+import { ViewTransition } from 'react';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <ViewTransition
+          default="none"
+          enter={{
+            'navigation-forward': 'slide-in-from-right',
+            'navigation-back': 'slide-in-from-left',
+            default: 'none',
+          }}
+          exit={{
+            'navigation-forward': 'slide-out-to-left',
+            'navigation-back': 'slide-out-to-right',
+            default: 'none',
+          }}
+        >
+          {children}
+        </ViewTransition>
+      </body>
+    </html>
+  );
+}
+```
+
+---
+
+### Shared Elements Across Routes
+
+Animate a thumbnail expanding into a full image across route transitions. Use `transitionTypes` on the link to tag the navigation direction:
+
+```tsx
+// app/products/page.tsx (list page)
+import { ViewTransition } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+
+export default function ProductList({ products }) {
+  return (
+    <div className="grid grid-cols-3 gap-6">
+      {products.map((product) => (
+        <Link
+          key={product.id}
+          href={`/products/${product.id}`}
+          transitionTypes={['transition-to-detail']}
+        >
+          <ViewTransition name={`product-${product.id}`}>
+            <Image src={product.image} alt={product.name} width={400} height={300} />
+          </ViewTransition>
+          <p>{product.name}</p>
+        </Link>
+      ))}
+    </div>
+  );
+}
+```
+
+```tsx
+// app/products/[id]/page.tsx (detail page)
+import { ViewTransition } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+
+export default function ProductDetail({ product }) {
+  return (
+    <article>
+      <Link href="/products" transitionTypes={['transition-to-list']}>
+        ← Back to Products
+      </Link>
+      <ViewTransition name={`product-${product.id}`}>
+        <Image src={product.image} alt={product.name} width={800} height={600} />
+      </ViewTransition>
+      <h1>{product.name}</h1>
+      <p>{product.description}</p>
+    </article>
+  );
+}
+```
+
+Only one `<ViewTransition>` with a given name can be mounted at a time. Since Next.js unmounts the old page and mounts the new page within the same transition, the two `product-${product.id}` boundaries form a shared element pair and the image morphs from its thumbnail size to its full size.
+
+---
+
+### Combining with Suspense and Loading States
+
+Next.js `loading.tsx` files create `<Suspense>` boundaries. Wrap them with `<ViewTransition>` for smooth fallback-to-content reveals:
+
+```tsx
+// app/dashboard/layout.tsx
+import { ViewTransition } from 'react';
+import { Suspense } from 'react';
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="dashboard">
+      <Sidebar />
+      <ViewTransition>
+        <Suspense fallback={<DashboardSkeleton />}>
+          {children}
+        </Suspense>
+      </ViewTransition>
+    </div>
+  );
+}
+```
+
+The skeleton cross-fades into the actual content once it loads.
+
+> **Important:** If you also have a layout-level `<ViewTransition>` wrapping `{children}` with `default="auto"`, it will fire simultaneously with this Suspense VT on every navigation, producing a double-animation. Either remove the layout-level VT, or set `default="none"` on it so it only responds to explicit `transitionTypes`.
+
+---
+
+### Server Components Considerations
+
+- `<ViewTransition>` can be used in both Server and Client Components — it renders no DOM of its own.
+- `<Link>` with `transitionTypes` works in Server Components — no `'use client'` directive needed for link-based transitions.
+- `addTransitionType` must be called from a Client Component (inside an event handler with `startTransition`).
+- `startTransition` for programmatic navigation must be called from a Client Component.
+- Navigation via `<Link>` from `next/link` triggers transitions automatically when the experimental flag is enabled.
+- Prefer `transitionTypes` on `<Link>` over custom wrapper components. Only use manual `startTransition` + `addTransitionType` + `router.push()` for non-link interactions (buttons, form submissions, etc.).

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -319,7 +319,9 @@ The simplest approach: wrap `<Suspense>` in a single `<ViewTransition>` for a ze
 </ViewTransition>
 ```
 
-For directional motion, give the fallback and content separate `<ViewTransition>`s. Use `default="none"` on the content to prevent re-animation on revalidation:
+**This only works reliably when the page has a single Suspense boundary and no other transitions.** The bare `<ViewTransition>` uses `default="auto"` implicitly, which means it participates in *every* `document.startViewTransition` on the page — not just its own Suspense resolve. If other Suspense boundaries, `useDeferredValue` updates, or navigations fire, this VT re-animates each time. For pages with multiple Suspense boundaries or any client components, use the split pattern below instead.
+
+For directional motion (or multi-Suspense pages), give the fallback and content separate `<ViewTransition>`s. Use `default="none"` on the content to prevent re-animation on revalidation:
 
 ```jsx
 <Suspense
@@ -812,6 +814,12 @@ These are starting points. Test on low-end devices — animations that feel smoo
 
 **TypeScript error: "Property 'default' is missing in type 'ViewTransitionClassPerType'":**
 - When passing an object to `enter`/`exit`/`update`/`share`, TypeScript requires a `default` key in the object. This applies even if the component-level `default` prop is set. Always include `default: 'none'` (or `'auto'`) in type-keyed objects.
+
+**Sibling Suspense boundaries re-trigger each other's view transitions:**
+- With `experimental: { viewTransition: true }`, each Suspense resolution fires its own `document.startViewTransition`. A `<ViewTransition>` with `default="auto"` participates in **all** transitions on the page — not just its own Suspense resolve. If three Suspense boundaries resolve at different times, each one re-triggers every `default="auto"` VT on the page, producing repeated or staggered animations. Fix: use the split pattern with `default="none"` on the content `<ViewTransition>` and explicit `enter`/`exit` props — never rely on `default="auto"` on pages with multiple Suspense boundaries.
+
+**Cross-fade looks like a jump / stagger:**
+- If the Suspense fallback (skeleton) and the resolved content have different dimensions, the view transition captures different-sized before/after snapshots. The size change during the cross-fade produces a jarring shift. Fix: match the skeleton's item count, line heights, and overall dimensions to the real content as closely as possible.
 
 **Hash fragments cause scroll jumps during view transitions:**
 - Links with URL hash fragments (e.g., `/page#section`) trigger the browser's native scroll-to-anchor behavior during the navigation transition. This interferes with directional slide animations — the page scrolls to the anchor while simultaneously sliding horizontally, producing a diagonal jump. If you need to link to a specific section on a detail page, navigate without the hash and handle scroll/expansion programmatically after navigation completes.

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -1,4 +1,7 @@
-# React View Transitions — Complete Reference
+# React View Transitions
+
+**Version 1.0.0**
+Vercel
 
 React's View Transition API lets you animate between UI states using the browser's native `document.startViewTransition` under the hood. Declare *what* to animate with `<ViewTransition>`, trigger *when* with `startTransition` / `useDeferredValue` / `Suspense`, and control *how* with CSS classes or the Web Animations API. Unsupported browsers skip the animation and apply the DOM change instantly.
 
@@ -21,6 +24,21 @@ From highest value to lowest — start from the top and only move down if your a
 Route-level transitions (#5) are the lowest priority because the URL change already signals a context switch. A blanket cross-fade on every navigation says nothing — it's visual noise. Prefer specific, intentional animations (#1–#4) over ambient page transitions.
 
 **Rule of thumb:** at any given moment, only one level of the tree should be visually transitioning. If your pages already manage their own Suspense reveals or shared element morphs, adding a layout-level route transition on top produces double-animation where both levels fight for attention.
+
+### Choosing the Right Animation Style
+
+Not everything should slide. Match the animation to the spatial relationship:
+
+| Context | Animation | Why |
+|---------|-----------|-----|
+| Detail page main content | `enter="slide-up"` | Reveals "deeper" content the user drilled into |
+| Detail page outer wrapper | `enter`/`exit` type map for `nav-forward` | Navigating forward — horizontal direction |
+| List / overview pages | Bare `<ViewTransition>` (fade) or `default="none"` | Lateral navigation — no spatial depth to communicate |
+| Page headers / breadcrumbs | Bare `<ViewTransition>` (fade) | Small, fast-loading metadata — slide feels excessive |
+| Secondary section on same page | `enter="slide-up"` | Second Suspense boundary streaming in after the header |
+| Revalidation / background refresh | `default="none"` | Data refreshed silently — animation would be distracting |
+
+When in doubt, use a bare `<ViewTransition>` (default cross-fade) or `default="none"`. Only add directional motion (slide-up, slide-from-right) when it communicates spatial meaning.
 
 ---
 
@@ -184,37 +202,26 @@ The `default` key inside the object is the fallback when no type matches. If any
 
 ### Using Types with CSS `:active-view-transition-type()`
 
-React also adds all transition types as browser view transition types, enabling pure CSS scoping:
+React adds transition types as browser view transition types, enabling pure CSS scoping with `:root:active-view-transition-type(type-name)`. **Caveat:** `::view-transition-old(*)` / `::view-transition-new(*)` match **all** named elements — the wildcard can override specific class-based animations. Prefer class-based props for per-component animations; reserve `:active-view-transition-type()` for global rules.
 
-```css
-:root:active-view-transition-type(navigation-forward) {
-  &::view-transition-old(*) {
-    animation: 300ms ease-out slide-out-to-left;
-  }
-  &::view-transition-new(*) {
-    animation: 300ms ease-out slide-in-from-right;
-  }
-}
-```
+The `types` array is also available as the second argument in event callbacks (`onEnter`, `onExit`, etc.).
 
-**Caveat:** `::view-transition-old(*)` and `::view-transition-new(*)` match **all** named view transition elements, not just the one you intend. If a Suspense `<ViewTransition>` has its own class-based animation (e.g., `enter="slide-up"`), the wildcard `*` selector can override it depending on CSS specificity. The class-based approach via `<ViewTransition>` props is safer because it only affects the specific boundary. Prefer class-based props for per-component animations and reserve `:active-view-transition-type()` for global, app-wide rules where you want all elements to animate the same way.
+### Types and Suspense: When Types Are Available
 
-### Using Types with View Transition Events
+When a `<Link>` with `transitionTypes` triggers navigation, the transition type is available to **all `<ViewTransition>`s that enter/exit during that navigation**. An outer page-level `<ViewTransition>` with a type map sees the type and responds. Inner `<ViewTransition>`s with simple string props also enter — the type is irrelevant to them because simple strings fire regardless of type.
 
-The `types` array is also available in event callbacks:
+Subsequent Suspense reveals — when streamed data loads after navigation completes — are **separate transitions with no type**. This means type-keyed props on Suspense content don't work:
 
 ```jsx
-<ViewTransition
-  onEnter={(instance, types) => {
-    const duration = types.includes('fast') ? 150 : 500;
-    const anim = instance.new.animate(
-      [{ opacity: 0 }, { opacity: 1 }],
-      { duration, easing: 'ease-out' }
-    );
-    return () => anim.cancel();
-  }}
->
+// This does NOT animate on Suspense reveal — the type is gone by then
+<ViewTransition enter={{ "nav-forward": "slide-up", default: "none" }} default="none">
+  <AsyncContent />
+</ViewTransition>
 ```
+
+When Suspense resolves later, a new transition fires with no type — so `default: "none"` applies and nothing animates.
+
+**Use type maps for `<ViewTransition>`s that enter/exit directly with the navigation. Use simple string props for Suspense reveals.** See the two-layer pattern in "Two Patterns — Can Coexist with Proper Isolation" below for a complete example.
 
 ---
 
@@ -246,12 +253,7 @@ Rules for shared element transitions:
 - Only one `<ViewTransition>` with a given `name` can be mounted at a time — use globally unique names (namespace with a prefix or module constant).
 - The "share" trigger takes precedence over "enter"/"exit".
 - If either side is outside the viewport, no pair forms and each side animates independently as enter/exit.
-- Use a constant defined in a shared module to avoid name collisions:
-
-```jsx
-// shared-names.ts
-export const HERO_IMAGE = 'hero-image-detail';
-```
+- Use a constant defined in a shared module to avoid name collisions.
 
 ---
 
@@ -266,7 +268,7 @@ For imperative control, use the `onEnter`, `onExit`, `onUpdate`, and `onShare` c
       [{ transform: 'scale(0.8)', opacity: 0 }, { transform: 'scale(1)', opacity: 1 }],
       { duration: 300, easing: 'ease-out' }
     );
-    return () => anim.cancel(); // always return cleanup
+    return () => anim.cancel();
   }}
   onExit={(instance, types) => {
     const anim = instance.old.animate(
@@ -291,30 +293,37 @@ Always return a cleanup function that cancels the animation so the browser can p
 
 Only one event fires per `<ViewTransition>` per Transition. `onShare` takes precedence over `onEnter` and `onExit`.
 
+### Using Types in Event Callbacks
+
+The `types` array is available as the second argument to all event callbacks:
+
+```jsx
+<ViewTransition
+  onEnter={(instance, types) => {
+    const duration = types.includes('fast') ? 150 : 500;
+    const anim = instance.new.animate(
+      [{ opacity: 0 }, { opacity: 1 }],
+      { duration, easing: 'ease-out' }
+    );
+    return () => anim.cancel();
+  }}
+>
+```
+
 ---
 
 ## Common Patterns
 
 ### Animate Enter/Exit of a Component
 
-```jsx
-import { ViewTransition, useState, startTransition } from 'react';
+Conditionally render the `<ViewTransition>` itself — toggle with `startTransition`:
 
-function App() {
-  const [show, setShow] = useState(false);
-  return (
-    <>
-      <button onClick={() => startTransition(() => setShow(s => !s))}>
-        Toggle
-      </button>
-      {show && (
-        <ViewTransition enter="fade-in" exit="fade-out">
-          <Panel />
-        </ViewTransition>
-      )}
-    </>
-  );
-}
+```jsx
+{show && (
+  <ViewTransition enter="fade-in" exit="fade-out">
+    <Panel />
+  </ViewTransition>
+)}
 ```
 
 ### Animate List Reorder
@@ -347,17 +356,7 @@ When the key changes, React unmounts and remounts the `<ViewTransition>`, which 
 
 ### Animate Suspense Fallback to Content
 
-Wrap `<Suspense>` in `<ViewTransition>` to cross-fade from fallback to loaded content:
-
-```jsx
-<ViewTransition>
-  <Suspense fallback={<Skeleton />}>
-    <AsyncContent />
-  </Suspense>
-</ViewTransition>
-```
-
-For directional motion, give the fallback and content separate `<ViewTransition>`s with explicit triggers. Use `default="none"` on the content one to prevent it from re-animating on unrelated transitions:
+Wrap `<Suspense>` in a bare `<ViewTransition>` for a simple cross-fade, or give fallback and content separate `<ViewTransition>`s for directional motion. Use `default="none"` on the content to prevent re-animation on revalidation:
 
 ```jsx
 <Suspense
@@ -373,6 +372,8 @@ For directional motion, give the fallback and content separate `<ViewTransition>
 </Suspense>
 ```
 
+**Why `exit` on the fallback and `enter` on the content?** When Suspense resolves, two things happen simultaneously in one transition: the fallback unmounts (exit) and the content mounts (enter). The fallback slides down and fades out while the content slides up and fades in — creating a smooth handoff. The staggered CSS timing (`enter` delays by the `exit` duration) ensures the skeleton leaves before new content arrives.
+
 ### Opt Out of Nested Animations
 
 Wrap children in `<ViewTransition update="none">` to prevent them from animating when a parent changes:
@@ -387,271 +388,32 @@ Wrap children in `<ViewTransition update="none">` to prevent them from animating
 </ViewTransition>
 ```
 
-For more patterns (isolate floating elements, reusable animated collapse, preserve state with `<Activity>`, exclude elements with `useOptimistic`), see Appendix: Patterns and Guidelines below.
+### Isolate Elements from Parent Animations
 
----
+#### Persistent Layout Elements (Headers, Sidebars)
 
-## How Multiple `<ViewTransition>`s Interact
+Sticky headers, navbars, and sidebars that persist across navigations get captured in the page content's transition snapshot. When a directional slide animates the page, the header slides away with it — which looks broken.
 
-When a transition fires, **every** `<ViewTransition>` in the tree that matches the trigger participates simultaneously. Each gets its own `view-transition-name`, and the browser animates all of them inside a single `document.startViewTransition` call. They run in parallel, not sequentially.
-
-This means a layout-level `<ViewTransition>` (whole-page cross-fade) + a page-level one (Suspense slide-up) + per-item ones (list reorder) all fire at once. The result is usually competing animations that look broken.
-
-### Use `default="none"` Liberally
-
-Prevent unintended animations by disabling the default trigger on ViewTransitions that should only fire for specific types:
+Fix: give persistent elements their own `viewTransitionName` and disable animation on their transition group:
 
 ```jsx
-// Only animates when 'navigation-forward' or 'navigation-back' types are present.
-// Silent on all other transitions (Suspense reveals, state changes, etc.)
-<ViewTransition
-  default="none"
-  enter={{
-    'navigation-forward': 'slide-in-from-right',
-    'navigation-back': 'slide-in-from-left',
-    default: 'none',
-  }}
-  exit={{
-    'navigation-forward': 'slide-out-to-left',
-    'navigation-back': 'slide-out-to-right',
-    default: 'none',
-  }}
->
-  {children}
-</ViewTransition>
+<header style={{ viewTransitionName: "dashboard-header" }}>
+  {/* header content */}
+</header>
 ```
-
-**TypeScript note:** When passing an object to `enter`/`exit`, the `ViewTransitionClassPerType` type requires a `default` key. Always include `default: 'none'` (or `'auto'`) in the object — omitting it causes a type error even if the component-level `default` prop is set.
-
-Without `default="none"`, a `<ViewTransition>` with `default="auto"` (the implicit default) fires the browser's cross-fade on **every** transition — including ones triggered by child Suspense boundaries, `useDeferredValue` updates, or `startTransition` calls within the page.
-
-### Choosing One Level
-
-Pick the level that carries the most meaning for your app:
-
-- **App with per-page Suspense reveals and shared elements:** Don't add a layout-level `<ViewTransition>` on `{children}`. The pages already manage their own transitions. A layout-level cross-fade on top will double-animate. This includes directional (forward/back) navigation — even with `default="none"`, a layout-level slide fires simultaneously with per-page Suspense slide-ups, producing a diagonal movement.
-- **Simple app with no per-page animations:** A layout-level `<ViewTransition>` with `default="auto"` on `{children}` gives you free cross-fades between routes.
-- **Directional navigation only (no per-page VTs):** Use `default="none"` at the layout level and only activate it for specific `transitionTypes`. This works well when pages have no `<ViewTransition>` components of their own.
-
-The exception is **shared element transitions** — these intentionally span levels (one side unmounts while the other mounts) and don't conflict with other VTs because the `share` trigger takes precedence over `enter`/`exit`.
-
----
-
-## Next.js Integration
-
-Next.js supports React View Transitions. `<ViewTransition>` works out of the box for `startTransition`- and `Suspense`-triggered updates — no config needed.
-
-To also animate `<Link>` navigations, enable the experimental flag in `next.config.js` (or `next.config.ts`):
-
-```js
-const nextConfig = {
-  experimental: {
-    viewTransition: true,
-  },
-};
-module.exports = nextConfig;
-```
-
-**What this flag does:** It wraps every `<Link>` navigation in `document.startViewTransition`, so all mounted `<ViewTransition>` components participate in every link click. Without this flag, only `startTransition`/`Suspense`-triggered transitions animate. This makes the composition rules in "How Multiple `<ViewTransition>`s Interact" especially important: use `default="none"` on layout-level `<ViewTransition>`s to avoid competing animations.
-
-For a detailed guide including App Router patterns and Server Component considerations, see Appendix: Next.js Integration Guide below.
-
-Key points:
-- The `<ViewTransition>` component is imported from `react` directly — no Next.js-specific import.
-- Works with the App Router and `startTransition` + `router.push()` for programmatic navigation.
-
-### The `transitionTypes` prop on `next/link`
-
-`next/link` supports a native `transitionTypes` prop that eliminates the need for custom `TransitionLink` wrapper components. Instead of intercepting navigation with `onNavigate`, `startTransition`, and `addTransitionType`, you pass transition types directly:
-
-```tsx
-import Link from 'next/link';
-
-// Before (manual wrapper required):
-<TransitionLink href="/products/1" type="transition-to-detail">
-  View Product
-</TransitionLink>
-
-// After (native prop, no wrapper needed):
-<Link href="/products/1" transitionTypes={['transition-to-detail']}>
-  View Product
-</Link>
-```
-
-The `transitionTypes` prop accepts an array of strings — the same types you would pass to `addTransitionType`. This removes the need for `'use client'`, `useRouter`, and custom link components when all you need is to tag a navigation with a transition type.
-
-For full examples with shared element transitions and directional animations, see Appendix: Next.js Integration Guide below.
-
----
-
-## Real-World Patterns
-
-For complete real-world patterns (searchable grids, card expand/collapse, type-safe transition helpers, shared elements across routes), see Appendix: Patterns and Guidelines below.
-
----
-
-## Accessibility
-
-Always respect `prefers-reduced-motion`. React does not disable animations automatically for this preference. Add this to your global CSS:
 
 ```css
-@media (prefers-reduced-motion: reduce) {
-  ::view-transition-old(*),
-  ::view-transition-new(*),
-  ::view-transition-group(*) {
-    animation-duration: 0s !important;
-    animation-delay: 0s !important;
-  }
+::view-transition-group(dashboard-header) {
+  animation: none;
+  z-index: 100;
 }
 ```
 
-Or disable specific animations conditionally in JavaScript events by checking the media query.
+This isolates the header into its own transition group that stays static during page slides. The element won't be included in the page content's old/new snapshot.
 
----
+#### Floating Elements (Popovers, Tooltips)
 
-## Troubleshooting
-
-**ViewTransition not activating:**
-- Ensure the `<ViewTransition>` comes before any DOM node in the component (not wrapped in a `<div>`).
-- Ensure the state update is inside `startTransition`, not a plain `setState`.
-
-**"Two ViewTransition components with the same name" error:**
-- Each `name` must be globally unique across the entire app at any point in time. Add item IDs: `name={\`hero-${item.id}\`}`.
-
-**Back button skips animation:**
-- The legacy `popstate` event requires synchronous completion, conflicting with view transitions. Upgrade your router to use the Navigation API for back-button animations.
-
-**Animations from `flushSync` are skipped:**
-- `flushSync` completes synchronously, which prevents view transitions from running. Use `startTransition` instead.
-
-**Enter/exit not firing in a client component (only updates animate):**
-- `startTransition(() => setState(...))` triggers a Transition, but if the new content isn't behind a `<Suspense>` boundary, React treats the swap as an **update** to the existing tree — not an enter/exit. The `<ViewTransition>` sees its children change but never fully unmounts/remounts, so only `update` animations fire. To get true enter/exit, either conditionally render the `<ViewTransition>` itself (so it mounts/unmounts with the content), or wrap the async content in `<Suspense>` so React can treat the reveal as an insertion.
-
-**Competing / double animations on navigation:**
-- Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level one cross-fades the whole page while a page-level one slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level `<ViewTransition>`, or remove it entirely if pages manage their own animations. See "How Multiple `<ViewTransition>`s Interact" above.
-
-**List reorder not animating with `useOptimistic`:**
-- If the optimistic value drives the list sort order, items are already in their final positions before the transition snapshot — there's nothing to animate. Use the optimistic value only for controls (labels, icons) and the committed state (`useState`) for the list sort order.
-
-**TypeScript error: "Property 'default' is missing in type 'ViewTransitionClassPerType'":**
-- When passing an object to `enter`/`exit`/`update`/`share`, TypeScript requires a `default` key in the object. This applies even if the component-level `default` prop is set. Always include `default: 'none'` (or `'auto'`) in type-keyed objects.
-
-**Batching:**
-- If multiple updates occur while an animation is running, React batches them into one. For example: if you navigate A→B, then B→C, then C→D during the first animation, the next animation will go B→D.
-
----
-
----
-
-## Appendix: Patterns and Guidelines
-
-## Searchable Grid with `useDeferredValue`
-
-A client-side searchable grid where the filtered results cross-fade as the user types. `useDeferredValue` makes the filter update a transition, which activates the wrapping `<ViewTransition>`:
-
-```tsx
-'use client';
-
-import { useDeferredValue, useState, ViewTransition, Suspense } from 'react';
-
-export default function SearchableGrid({ itemsPromise }) {
-  const [search, setSearch] = useState('');
-  const deferredSearch = useDeferredValue(search);
-
-  return (
-    <>
-      <input
-        value={search}
-        onChange={(e) => setSearch(e.currentTarget.value)}
-        placeholder="Search..."
-      />
-      <ViewTransition>
-        <Suspense fallback={<GridSkeleton />}>
-          <ItemGrid itemsPromise={itemsPromise} search={deferredSearch} />
-        </Suspense>
-      </ViewTransition>
-    </>
-  );
-}
-```
-
-## Card Expand/Collapse with `startTransition`
-
-Toggle between a card grid and a detail view using `startTransition` to animate the swap. Add a shared element `name` to morph the card into the detail view:
-
-```tsx
-'use client';
-
-import { useState, useRef, startTransition, ViewTransition } from 'react';
-
-export default function ItemGrid({ items }) {
-  const [expandedId, setExpandedId] = useState(null);
-  const scrollRef = useRef(0);
-
-  return expandedId ? (
-    <ViewTransition enter="slide-in" name={`item-${expandedId}`}>
-      <ItemDetail
-        item={items.find(i => i.id === expandedId)}
-        onClose={() => {
-          startTransition(() => {
-            setExpandedId(null);
-            setTimeout(() => window.scrollTo({ behavior: 'smooth', top: scrollRef.current }), 100);
-          });
-        }}
-      />
-    </ViewTransition>
-  ) : (
-    <div className="grid grid-cols-3 gap-4">
-      {items.map(item => (
-        <ViewTransition key={item.id} name={`item-${item.id}`}>
-          <ItemCard
-            item={item}
-            onSelect={() => {
-              scrollRef.current = window.scrollY;
-              startTransition(() => setExpandedId(item.id));
-            }}
-          />
-        </ViewTransition>
-      ))}
-    </div>
-  );
-}
-```
-
-The shared `name={`item-${id}`}` on both the card and detail `<ViewTransition>` creates a shared element pair — the card morphs into the detail view. The `scrollRef` saves and restores scroll position so users return to where they were in the grid. See `css-recipes.md` for the slide-up/slide-down CSS.
-
-## Type-Safe Transition Helpers
-
-For larger apps, define type-safe transition IDs and transition maps to prevent ID clashes and keep animation configurations consistent. Use `as const` arrays for transition IDs, types, and animation classes, then derive types from them:
-
-```tsx
-import { ViewTransition } from 'react';
-
-const transitionTypes = ['default', 'transition-to-detail', 'transition-to-list', 'transition-backwards', 'transition-forwards'] as const;
-const animationTypes = ['auto', 'none', 'animate-slide-from-left', 'animate-slide-from-right', 'animate-slide-to-left', 'animate-slide-to-right'] as const;
-
-type TransitionType = (typeof transitionTypes)[number];
-type AnimationType = (typeof animationTypes)[number];
-type TransitionMap = { default: AnimationType } & Partial<Record<Exclude<TransitionType, 'default'>, AnimationType>>;
-
-export function HorizontalTransition({ children, enter, exit }: {
-  children: React.ReactNode;
-  enter: TransitionMap;
-  exit: TransitionMap;
-}) {
-  return <ViewTransition enter={enter} exit={exit}>{children}</ViewTransition>;
-}
-```
-
-These wrappers enforce that only valid transition IDs and animation classes are used, catching mistakes at compile time.
-
-## Shared Elements Across Routes in Next.js
-
-See Appendix: Next.js Integration Guide (Shared Elements Across Routes) for complete examples using `transitionTypes` on `next/link` combined with shared element `<ViewTransition name={...}>` for list-to-detail image morph animations.
-
-## Isolate Floating Elements from Parent Animations
-
-Popovers, tooltips, and dropdowns can get captured in a parent's view transition snapshot, causing them to ghost or animate unexpectedly. Give them their own `viewTransitionName` to isolate them into a separate transition group:
+Popovers, tooltips, and dropdowns can also get captured in a parent's view transition snapshot, causing them to ghost or animate unexpectedly. The same pattern applies — give them their own `viewTransitionName`:
 
 ```jsx
 <SelectPopover style={{ viewTransitionName: 'popover' }}>
@@ -665,8 +427,6 @@ Popovers, tooltips, and dropdowns can get captured in a parent's view transition
 }
 ```
 
-This creates an independent transition group that renders above other transitioning elements. The element won't be included in its parent's old/new snapshot.
-
 For a global fix that ensures all view transition groups render above normal content, use the wildcard selector:
 
 ```css
@@ -675,7 +435,7 @@ For a global fix that ensures all view transition groups render above normal con
 }
 ```
 
-## Reusable Animated Collapse
+### Reusable Animated Collapse
 
 For apps with many expand/collapse interactions, extract a reusable wrapper instead of repeating the conditional-render-with-`<ViewTransition>` pattern:
 
@@ -701,7 +461,7 @@ Use it with `startTransition` on the toggle:
 </AnimatedCollapse>
 ```
 
-## Preserve State with Activity
+### Preserve State with Activity
 
 Use `<Activity>` with `<ViewTransition>` to animate show/hide while preserving component state:
 
@@ -715,7 +475,7 @@ import { Activity, ViewTransition, startTransition } from 'react';
 </Activity>
 ```
 
-## Exclude Elements from a Transition with `useOptimistic`
+### Exclude Elements from a Transition with `useOptimistic`
 
 When a `startTransition` changes both a control (e.g. a button label) and content (e.g. list order), use `useOptimistic` for the control. The optimistic value updates before React's transition snapshot, so it won't animate. The committed state drives the content, which changes within the transition and animates:
 
@@ -746,162 +506,29 @@ function cycleSort() {
 
 ---
 
-## Animation Timing Guidelines
+## How Multiple `<ViewTransition>`s Interact
 
-Match duration to the interaction type — direct user actions need fast feedback, while ambient reveals can be slower:
+When a transition fires, **every** `<ViewTransition>` in the tree that matches the trigger participates simultaneously. Each gets its own `view-transition-name`, and the browser animates all of them inside a single `document.startViewTransition` call. They run in parallel, not sequentially.
 
-| Interaction | Duration | Rationale |
-|------------|----------|-----------|
-| Direct toggle (expand/collapse, show/hide) | 100–200ms | Responds to a click — must feel instant |
-| Route transition (directional slide) | 150–250ms | Brief spatial cue, shouldn't delay navigation |
-| Suspense reveal (skeleton → content) | 200–400ms | Soft reveal, content is "arriving" |
-| Shared element morph | 300–500ms | Users watch the morph — give it room to breathe |
+This means multiple `<ViewTransition>`s that fire during the **same** transition all animate at once. A layout-level cross-fade + a page-level slide-up + per-item reorder all running in the same `document.startViewTransition` produces competing animations. But `<ViewTransition>`s that fire in **different** transitions (e.g., navigation vs. a later Suspense resolve) don't compete — they animate at different moments.
 
-These are starting points. Test on low-end devices — animations that feel smooth on a fast machine can feel sluggish on mobile.
+### Use `default="none"` Liberally
 
----
+Prevent unintended animations by disabling the default trigger on ViewTransitions that should only fire for specific types:
 
-## Appendix: CSS Animation Recipes
-
-Ready-to-use CSS snippets for common view transition animations. Use these class names with `<ViewTransition>` props.
-
----
-
-## Timing Variables
-
-Define timing as CSS custom properties so durations are adjustable in one place. Use staggered timing — the enter animation delays by the exit duration so the old content leaves before the new content appears:
-
-```css
-:root {
-  --duration-exit: 150ms;
-  --duration-enter: 210ms;
-  --duration-move: 400ms;
-}
-```
-
-All recipes below reference these variables.
-
-### Shared Keyframes
-
-These reusable keyframes are used across multiple recipes:
-
-```css
-@keyframes fade {
-  from { filter: blur(3px); opacity: 0; }
-  to { filter: blur(0); opacity: 1; }
-}
-
-@keyframes slide {
-  from { translate: var(--slide-offset); }
-  to { translate: 0; }
-}
-
-@keyframes slide-y {
-  from { transform: translateY(var(--slide-y-offset, 10px)); }
-  to { transform: translateY(0); }
-}
-```
-
-The `slide` keyframe uses a CSS variable for direction — set `--slide-offset: -60px` for left, `60px` for right. The same keyframe with `animation-direction: reverse` handles the exit.
-
----
-
-## Fade
-
-```css
-::view-transition-old(.fade-out) {
-  animation: var(--duration-exit) ease-in fade reverse;
-}
-::view-transition-new(.fade-in) {
-  animation: var(--duration-enter) ease-out var(--duration-exit) both fade;
-}
-```
-
-Usage:
 ```jsx
-<ViewTransition enter="fade-in" exit="fade-out" />
-```
-
----
-
-## Slide (Vertical)
-
-Slide down on exit, slide up on enter — the most common pattern for Suspense fallback-to-content transitions. Uses staggered timing with a fade:
-
-```css
-::view-transition-old(.slide-down) {
-  animation:
-    var(--duration-exit) ease-out both fade reverse,
-    var(--duration-exit) ease-out both slide-y reverse;
-}
-::view-transition-new(.slide-up) {
-  animation:
-    var(--duration-enter) ease-in var(--duration-exit) both fade,
-    var(--duration-move) ease-in both slide-y;
-}
-```
-
-Usage:
-```jsx
-<Suspense
-  fallback={
-    <ViewTransition exit="slide-down">
-      <Skeleton />
-    </ViewTransition>
-  }
->
-  <ViewTransition default="none" enter="slide-up">
-    <Content />
-  </ViewTransition>
-</Suspense>
-```
-
----
-
-## Directional Navigation
-
-A single CSS class name targets both `::view-transition-old` and `::view-transition-new` with different animations. This keeps the JSX simple — `enter="nav-forward"` / `exit="nav-forward"`:
-
-```css
-::view-transition-old(.nav-forward) {
-  --slide-offset: -60px;
-  animation:
-    var(--duration-exit) ease-in both fade reverse,
-    var(--duration-move) ease-in-out both slide reverse;
-}
-::view-transition-new(.nav-forward) {
-  --slide-offset: 60px;
-  animation:
-    var(--duration-enter) ease-out var(--duration-exit) both fade,
-    var(--duration-move) ease-in-out both slide;
-}
-
-::view-transition-old(.nav-back) {
-  --slide-offset: 60px;
-  animation:
-    var(--duration-exit) ease-in both fade reverse,
-    var(--duration-move) ease-in-out both slide reverse;
-}
-::view-transition-new(.nav-back) {
-  --slide-offset: -60px;
-  animation:
-    var(--duration-enter) ease-out var(--duration-exit) both fade,
-    var(--duration-move) ease-in-out both slide;
-}
-```
-
-Usage with transition types:
-```jsx
+// Only animates when 'navigation-forward' or 'navigation-back' types are present.
+// Silent on all other transitions (Suspense reveals, state changes, etc.)
 <ViewTransition
   default="none"
   enter={{
-    'nav-forward': 'nav-forward',
-    'nav-back': 'nav-back',
+    'navigation-forward': 'slide-in-from-right',
+    'navigation-back': 'slide-in-from-left',
     default: 'none',
   }}
   exit={{
-    'nav-forward': 'nav-forward',
-    'nav-back': 'nav-back',
+    'navigation-forward': 'slide-out-to-left',
+    'navigation-back': 'slide-out-to-right',
     default: 'none',
   }}
 >
@@ -909,102 +536,60 @@ Usage with transition types:
 </ViewTransition>
 ```
 
-Triggering with `transitionTypes` on `next/link`:
+**TypeScript note:** When passing an object to `enter`/`exit`, the `ViewTransitionClassPerType` type requires a `default` key. Always include `default: 'none'` (or `'auto'`) in the object — omitting it causes a type error even if the component-level `default` prop is set.
+
+Without `default="none"`, a `<ViewTransition>` with `default="auto"` (the implicit default) fires the browser's cross-fade on **every** transition — including ones triggered by child Suspense boundaries, `useDeferredValue` updates, or `startTransition` calls within the page.
+
+**Next.js revalidation:** This is especially important in Next.js — when `revalidateTag()` fires (from a Server Action, webhook, or polling), the page re-renders. Without `default="none"`, every `<ViewTransition>` in the tree re-animates: content slides up again, things flash. Always use `default="none"` on content `<ViewTransition>`s and only enable specific triggers (`enter`, `exit`) explicitly.
+
+### Two Patterns — Can Coexist with Proper Isolation
+
+There are two distinct view transition patterns:
+
+**Pattern A — Directional page slides** (e.g., left/right navigation):
+- Uses `transitionTypes` on `<Link>` or `addTransitionType` to tag navigation direction
+- An outer `<ViewTransition>` on the page maps types to slide classes with `default="none"`
+- Fires during the navigation transition (when the type is present)
+
+**Pattern B — Suspense content reveals** (e.g., streaming data):
+- No `transitionTypes` needed
+- Simple `enter="slide-up"` / `exit="slide-down"` on `<ViewTransition>`s around Suspense boundaries
+- `default="none"` prevents re-animation on revalidation
+- Fires later when data loads (a separate transition with no type)
+
+**These coexist when they fire at different moments.** The nav slide fires during the navigation transition (with the type); the Suspense reveal fires later when data streams in (no type). `default="none"` on both layers prevents cross-interference — the nav VT ignores Suspense resolves, and the Suspense VT ignores navigations:
+
 ```jsx
-<Link href="/products/1" transitionTypes={['nav-forward']}>Next</Link>
-<Link href="/products" transitionTypes={['nav-back']}>Back</Link>
-```
-
-Or programmatically:
-```jsx
-startTransition(() => {
-  addTransitionType('nav-forward');
-  router.push('/next-page');
-});
-```
-
----
-
-## Shared Element Morph
-
-For shared element transitions, control the morph duration on `::view-transition-group` and add a motion blur on `::view-transition-image-pair` to smooth fast-moving elements:
-
-```css
-::view-transition-group(.morph) {
-  animation-duration: var(--duration-move);
-}
-
-::view-transition-image-pair(.morph) {
-  animation-name: via-blur;
-}
-
-@keyframes via-blur {
-  30% { filter: blur(3px); }
-}
-```
-
-The blur at 30% creates a subtle motion-blur effect — fast-moving elements can be visually jarring, and this smooths the transition without adding perceptible delay.
-
-Usage:
-```jsx
-<ViewTransition name={`product-${id}`} share="morph">
-  <Image src={product.image} alt={product.name} />
+<ViewTransition
+  enter={{ "nav-forward": "slide-from-right", default: "none" }}
+  exit={{ "nav-forward": "slide-to-left", default: "none" }}
+  default="none"
+>
+  <div>
+    <Suspense fallback={
+      <ViewTransition exit="slide-down"><Skeleton /></ViewTransition>
+    }>
+      <ViewTransition enter="slide-up" default="none">
+        <Content />
+      </ViewTransition>
+    </Suspense>
+  </div>
 </ViewTransition>
 ```
 
----
+**Always pair `enter` with `exit` on directional transitions.** Without an exit animation, the old page disappears instantly while the new one slides in at scroll position 0 — a jarring jump. The exit slide masks the scroll change within the transition snapshot because the old content animates out simultaneously.
 
-## Scale
+**When they DO conflict:** If both layers use `default="auto"`, or if a layout-level `<ViewTransition>` fires a cross-fade during the same transition as a page-level slide-up, they animate simultaneously and fight for attention. The conflict is about **same-moment** animations, not about using both patterns on the same page.
 
-```css
-::view-transition-old(.scale-out) {
-  animation: var(--duration-exit) ease-in scale-down;
-}
-::view-transition-new(.scale-in) {
-  animation: var(--duration-enter) ease-out var(--duration-exit) both scale-up;
-}
+Place the outer directional `<ViewTransition>` in each **page component** — not in a layout (layouts persist and don't trigger enter/exit). Per-page wrappers are the cleanest approach.
 
-@keyframes scale-down {
-  from { transform: scale(1); opacity: 1; }
-  to { transform: scale(0.85); opacity: 0; }
-}
-@keyframes scale-up {
-  from { transform: scale(0.85); opacity: 0; }
-  to { transform: scale(1); opacity: 1; }
-}
-```
-
-Usage:
-```jsx
-<ViewTransition enter="scale-in" exit="scale-out" />
-```
+Shared element transitions (`name` prop) work alongside either pattern because the `share` trigger takes precedence over `enter`/`exit`.
 
 ---
 
-## Reduced Motion
+## Next.js Integration
 
-Always include this in your global stylesheet to respect user preferences:
-
-```css
-@media (prefers-reduced-motion: reduce) {
-  ::view-transition-old(*),
-  ::view-transition-new(*),
-  ::view-transition-group(*) {
-    animation-duration: 0s !important;
-    animation-delay: 0s !important;
-  }
-}
-```
-
----
-
-## Appendix: Next.js Integration Guide
-
----
-
-## Setup
-
-`<ViewTransition>` works in Next.js out of the box for `startTransition`- and `Suspense`-triggered updates — no config flag is needed for those.
+Next.js supports React View Transitions. `<ViewTransition>` works out of the box for `startTransition`- and `Suspense`-triggered updates — no config needed.
 
 To also animate `<Link>` navigations, enable the experimental flag in `next.config.js` (or `next.config.ts`):
 
@@ -1018,22 +603,21 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-**What this flag does at runtime:** It wraps every `<Link>` navigation in `document.startViewTransition`. This means all mounted `<ViewTransition>` components in the tree participate in every link navigation — not just transitions triggered by `startTransition` or `Suspense`.
+**What this flag does:** It wraps every `<Link>` navigation in `document.startViewTransition`, so all mounted `<ViewTransition>` components participate in every link click. Without this flag, only `startTransition`/`Suspense`-triggered transitions animate. This makes the composition rules in "How Multiple `<ViewTransition>`s Interact" especially important: use `default="none"` on layout-level `<ViewTransition>`s to avoid competing animations.
 
-Implications:
-- Any `<ViewTransition>` with `default="auto"` (the implicit default) fires the browser's cross-fade on **every** `<Link>` navigation.
-- Combined with per-page `<ViewTransition>` components (Suspense reveals, item animations), this produces competing animations.
-- Without this flag, `<ViewTransition>` still works for all `startTransition`- and `Suspense`-triggered updates — only `<Link>` navigations won't participate.
+Key points:
+- The `<ViewTransition>` component is imported from `react` directly — no Next.js-specific import.
+- Works with the App Router and `startTransition` + `router.push()` for programmatic navigation.
 
-The `<ViewTransition>` component is currently available in `react@canary` and `react@experimental` only:
+### The `transitionTypes` prop on `next/link`
 
-```bash
-npm install react@canary react-dom@canary
+`next/link` supports a native `transitionTypes` prop — pass an array of strings directly, no `'use client'` or wrapper component needed:
+
+```tsx
+<Link href="/products/1" transitionTypes={['transition-to-detail']}>View Product</Link>
 ```
 
----
-
-## Layout-Level ViewTransition
+### Layout-Level ViewTransition
 
 **If your pages already have `<ViewTransition>` components (Suspense reveals, item reorder, shared elements), do NOT add a layout-level `<ViewTransition>` wrapping `{children}` with `default="auto"`.** Both levels fire simultaneously inside a single `document.startViewTransition` — the layout cross-fades the entire old page while the new page's own animations run at the same time. The result is competing, broken-looking animations.
 
@@ -1061,10 +645,12 @@ This works for simple apps where pages have **no** `<ViewTransition>` components
 
 **But the moment any page adds its own `<ViewTransition>` (a Suspense slide-up, an item reorder, a shared element), remove the layout-level one or set `default="none"` on it.** Otherwise both levels animate in parallel, not sequentially.
 
-For apps that need layout-level control, use `default="none"` and only activate for specific `transitionTypes`:
+**Layouts persist across navigations — they never unmount/remount.** `enter`/`exit` props on a `<ViewTransition>` inside a layout only fire when the layout itself first mounts, not on subsequent route changes. Do not use type-keyed `enter`/`exit` maps in a layout for directional navigation — they won't fire.
+
+If you need the layout to stay silent while pages manage their own animations, use `default="none"`:
 
 ```tsx
-// app/dashboard/layout.tsx
+// app/dashboard/layout.tsx — prevents layout from interfering with per-page VTs
 import { ViewTransition } from 'react';
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
@@ -1072,19 +658,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     <div className="dashboard">
       <Sidebar />
       <main>
-        <ViewTransition
-          default="none"
-          enter={{
-            'nav-forward': 'nav-forward',
-            'nav-back': 'nav-back',
-            default: 'none',
-          }}
-          exit={{
-            'nav-forward': 'nav-forward',
-            'nav-back': 'nav-back',
-            default: 'none',
-          }}
-        >
+        <ViewTransition default="none">
           {children}
         </ViewTransition>
       </main>
@@ -1093,60 +667,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 }
 ```
 
-Only the content area animates, only when explicit navigation types are present, and the sidebar stays static.
-
-**Even with `default="none"`, a layout-level directional slide will fire simultaneously with any per-page Suspense `<ViewTransition>`s.** If a page has `<ViewTransition enter="slide-up">` on a Suspense boundary, and the layout slides in from the right, both run at once — producing a diagonal movement. If your pages use Suspense reveals with `<ViewTransition>`, directional layout transitions usually hurt more than they help — the Suspense slide-up/slide-down already communicates "new content loading."
-
----
-
-## The `transitionTypes` Prop on `next/link`
-
-`next/link` supports a native `transitionTypes` prop. This eliminates the need for custom wrapper components that intercept navigation with `onNavigate` + `startTransition` + `addTransitionType` + `router.push()`.
-
-### Before (manual wrapper, requires `'use client'`)
-
-```tsx
-'use client';
-
-import { addTransitionType, startTransition } from 'react';
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-
-export function TransitionLink({ type, ...props }: { type: string } & React.ComponentProps<typeof Link>) {
-  const router = useRouter();
-
-  return (
-    <Link
-      onNavigate={(event) => {
-        event.preventDefault();
-        startTransition(() => {
-          addTransitionType(type);
-          router.push(props.href as string);
-        });
-      }}
-      {...props}
-    />
-  );
-}
-```
-
-### After (native prop, no wrapper needed, works in Server Components)
-
-```tsx
-import Link from 'next/link';
-
-<Link href="/products/1" transitionTypes={['transition-to-detail']}>
-  View Product
-</Link>
-```
-
-The `transitionTypes` prop accepts an array of strings. These types are passed to the View Transition system the same way `addTransitionType` would. `<ViewTransition>` components in the tree respond to these types identically.
-
-This is the recommended approach for link-based navigation transitions. Reserve manual `startTransition` + `addTransitionType` for programmatic navigation (buttons, form submissions, etc.) where `next/link` isn't used.
-
----
-
-## Programmatic Navigation with Transitions
+### Programmatic Navigation with Transitions
 
 Use `startTransition` with Next.js's `router.push()` to trigger view transitions from code:
 
@@ -1174,15 +695,11 @@ export function NavigateButton({ href }: { href: string }) {
 }
 ```
 
-Wrapping `router.push()` in `startTransition` is what activates the `<ViewTransition>` boundaries in the tree.
+### Transition Types for Navigation Direction
 
----
+Directional transitions animate forward/backward navigation with horizontal slides. They can coexist with Suspense reveals on the same page when properly isolated — see the two-layer pattern below.
 
-## Transition Types for Navigation Direction
-
-A common pattern is to animate differently for forward vs. backward navigation.
-
-### Using `transitionTypes` on `next/link` (preferred)
+Using `transitionTypes` on `next/link` (preferred):
 
 ```tsx
 import Link from 'next/link';
@@ -1198,47 +715,63 @@ import Link from 'next/link';
 </Link>
 ```
 
-### Using `startTransition` + `addTransitionType` (for programmatic navigation)
+Place a `<ViewTransition>` with type-keyed `enter`/`exit` on each **page** (not in a layout — layouts persist and don't trigger enter/exit on navigation):
 
 ```tsx
-'use client';
+// In each page component — NOT in layout.tsx
+<ViewTransition
+  default="none"
+  enter={{
+    'transition-forwards': 'slide-in-from-right',
+    'transition-backwards': 'slide-in-from-left',
+    default: 'none',
+  }}
+  exit={{
+    'transition-forwards': 'slide-out-to-left',
+    'transition-backwards': 'slide-out-to-right',
+    default: 'none',
+  }}
+>
+  <PageContent />
+</ViewTransition>
+```
 
-import { useRouter } from 'next/navigation';
-import { startTransition, addTransitionType } from 'react';
+#### Two-Layer Pattern: Directional Nav + Suspense Reveals
 
-export function NavigateButton({
-  href,
-  direction = 'forward',
-  children,
-}: {
-  href: string;
-  direction?: 'forward' | 'back';
-  children: React.ReactNode;
-}) {
-  const router = useRouter();
+Directional nav slides and Suspense content reveals can coexist on the same page because they fire at **different moments**: the nav slide fires during navigation (when the `transitionTypes` type is present), and the Suspense reveal fires later when streamed data loads (a separate transition with no type). `default="none"` on both layers prevents cross-interference:
 
+```tsx
+export default function DetailPage() {
   return (
-    <button
-      onClick={() => {
-        startTransition(() => {
-          addTransitionType(`navigation-${direction}`);
-          router.push(href);
-        });
-      }}
+    <ViewTransition
+      enter={{ "nav-forward": "slide-from-right", default: "none" }}
+      exit={{ "nav-forward": "slide-to-left", default: "none" }}
+      default="none"
     >
-      {children}
-    </button>
+      <div>
+        <Suspense fallback={
+          <ViewTransition exit="slide-down"><HeaderSkeleton /></ViewTransition>
+        }>
+          <ViewTransition enter="slide-up" default="none">
+            <Header />
+          </ViewTransition>
+        </Suspense>
+        <Suspense fallback={
+          <ViewTransition exit="slide-down"><ContentSkeleton /></ViewTransition>
+        }>
+          <ViewTransition enter="slide-up" default="none">
+            <Content />
+          </ViewTransition>
+        </Suspense>
+      </div>
+    </ViewTransition>
   );
 }
 ```
 
-Configure `<ViewTransition>` in the layout to respond to these types. See the Layout-Level ViewTransition section above for the `default="none"` pattern with type-keyed `enter`/`exit` maps.
+Place the outer wrapper in each **page component**, not in `layout.tsx` (layouts persist, enter/exit won't fire).
 
-**When to skip directional nav transitions:** If your pages already use Suspense reveals with `<ViewTransition>` (priority #2 in the Hierarchy of Animation Intent), adding route-level directional transitions (priority #5) usually hurts more than it helps. The Suspense slide-up/slide-down already communicates "new content loading" — adding a horizontal slide on top produces a diagonal movement where both animations fight for attention. Prefer shared element transitions (#1) or just let Suspense handle it.
-
----
-
-## Shared Elements Across Routes
+### Shared Elements Across Routes
 
 Animate a thumbnail expanding into a full image across route transitions. Use `transitionTypes` on the link to tag the navigation direction:
 
@@ -1292,14 +825,11 @@ export default function ProductDetail({ product }) {
 
 Only one `<ViewTransition>` with a given name can be mounted at a time. Since Next.js unmounts the old page and mounts the new page within the same transition, the two `product-${product.id}` boundaries form a shared element pair and the image morphs from its thumbnail size to its full size.
 
----
-
-## Combining with Suspense and Loading States
+### Combining with Suspense and Loading States
 
 Next.js `loading.tsx` files create `<Suspense>` boundaries. Wrap them with `<ViewTransition>` for smooth fallback-to-content reveals. Place the Suspense `<ViewTransition>` in the page, not alongside a layout-level one:
 
 ```tsx
-// In a page or page-level component — NOT in a layout that also has a ViewTransition on {children}
 <Suspense
   fallback={
     <ViewTransition exit="slide-down">
@@ -1313,13 +843,11 @@ Next.js `loading.tsx` files create `<Suspense>` boundaries. Wrap them with `<Vie
 </Suspense>
 ```
 
-The skeleton slides out, then the content slides in. `default="none"` on the content prevents it from re-animating on unrelated transitions.
+**Do not combine this with a layout-level `<ViewTransition>` that has `default="auto"`.** Both fire during the same transition — the layout cross-fades while the Suspense boundary slides up, producing competing animations. Use `default="none"` on layout-level `<ViewTransition>`s, or remove them entirely.
 
-**Do not combine this with a layout-level `<ViewTransition>` that has `default="auto"`.** Both will fire simultaneously — the layout cross-fades the whole page while the Suspense boundary slides up content, producing a broken double-animation. If you need both, set `default="none"` on the layout-level one and only activate it for specific `transitionTypes`.
+Directional navigation transitions (via `transitionTypes`) can coexist with Suspense reveals when placed as an outer wrapper in the page component with `default="none"` and type-keyed enter/exit — they fire at different moments (see "Two-Layer Pattern" in Transition Types for Navigation Direction).
 
----
-
-## Server Components Considerations
+### Server Components Considerations
 
 - `<ViewTransition>` can be used in both Server and Client Components — it renders no DOM of its own.
 - `<Link>` with `transitionTypes` works in Server Components — no `'use client'` directive needed for link-based transitions.
@@ -1327,3 +855,249 @@ The skeleton slides out, then the content slides in. `default="none"` on the con
 - `startTransition` for programmatic navigation must be called from a Client Component.
 - Navigation via `<Link>` from `next/link` triggers transitions automatically when the experimental flag is enabled.
 - Prefer `transitionTypes` on `<Link>` over custom wrapper components. Only use manual `startTransition` + `addTransitionType` + `router.push()` for non-link interactions (buttons, form submissions, etc.).
+
+---
+
+## Accessibility
+
+Always respect `prefers-reduced-motion`. React does not disable animations automatically for this preference. Add this to your global CSS:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(*),
+  ::view-transition-new(*),
+  ::view-transition-group(*) {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+  }
+}
+```
+
+Or disable specific animations conditionally in JavaScript events by checking the media query.
+
+---
+
+## Appendix: CSS Animation Recipes
+
+Ready-to-use CSS snippets for common view transition animations. Use these class names with `<ViewTransition>` props.
+
+### Timing Variables
+
+Define timing as CSS custom properties so durations are adjustable in one place. Use staggered timing — the enter animation delays by the exit duration so the old content leaves before the new content appears:
+
+```css
+:root {
+  --duration-exit: 150ms;
+  --duration-enter: 210ms;
+  --duration-move: 400ms;
+}
+```
+
+### Shared Keyframes
+
+```css
+@keyframes fade {
+  from { filter: blur(3px); opacity: 0; }
+  to { filter: blur(0); opacity: 1; }
+}
+
+@keyframes slide {
+  from { translate: var(--slide-offset); }
+  to { translate: 0; }
+}
+
+@keyframes slide-y {
+  from { transform: translateY(var(--slide-y-offset, 10px)); }
+  to { transform: translateY(0); }
+}
+```
+
+### Fade
+
+```css
+::view-transition-old(.fade-out) {
+  animation: var(--duration-exit) ease-in fade reverse;
+}
+::view-transition-new(.fade-in) {
+  animation: var(--duration-enter) ease-out var(--duration-exit) both fade;
+}
+```
+
+### Slide (Vertical)
+
+```css
+::view-transition-old(.slide-down) {
+  animation:
+    var(--duration-exit) ease-out both fade reverse,
+    var(--duration-exit) ease-out both slide-y reverse;
+}
+::view-transition-new(.slide-up) {
+  animation:
+    var(--duration-enter) ease-in var(--duration-exit) both fade,
+    var(--duration-move) ease-in both slide-y;
+}
+```
+
+### Directional Navigation — Separate Enter/Exit Classes
+
+```css
+::view-transition-new(.slide-from-right) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+::view-transition-old(.slide-to-left) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+
+::view-transition-new(.slide-from-left) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+::view-transition-old(.slide-to-right) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+```
+
+### Directional Navigation — Single-Class Approach
+
+```css
+::view-transition-old(.nav-forward) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+::view-transition-new(.nav-forward) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+
+::view-transition-old(.nav-back) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+::view-transition-new(.nav-back) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+```
+
+### Shared Element Morph
+
+```css
+::view-transition-group(.morph) {
+  animation-duration: var(--duration-move);
+}
+
+::view-transition-image-pair(.morph) {
+  animation-name: via-blur;
+}
+
+@keyframes via-blur {
+  30% { filter: blur(3px); }
+}
+```
+
+### Scale
+
+```css
+::view-transition-old(.scale-out) {
+  animation: var(--duration-exit) ease-in scale-down;
+}
+::view-transition-new(.scale-in) {
+  animation: var(--duration-enter) ease-out var(--duration-exit) both scale-up;
+}
+
+@keyframes scale-down {
+  from { transform: scale(1); opacity: 1; }
+  to { transform: scale(0.85); opacity: 0; }
+}
+@keyframes scale-up {
+  from { transform: scale(0.85); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+```
+
+### Persistent Element Isolation
+
+```css
+::view-transition-group(dashboard-header) {
+  animation: none;
+  z-index: 100;
+}
+```
+
+### Reduced Motion
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(*),
+  ::view-transition-new(*),
+  ::view-transition-group(*) {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+  }
+}
+```
+
+---
+
+## Appendix: Animation Timing Guidelines
+
+| Interaction | Duration | Rationale |
+|------------|----------|-----------|
+| Direct toggle (expand/collapse, show/hide) | 100–200ms | Responds to a click — must feel instant |
+| Route transition (directional slide) | 150–250ms | Brief spatial cue, shouldn't delay navigation |
+| Suspense reveal (skeleton → content) | 200–400ms | Soft reveal, content is "arriving" |
+| Shared element morph | 300–500ms | Users watch the morph — give it room to breathe |
+
+---
+
+## Troubleshooting
+
+**ViewTransition not activating:**
+- Ensure the `<ViewTransition>` comes before any DOM node in the component (not wrapped in a `<div>`).
+- Ensure the state update is inside `startTransition`, not a plain `setState`.
+
+**"Two ViewTransition components with the same name" error:**
+- Each `name` must be globally unique across the entire app at any point in time. Add item IDs: `` name={`hero-${item.id}`} ``.
+
+**Back button skips animation:**
+- The legacy `popstate` event requires synchronous completion, conflicting with view transitions. Upgrade your router to use the Navigation API for back-button animations.
+
+**Animations from `flushSync` are skipped:**
+- `flushSync` completes synchronously, which prevents view transitions from running. Use `startTransition` instead.
+
+**Enter/exit not firing in a client component (only updates animate):**
+- `startTransition(() => setState(...))` triggers a Transition, but if the new content isn't behind a `<Suspense>` boundary, React treats the swap as an **update** to the existing tree — not an enter/exit. The `<ViewTransition>` sees its children change but never fully unmounts/remounts, so only `update` animations fire. To get true enter/exit, either conditionally render the `<ViewTransition>` itself (so it mounts/unmounts with the content), or wrap the async content in `<Suspense>` so React can treat the reveal as an insertion.
+
+**Competing / double animations on navigation:**
+- Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level one cross-fades the whole page while a page-level one slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level `<ViewTransition>`, or remove it entirely if pages manage their own animations.
+
+**List reorder not animating with `useOptimistic`:**
+- If the optimistic value drives the list sort order, items are already in their final positions before the transition snapshot — there's nothing to animate. Use the optimistic value only for controls (labels, icons) and the committed state (`useState`) for the list sort order.
+
+**TypeScript error: "Property 'default' is missing in type 'ViewTransitionClassPerType'":**
+- When passing an object to `enter`/`exit`/`update`/`share`, TypeScript requires a `default` key in the object. This applies even if the component-level `default` prop is set. Always include `default: 'none'` (or `'auto'`) in type-keyed objects.
+
+**Hash fragments cause scroll jumps during view transitions:**
+- Links with URL hash fragments (e.g., `/page#section`) trigger the browser's native scroll-to-anchor behavior during the navigation transition. This interferes with directional slide animations — the page scrolls to the anchor while simultaneously sliding horizontally, producing a diagonal jump. If you need to link to a specific section on a detail page, navigate without the hash and handle scroll/expansion programmatically after navigation completes.
+
+**Batching:**
+- If multiple updates occur while an animation is running, React batches them into one. For example: if you navigate A→B, then B→C, then C→D during the first animation, the next animation will go B→D.

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -28,8 +28,8 @@ Route-level transitions (#5) are the lowest priority because the URL change alre
 
 ## Availability
 
-- `<ViewTransition>` and `addTransitionType` shipped in **React 19.2** (stable).
-- For older React 19 versions, both are available in `react@canary` and `react@experimental`.
+- `<ViewTransition>` and `addTransitionType` are currently available in `react@canary` and `react@experimental` only — they are **not yet in a stable release**.
+- Install with `npm install react@canary react-dom@canary` (or `@experimental`).
 - Browser support: Chromium-based browsers have full support. Firefox and Safari are adding support. The API gracefully degrades — unsupported browsers skip the animation and apply the DOM change instantly.
 
 ---
@@ -1082,9 +1082,7 @@ Implications:
 - Combined with per-page `<ViewTransition>` components (Suspense reveals, item animations), this produces competing animations.
 - Without this flag, only `Suspense`-triggered and `startTransition`-triggered transitions fire.
 
-The `<ViewTransition>` component itself is available from `react` in canary/experimental channels or React 19.2+.
-
-Install React canary if you're not yet on 19.2+:
+The `<ViewTransition>` component is currently available in `react@canary` and `react@experimental` only:
 
 ```bash
 npm install react@canary react-dom@canary

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -337,7 +337,25 @@ Triggering the reorder inside `startTransition` will smoothly animate each item 
 
 ### Animate Suspense Fallback to Content
 
-Wrap `<Suspense>` in `<ViewTransition>` to cross-fade from fallback to loaded content:
+The production pattern is to give the fallback an **exit-only** animation and the content an **enter-only** animation with `default="none"`. This is more intentional than a blanket crossfade and prevents the content VT from re-animating on every subsequent route navigation:
+
+```jsx
+<Suspense
+  fallback={
+    <ViewTransition exit="slide-down">
+      <Skeleton />
+    </ViewTransition>
+  }
+>
+  <ViewTransition default="none" enter="slide-up">
+    <AsyncContent />
+  </ViewTransition>
+</Suspense>
+```
+
+The skeleton slides down when content replaces it (`exit`). The content slides up when it first appears (`enter`). `default="none"` on the content VT ensures it stays silent during unrelated transitions (e.g., link navigations that trigger the layout-level VT).
+
+For a simple crossfade without directional motion, wrap the whole `<Suspense>` instead:
 
 ```jsx
 <ViewTransition>
@@ -360,6 +378,24 @@ Wrap children in `<ViewTransition update="none">` to prevent them from animating
   </div>
 </ViewTransition>
 ```
+
+### Isolate Floating Elements from Parent Animations
+
+Popovers, tooltips, and dropdowns can get captured in a parent's view transition snapshot, causing them to ghost or animate unexpectedly. Give them their own `viewTransitionName` to isolate them into a separate transition group:
+
+```jsx
+<SelectPopover style={{ viewTransitionName: 'popover' }}>
+  {options}
+</SelectPopover>
+```
+
+```css
+::view-transition-group(popover) {
+  z-index: 100;
+}
+```
+
+This creates an independent transition group that renders above other transitioning elements. The element won't be included in its parent's old/new snapshot.
 
 ### Reusable Animated Collapse
 

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -204,7 +204,7 @@ The `default` key inside the object is the fallback when no type matches. If any
 
 React adds transition types as browser view transition types, enabling pure CSS scoping with `:root:active-view-transition-type(type-name)`. **Caveat:** `::view-transition-old(*)` / `::view-transition-new(*)` match **all** named elements — the wildcard can override specific class-based animations. Prefer class-based props for per-component animations; reserve `:active-view-transition-type()` for global rules.
 
-The `types` array is also available as the second argument in event callbacks (`onEnter`, `onExit`, etc.) — see `references/patterns.md`.
+The `types` array is also available as the second argument in event callbacks (`onEnter`, `onExit`, etc.) — see **Patterns and Guidelines** below.
 
 ### Types and Suspense: When Types Are Available
 
@@ -259,7 +259,7 @@ Rules for shared element transitions:
 
 ## View Transition Events (JavaScript Animations)
 
-For imperative control with `onEnter`, `onExit`, `onUpdate`, `onShare` callbacks and the `instance` object (`.old`, `.new`, `.group`, `.imagePair`, `.name`), see `references/patterns.md`. Always return a cleanup function from event handlers. Only one event fires per `<ViewTransition>` per Transition — `onShare` takes precedence over `onEnter`/`onExit`.
+For imperative control with `onEnter`, `onExit`, `onUpdate`, `onShare` callbacks and the `instance` object (`.old`, `.new`, `.group`, `.imagePair`, `.name`), see **Patterns and Guidelines** below. Always return a cleanup function from event handlers. Only one event fires per `<ViewTransition>` per Transition — `onShare` takes precedence over `onEnter`/`onExit`.
 
 ---
 
@@ -319,9 +319,7 @@ The simplest approach: wrap `<Suspense>` in a single `<ViewTransition>` for a ze
 </ViewTransition>
 ```
 
-**This only works reliably when the page has a single Suspense boundary and no other transitions.** The bare `<ViewTransition>` uses `default="auto"` implicitly, which means it participates in *every* `document.startViewTransition` on the page — not just its own Suspense resolve. If other Suspense boundaries, `useDeferredValue` updates, or navigations fire, this VT re-animates each time. For pages with multiple Suspense boundaries or any client components, use the split pattern below instead.
-
-For directional motion (or multi-Suspense pages), give the fallback and content separate `<ViewTransition>`s. Use `default="none"` on the content to prevent re-animation on revalidation:
+For directional motion, give the fallback and content separate `<ViewTransition>`s. Use `default="none"` on the content to prevent re-animation on revalidation:
 
 ```jsx
 <Suspense
@@ -355,7 +353,7 @@ Wrap children in `<ViewTransition update="none">` to prevent them from animating
 </ViewTransition>
 ```
 
-For more patterns (isolate persistent/floating elements, reusable animated collapse, preserve state with `<Activity>`, exclude elements with `useOptimistic`), see `references/patterns.md`.
+For more patterns (isolate persistent/floating elements, reusable animated collapse, preserve state with `<Activity>`, exclude elements with `useOptimistic`), see **Patterns and Guidelines** below.
 
 ---
 
@@ -457,7 +455,7 @@ module.exports = nextConfig;
 
 **What this flag does:** It wraps every `<Link>` navigation in `document.startViewTransition`, so all mounted `<ViewTransition>` components participate in every link click. Without this flag, only `startTransition`/`Suspense`-triggered transitions animate. This makes the composition rules in "How Multiple `<ViewTransition>`s Interact" especially important: use `default="none"` on layout-level `<ViewTransition>`s to avoid competing animations.
 
-For a detailed guide including App Router patterns and Server Component considerations, see `references/nextjs.md`.
+For a detailed guide including App Router patterns and Server Component considerations, see **View Transitions in Next.js** below.
 
 Key points:
 - The `<ViewTransition>` component is imported from `react` directly — no Next.js-specific import.
@@ -471,7 +469,7 @@ Key points:
 <Link href="/products/1" transitionTypes={['transition-to-detail']}>View Product</Link>
 ```
 
-For full examples with shared element transitions and directional animations, see `references/nextjs.md`.
+For full examples with shared element transitions and directional animations, see **View Transitions in Next.js** below.
 
 ---
 
@@ -569,7 +567,7 @@ export default function ItemGrid({ items }) {
 }
 ```
 
-The shared `name={`item-${id}`}` on both the card and detail `<ViewTransition>` creates a shared element pair — the card morphs into the detail view. The `scrollRef` saves and restores scroll position so users return to where they were in the grid. See `css-recipes.md` for the slide-up/slide-down CSS.
+The shared `name={`item-${id}`}` on both the card and detail `<ViewTransition>` creates a shared element pair — the card morphs into the detail view. The `scrollRef` saves and restores scroll position so users return to where they were in the grid. See **CSS Animation Recipes** below for the slide-up/slide-down CSS.
 
 ## Type-Safe Transition Helpers
 
@@ -598,7 +596,7 @@ These wrappers enforce that only valid transition IDs and animation classes are 
 
 ## Shared Elements Across Routes in Next.js
 
-See `nextjs.md` (Shared Elements Across Routes) for complete examples using `transitionTypes` on `next/link` combined with shared element `<ViewTransition name={...}>` for list-to-detail image morph animations.
+See **View Transitions in Next.js** below (Shared Elements Across Routes) for complete examples using `transitionTypes` on `next/link` combined with shared element `<ViewTransition name={...}>` for list-to-detail image morph animations.
 
 ## Isolate Elements from Parent Animations
 
@@ -814,12 +812,6 @@ These are starting points. Test on low-end devices — animations that feel smoo
 
 **TypeScript error: "Property 'default' is missing in type 'ViewTransitionClassPerType'":**
 - When passing an object to `enter`/`exit`/`update`/`share`, TypeScript requires a `default` key in the object. This applies even if the component-level `default` prop is set. Always include `default: 'none'` (or `'auto'`) in type-keyed objects.
-
-**Sibling Suspense boundaries re-trigger each other's view transitions:**
-- With `experimental: { viewTransition: true }`, each Suspense resolution fires its own `document.startViewTransition`. A `<ViewTransition>` with `default="auto"` participates in **all** transitions on the page — not just its own Suspense resolve. If three Suspense boundaries resolve at different times, each one re-triggers every `default="auto"` VT on the page, producing repeated or staggered animations. Fix: use the split pattern with `default="none"` on the content `<ViewTransition>` and explicit `enter`/`exit` props — never rely on `default="auto"` on pages with multiple Suspense boundaries.
-
-**Cross-fade looks like a jump / stagger:**
-- If the Suspense fallback (skeleton) and the resolved content have different dimensions, the view transition captures different-sized before/after snapshots. The size change during the cross-fade produces a jarring shift. Fix: match the skeleton's item count, line heights, and overall dimensions to the real content as closely as possible.
 
 **Hash fragments cause scroll jumps during view transitions:**
 - Links with URL hash fragments (e.g., `/page#section`) trigger the browser's native scroll-to-anchor behavior during the navigation transition. This interferes with directional slide animations — the page scrolls to the anchor while simultaneously sliding horizontally, producing a diagonal jump. If you need to link to a specific section on a detail page, navigate without the hash and handle scroll/expansion programmatically after navigation completes.

--- a/skills/react-view-transitions/README.md
+++ b/skills/react-view-transitions/README.md
@@ -1,35 +1,41 @@
-# React View Transitions
+# React View Transitions Skill
 
-Guide for implementing smooth, native-feeling animations using React's View
-Transition API. Covers the `<ViewTransition>` component, `addTransitionType`,
-CSS view transition pseudo-elements, shared element transitions, and Next.js
-integration including the `transitionTypes` prop on `next/link`.
+An agent skill for implementing smooth, native-feeling animations using React's View Transition API.
 
-## Structure
+## What This Skill Covers
 
-- `SKILL.md` - Core skill instructions with references to sub-documents
-- `references/` - Supporting documentation
-  - `nextjs.md` - Next.js-specific patterns (App Router, `transitionTypes`, shared elements across routes)
-  - `css-recipes.md` - Ready-to-use CSS animation recipes (fade, slide, scale, flip, directional)
-- `metadata.json` - Skill metadata (version, organization, abstract)
-- **`AGENTS.md`** - Full compiled document with all references inlined
+- **`<ViewTransition>` component** — animation triggers (enter, exit, update, share), placement rules, View Transition Classes
+- **`addTransitionType`** — tagging transitions for directional or context-specific animations
+- **Shared element transitions** — morphing elements across different views
+- **View Transition Events** — imperative JavaScript animations via the Web Animations API
+- **CSS pseudo-elements** — `::view-transition-old`, `::view-transition-new`, `::view-transition-group`
+- **Next.js integration** — `experimental.viewTransition`, the `transitionTypes` prop on `next/link`, App Router patterns
+- **Accessibility** — `prefers-reduced-motion` handling
+- **Ready-to-use CSS recipes** — fade, slide, scale, flip, directional navigation
 
-## Topics Covered
+## Skill Structure
 
-- `<ViewTransition>` component (enter, exit, update, share triggers)
-- `addTransitionType` for directional/context-specific animations
-- View Transition Classes and CSS pseudo-elements
-- Shared element transitions with the `name` prop
-- JavaScript animations via Web Animations API (`onEnter`, `onExit`, `onUpdate`, `onShare`)
-- Next.js `transitionTypes` prop on `next/link` (Next.js 16.2+)
-- `useDeferredValue` + `ViewTransition` for search animations
-- Type-safe transition helpers
-- Accessibility (`prefers-reduced-motion`)
+```
+react-view-transition-skill/
+├── SKILL.md                      # Core skill (always loaded)
+└── references/
+    ├── patterns.md               # Real-world patterns, events API, troubleshooting
+    ├── nextjs.md                 # Next.js-specific patterns
+    └── css-recipes.md            # Copy-paste CSS animations
+```
 
-## References
+## Installation
+
+Install via [skills.sh](https://skills.sh):
+
+```bash
+npx skills install https://github.com/vercel-labs/react-view-transitions-skill
+```
+
+## Resources
 
 - [React `<ViewTransition>` docs](https://react.dev/reference/react/ViewTransition)
 - [React `addTransitionType` docs](https://react.dev/reference/react/addTransitionType)
 - [Next.js `viewTransition` config](https://nextjs.org/docs/app/api-reference/config/next-config-js/viewTransition)
 - [next16-conferences](https://github.com/aurorascharff/next16-conferences) — real-world example app
-- [Next.js App Router Playground](https://github.com/vercel/next-app-router-playground/tree/main/app/view-transitions) — Vercel's reference implementation
+- [Next.js App Router Playground (view transitions)](https://github.com/vercel/next-app-router-playground/tree/main/app/view-transitions) — Vercel's reference implementation

--- a/skills/react-view-transitions/README.md
+++ b/skills/react-view-transitions/README.md
@@ -1,0 +1,35 @@
+# React View Transitions
+
+Guide for implementing smooth, native-feeling animations using React's View
+Transition API. Covers the `<ViewTransition>` component, `addTransitionType`,
+CSS view transition pseudo-elements, shared element transitions, and Next.js
+integration including the `transitionTypes` prop on `next/link`.
+
+## Structure
+
+- `SKILL.md` - Core skill instructions with references to sub-documents
+- `references/` - Supporting documentation
+  - `nextjs.md` - Next.js-specific patterns (App Router, `transitionTypes`, shared elements across routes)
+  - `css-recipes.md` - Ready-to-use CSS animation recipes (fade, slide, scale, flip, directional)
+- `metadata.json` - Skill metadata (version, organization, abstract)
+- **`AGENTS.md`** - Full compiled document with all references inlined
+
+## Topics Covered
+
+- `<ViewTransition>` component (enter, exit, update, share triggers)
+- `addTransitionType` for directional/context-specific animations
+- View Transition Classes and CSS pseudo-elements
+- Shared element transitions with the `name` prop
+- JavaScript animations via Web Animations API (`onEnter`, `onExit`, `onUpdate`, `onShare`)
+- Next.js `transitionTypes` prop on `next/link` (Next.js 16.2+)
+- `useDeferredValue` + `ViewTransition` for search animations
+- Type-safe transition helpers
+- Accessibility (`prefers-reduced-motion`)
+
+## References
+
+- [React `<ViewTransition>` docs](https://react.dev/reference/react/ViewTransition)
+- [React `addTransitionType` docs](https://react.dev/reference/react/addTransitionType)
+- [Next.js `viewTransition` config](https://nextjs.org/docs/app/api-reference/config/next-config-js/viewTransition)
+- [next16-conferences](https://github.com/aurorascharff/next16-conferences) — real-world example app
+- [Next.js App Router Playground](https://github.com/vercel/next-app-router-playground/tree/main/app/view-transitions) — Vercel's reference implementation

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -425,15 +425,19 @@ Prevent unintended animations by disabling the default trigger on ViewTransition
   enter={{
     'navigation-forward': 'slide-in-from-right',
     'navigation-back': 'slide-in-from-left',
+    default: 'none',
   }}
   exit={{
     'navigation-forward': 'slide-out-to-left',
     'navigation-back': 'slide-out-to-right',
+    default: 'none',
   }}
 >
   {children}
 </ViewTransition>
 ```
+
+**TypeScript note:** When passing an object to `enter`/`exit`, the `ViewTransitionClassPerType` type requires a `default` key. Always include `default: 'none'` (or `'auto'`) in the object — omitting it causes a type error even if the component-level `default` prop is set.
 
 Without `default="none"`, a `<ViewTransition>` with `default="auto"` (the implicit default) fires the browser's cross-fade on **every** transition — including ones triggered by child Suspense boundaries, `useDeferredValue` updates, or `startTransition` calls within the page.
 

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -365,6 +365,32 @@ Wrap children in `<ViewTransition update="none">` to prevent them from animating
 </ViewTransition>
 ```
 
+### Reusable Animated Collapse
+
+For apps with many expand/collapse interactions, extract a reusable wrapper instead of repeating the conditional-render-with-VT pattern:
+
+```jsx
+import { ViewTransition } from 'react';
+
+function AnimatedCollapse({ open, children }) {
+  if (!open) return null;
+  return (
+    <ViewTransition enter="expand-in" exit="collapse-out">
+      {children}
+    </ViewTransition>
+  );
+}
+```
+
+Use it with `startTransition` on the toggle — never with native `<details>`/`<summary>` (which bypasses React state):
+
+```jsx
+<button onClick={() => startTransition(() => setOpen(o => !o))}>Toggle</button>
+<AnimatedCollapse open={open}>
+  <SectionContent />
+</AnimatedCollapse>
+```
+
 ### Preserve State with Activity
 
 Use `<Activity>` with `<ViewTransition>` to animate show/hide while preserving component state:
@@ -420,6 +446,16 @@ Pick the level that carries the most meaning for your app:
 - **Mixed:** Use `default="none"` at the layout level and only activate it for specific `transitionTypes` (e.g., directional navigation). This way it stays silent during per-page Suspense transitions.
 
 The exception is **shared element transitions** — these intentionally span levels (one side unmounts while the other mounts) and don't conflict with other VTs because the `share` trigger takes precedence over `enter`/`exit`.
+
+### Multi-Level Coordination Checklist
+
+When combining directional layout VTs with per-page Suspense VTs, set `default="none"` at **every** level — not just the layout:
+
+1. **Layout VT** (`{children}`): `default="none"` — only fires for explicit `transitionTypes` (e.g., directional navigation)
+2. **Suspense fallback VTs** (skeleton → content): `default="none"` + explicit `exit` — they only need the exit animation (slide-down when content replaces skeleton). Without `default="none"`, the fallback VT would also cross-fade during route transitions triggered by `<Link>`
+3. **Content/item VTs** (per-item, expand/collapse): `default="none"` + explicit `enter`/`exit` — they only fire for their specific `startTransition` triggers
+
+This ensures each VT stays silent except for its intended trigger, even when `viewTransition: true` makes every `<Link>` navigation activate all mounted VTs.
 
 ---
 
@@ -646,11 +682,29 @@ Or disable specific animations conditionally in JavaScript events by checking th
 **Enter/exit not firing in a client component (only updates animate):**
 - `startTransition(() => setState(...))` triggers a Transition, but if the new content isn't behind a `<Suspense>` boundary, React treats the swap as an **update** to the existing tree — not an enter/exit. The `<ViewTransition>` sees its children change but never fully unmounts/remounts, so only `update` animations fire. To get true enter/exit, either conditionally render the `<ViewTransition>` itself (so it mounts/unmounts with the content), or wrap the async content in `<Suspense>` so React can treat the reveal as an insertion.
 
+**ViewTransition not firing on `<details>` toggle:**
+- Native `<details>`/`<summary>` elements are browser-controlled — their open/close state bypasses React entirely, so `startTransition` never wraps the toggle and `<ViewTransition>` never fires. Convert to controlled state with `useState` + `startTransition` + a `<button>` for animated expand/collapse (see the "Reusable Animated Collapse" pattern above).
+
 **Competing / double animations on navigation:**
 - Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level VT cross-fades the whole page while a page-level VT slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level VT, or remove it entirely if pages manage their own animations. See "How Multiple ViewTransitions Interact" above.
 
 **Batching:**
 - If multiple updates occur while an animation is running, React batches them into one. For example: if you navigate A→B, then B→C, then C→D during the first animation, the next animation will go B→D.
+
+---
+
+## Animation Timing Guidelines
+
+Match duration to the interaction type — direct user actions need fast feedback, while ambient reveals can be slower:
+
+| Interaction | Duration | Rationale |
+|------------|----------|-----------|
+| Direct toggle (expand/collapse, show/hide) | 100–200ms | Responds to a click — must feel instant |
+| Route transition (directional slide) | 150–250ms | Brief spatial cue, shouldn't delay navigation |
+| Suspense reveal (skeleton → content) | 200–400ms | Soft reveal, content is "arriving" |
+| Shared element morph | 300–500ms | Users watch the morph — give it room to breathe |
+
+These are starting points. Test on low-end devices — animations that feel smooth on a fast machine can feel sluggish on mobile.
 
 ---
 

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -31,6 +31,21 @@ Route-level transitions (#5) are the lowest priority because the URL change alre
 
 **Rule of thumb:** at any given moment, only one level of the tree should be visually transitioning. If your pages already manage their own Suspense reveals or shared element morphs, adding a layout-level route transition on top produces double-animation where both levels fight for attention.
 
+### Choosing the Right Animation Style
+
+Not everything should slide. Match the animation to the spatial relationship:
+
+| Context | Animation | Why |
+|---------|-----------|-----|
+| Detail page main content | `enter="slide-up"` | Reveals "deeper" content the user drilled into |
+| Detail page outer wrapper | `enter`/`exit` type map for `nav-forward` | Navigating forward — horizontal direction |
+| List / overview pages | Bare `<ViewTransition>` (fade) or `default="none"` | Lateral navigation — no spatial depth to communicate |
+| Page headers / breadcrumbs | Bare `<ViewTransition>` (fade) | Small, fast-loading metadata — slide feels excessive |
+| Secondary section on same page | `enter="slide-up"` | Second Suspense boundary streaming in after the header |
+| Revalidation / background refresh | `default="none"` | Data refreshed silently — animation would be distracting |
+
+When in doubt, use a bare `<ViewTransition>` (default cross-fade) or `default="none"`. Only add directional motion (slide-up, slide-from-right) when it communicates spatial meaning.
+
 ---
 
 ## Availability
@@ -193,37 +208,26 @@ The `default` key inside the object is the fallback when no type matches. If any
 
 ### Using Types with CSS `:active-view-transition-type()`
 
-React also adds all transition types as browser view transition types, enabling pure CSS scoping:
+React adds transition types as browser view transition types, enabling pure CSS scoping with `:root:active-view-transition-type(type-name)`. **Caveat:** `::view-transition-old(*)` / `::view-transition-new(*)` match **all** named elements — the wildcard can override specific class-based animations. Prefer class-based props for per-component animations; reserve `:active-view-transition-type()` for global rules.
 
-```css
-:root:active-view-transition-type(navigation-forward) {
-  &::view-transition-old(*) {
-    animation: 300ms ease-out slide-out-to-left;
-  }
-  &::view-transition-new(*) {
-    animation: 300ms ease-out slide-in-from-right;
-  }
-}
-```
+The `types` array is also available as the second argument in event callbacks (`onEnter`, `onExit`, etc.) — see `references/patterns.md`.
 
-**Caveat:** `::view-transition-old(*)` and `::view-transition-new(*)` match **all** named view transition elements, not just the one you intend. If a Suspense `<ViewTransition>` has its own class-based animation (e.g., `enter="slide-up"`), the wildcard `*` selector can override it depending on CSS specificity. The class-based approach via `<ViewTransition>` props is safer because it only affects the specific boundary. Prefer class-based props for per-component animations and reserve `:active-view-transition-type()` for global, app-wide rules where you want all elements to animate the same way.
+### Types and Suspense: When Types Are Available
 
-### Using Types with View Transition Events
+When a `<Link>` with `transitionTypes` triggers navigation, the transition type is available to **all `<ViewTransition>`s that enter/exit during that navigation**. An outer page-level `<ViewTransition>` with a type map sees the type and responds. Inner `<ViewTransition>`s with simple string props also enter — the type is irrelevant to them because simple strings fire regardless of type.
 
-The `types` array is also available in event callbacks:
+Subsequent Suspense reveals — when streamed data loads after navigation completes — are **separate transitions with no type**. This means type-keyed props on Suspense content don't work:
 
 ```jsx
-<ViewTransition
-  onEnter={(instance, types) => {
-    const duration = types.includes('fast') ? 150 : 500;
-    const anim = instance.new.animate(
-      [{ opacity: 0 }, { opacity: 1 }],
-      { duration, easing: 'ease-out' }
-    );
-    return () => anim.cancel();
-  }}
->
+// This does NOT animate on Suspense reveal — the type is gone by then
+<ViewTransition enter={{ "nav-forward": "slide-up", default: "none" }} default="none">
+  <AsyncContent />
+</ViewTransition>
 ```
+
+When Suspense resolves later, a new transition fires with no type — so `default: "none"` applies and nothing animates.
+
+**Use type maps for `<ViewTransition>`s that enter/exit directly with the navigation. Use simple string props for Suspense reveals.** See the two-layer pattern in "Two Patterns — Can Coexist with Proper Isolation" below for a complete example.
 
 ---
 
@@ -255,50 +259,13 @@ Rules for shared element transitions:
 - Only one `<ViewTransition>` with a given `name` can be mounted at a time — use globally unique names (namespace with a prefix or module constant).
 - The "share" trigger takes precedence over "enter"/"exit".
 - If either side is outside the viewport, no pair forms and each side animates independently as enter/exit.
-- Use a constant defined in a shared module to avoid name collisions:
-
-```jsx
-// shared-names.ts
-export const HERO_IMAGE = 'hero-image-detail';
-```
+- Use a constant defined in a shared module to avoid name collisions.
 
 ---
 
 ## View Transition Events (JavaScript Animations)
 
-For imperative control, use the `onEnter`, `onExit`, `onUpdate`, and `onShare` callbacks:
-
-```jsx
-<ViewTransition
-  onEnter={(instance, types) => {
-    const anim = instance.new.animate(
-      [{ transform: 'scale(0.8)', opacity: 0 }, { transform: 'scale(1)', opacity: 1 }],
-      { duration: 300, easing: 'ease-out' }
-    );
-    return () => anim.cancel(); // always return cleanup
-  }}
-  onExit={(instance, types) => {
-    const anim = instance.old.animate(
-      [{ transform: 'scale(1)', opacity: 1 }, { transform: 'scale(0.8)', opacity: 0 }],
-      { duration: 200, easing: 'ease-in' }
-    );
-    return () => anim.cancel();
-  }}
->
-  <Component />
-</ViewTransition>
-```
-
-The `instance` object provides:
-- `instance.old` — the `::view-transition-old` pseudo-element
-- `instance.new` — the `::view-transition-new` pseudo-element
-- `instance.group` — the `::view-transition-group` pseudo-element
-- `instance.imagePair` — the `::view-transition-image-pair` pseudo-element
-- `instance.name` — the `view-transition-name` string
-
-Always return a cleanup function that cancels the animation so the browser can properly handle interruptions.
-
-Only one event fires per `<ViewTransition>` per Transition. `onShare` takes precedence over `onEnter` and `onExit`.
+For imperative control with `onEnter`, `onExit`, `onUpdate`, `onShare` callbacks and the `instance` object (`.old`, `.new`, `.group`, `.imagePair`, `.name`), see `references/patterns.md`. Always return a cleanup function from event handlers. Only one event fires per `<ViewTransition>` per Transition — `onShare` takes precedence over `onEnter`/`onExit`.
 
 ---
 
@@ -306,24 +273,14 @@ Only one event fires per `<ViewTransition>` per Transition. `onShare` takes prec
 
 ### Animate Enter/Exit of a Component
 
-```jsx
-import { ViewTransition, useState, startTransition } from 'react';
+Conditionally render the `<ViewTransition>` itself — toggle with `startTransition`:
 
-function App() {
-  const [show, setShow] = useState(false);
-  return (
-    <>
-      <button onClick={() => startTransition(() => setShow(s => !s))}>
-        Toggle
-      </button>
-      {show && (
-        <ViewTransition enter="fade-in" exit="fade-out">
-          <Panel />
-        </ViewTransition>
-      )}
-    </>
-  );
-}
+```jsx
+{show && (
+  <ViewTransition enter="fade-in" exit="fade-out">
+    <Panel />
+  </ViewTransition>
+)}
 ```
 
 ### Animate List Reorder
@@ -356,17 +313,7 @@ When the key changes, React unmounts and remounts the `<ViewTransition>`, which 
 
 ### Animate Suspense Fallback to Content
 
-Wrap `<Suspense>` in `<ViewTransition>` to cross-fade from fallback to loaded content:
-
-```jsx
-<ViewTransition>
-  <Suspense fallback={<Skeleton />}>
-    <AsyncContent />
-  </Suspense>
-</ViewTransition>
-```
-
-For directional motion, give the fallback and content separate `<ViewTransition>`s with explicit triggers. Use `default="none"` on the content one to prevent it from re-animating on unrelated transitions:
+Wrap `<Suspense>` in a bare `<ViewTransition>` for a simple cross-fade, or give fallback and content separate `<ViewTransition>`s for directional motion. Use `default="none"` on the content to prevent re-animation on revalidation:
 
 ```jsx
 <Suspense
@@ -382,6 +329,8 @@ For directional motion, give the fallback and content separate `<ViewTransition>
 </Suspense>
 ```
 
+**Why `exit` on the fallback and `enter` on the content?** When Suspense resolves, two things happen simultaneously in one transition: the fallback unmounts (exit) and the content mounts (enter). The fallback slides down and fades out while the content slides up and fades in — creating a smooth handoff. The staggered CSS timing (`enter` delays by the `exit` duration) ensures the skeleton leaves before new content arrives.
+
 ### Opt Out of Nested Animations
 
 Wrap children in `<ViewTransition update="none">` to prevent them from animating when a parent changes:
@@ -396,7 +345,7 @@ Wrap children in `<ViewTransition update="none">` to prevent them from animating
 </ViewTransition>
 ```
 
-For more patterns (isolate floating elements, reusable animated collapse, preserve state with `<Activity>`, exclude elements with `useOptimistic`), see `references/patterns.md`.
+For more patterns (isolate persistent/floating elements, reusable animated collapse, preserve state with `<Activity>`, exclude elements with `useOptimistic`), see `references/patterns.md`.
 
 ---
 
@@ -404,7 +353,7 @@ For more patterns (isolate floating elements, reusable animated collapse, preser
 
 When a transition fires, **every** `<ViewTransition>` in the tree that matches the trigger participates simultaneously. Each gets its own `view-transition-name`, and the browser animates all of them inside a single `document.startViewTransition` call. They run in parallel, not sequentially.
 
-This means a layout-level `<ViewTransition>` (whole-page cross-fade) + a page-level one (Suspense slide-up) + per-item ones (list reorder) all fire at once. The result is usually competing animations that look broken.
+This means multiple `<ViewTransition>`s that fire during the **same** transition all animate at once. A layout-level cross-fade + a page-level slide-up + per-item reorder all running in the same `document.startViewTransition` produces competing animations. But `<ViewTransition>`s that fire in **different** transitions (e.g., navigation vs. a later Suspense resolve) don't compete — they animate at different moments.
 
 ### Use `default="none"` Liberally
 
@@ -434,15 +383,50 @@ Prevent unintended animations by disabling the default trigger on ViewTransition
 
 Without `default="none"`, a `<ViewTransition>` with `default="auto"` (the implicit default) fires the browser's cross-fade on **every** transition — including ones triggered by child Suspense boundaries, `useDeferredValue` updates, or `startTransition` calls within the page.
 
-### Choosing One Level
+**Next.js revalidation:** This is especially important in Next.js — when `revalidateTag()` fires (from a Server Action, webhook, or polling), the page re-renders. Without `default="none"`, every `<ViewTransition>` in the tree re-animates: content slides up again, things flash. Always use `default="none"` on content `<ViewTransition>`s and only enable specific triggers (`enter`, `exit`) explicitly.
 
-Pick the level that carries the most meaning for your app:
+### Two Patterns — Can Coexist with Proper Isolation
 
-- **App with per-page Suspense reveals and shared elements:** Don't add a layout-level `<ViewTransition>` on `{children}`. The pages already manage their own transitions. A layout-level cross-fade on top will double-animate. This includes directional (forward/back) navigation — even with `default="none"`, a layout-level slide fires simultaneously with per-page Suspense slide-ups, producing a diagonal movement.
-- **Simple app with no per-page animations:** A layout-level `<ViewTransition>` with `default="auto"` on `{children}` gives you free cross-fades between routes.
-- **Directional navigation only (no per-page VTs):** Use `default="none"` at the layout level and only activate it for specific `transitionTypes`. This works well when pages have no `<ViewTransition>` components of their own.
+There are two distinct view transition patterns:
 
-The exception is **shared element transitions** — these intentionally span levels (one side unmounts while the other mounts) and don't conflict with other VTs because the `share` trigger takes precedence over `enter`/`exit`.
+**Pattern A — Directional page slides** (e.g., left/right navigation):
+- Uses `transitionTypes` on `<Link>` or `addTransitionType` to tag navigation direction
+- An outer `<ViewTransition>` on the page maps types to slide classes with `default="none"`
+- Fires during the navigation transition (when the type is present)
+
+**Pattern B — Suspense content reveals** (e.g., streaming data):
+- No `transitionTypes` needed
+- Simple `enter="slide-up"` / `exit="slide-down"` on `<ViewTransition>`s around Suspense boundaries
+- `default="none"` prevents re-animation on revalidation
+- Fires later when data loads (a separate transition with no type)
+
+**These coexist when they fire at different moments.** The nav slide fires during the navigation transition (with the type); the Suspense reveal fires later when data streams in (no type). `default="none"` on both layers prevents cross-interference — the nav VT ignores Suspense resolves, and the Suspense VT ignores navigations:
+
+```jsx
+<ViewTransition
+  enter={{ "nav-forward": "slide-from-right", default: "none" }}
+  exit={{ "nav-forward": "slide-to-left", default: "none" }}
+  default="none"
+>
+  <div>
+    <Suspense fallback={
+      <ViewTransition exit="slide-down"><Skeleton /></ViewTransition>
+    }>
+      <ViewTransition enter="slide-up" default="none">
+        <Content />
+      </ViewTransition>
+    </Suspense>
+  </div>
+</ViewTransition>
+```
+
+**Always pair `enter` with `exit` on directional transitions.** Without an exit animation, the old page disappears instantly while the new one slides in at scroll position 0 — a jarring jump. The exit slide masks the scroll change within the transition snapshot because the old content animates out simultaneously.
+
+**When they DO conflict:** If both layers use `default="auto"`, or if a layout-level `<ViewTransition>` fires a cross-fade during the same transition as a page-level slide-up, they animate simultaneously and fight for attention. The conflict is about **same-moment** animations, not about using both patterns on the same page.
+
+Place the outer directional `<ViewTransition>` in each **page component** — not in a layout (layouts persist and don't trigger enter/exit). Per-page wrappers are the cleanest approach.
+
+Shared element transitions (`name` prop) work alongside either pattern because the `share` trigger takes precedence over `enter`/`exit`.
 
 ---
 
@@ -471,31 +455,13 @@ Key points:
 
 ### The `transitionTypes` prop on `next/link`
 
-`next/link` supports a native `transitionTypes` prop that eliminates the need for custom `TransitionLink` wrapper components. Instead of intercepting navigation with `onNavigate`, `startTransition`, and `addTransitionType`, you pass transition types directly:
+`next/link` supports a native `transitionTypes` prop — pass an array of strings directly, no `'use client'` or wrapper component needed:
 
 ```tsx
-import Link from 'next/link';
-
-// Before (manual wrapper required):
-<TransitionLink href="/products/1" type="transition-to-detail">
-  View Product
-</TransitionLink>
-
-// After (native prop, no wrapper needed):
-<Link href="/products/1" transitionTypes={['transition-to-detail']}>
-  View Product
-</Link>
+<Link href="/products/1" transitionTypes={['transition-to-detail']}>View Product</Link>
 ```
 
-The `transitionTypes` prop accepts an array of strings — the same types you would pass to `addTransitionType`. This removes the need for `'use client'`, `useRouter`, and custom link components when all you need is to tag a navigation with a transition type.
-
 For full examples with shared element transitions and directional animations, see `references/nextjs.md`.
-
----
-
-## Real-World Patterns
-
-For complete real-world patterns (searchable grids, card expand/collapse, type-safe transition helpers, shared elements across routes), see `references/patterns.md`.
 
 ---
 
@@ -518,40 +484,8 @@ Or disable specific animations conditionally in JavaScript events by checking th
 
 ---
 
-## Troubleshooting
-
-**ViewTransition not activating:**
-- Ensure the `<ViewTransition>` comes before any DOM node in the component (not wrapped in a `<div>`).
-- Ensure the state update is inside `startTransition`, not a plain `setState`.
-
-**"Two ViewTransition components with the same name" error:**
-- Each `name` must be globally unique across the entire app at any point in time. Add item IDs: `name={\`hero-${item.id}\`}`.
-
-**Back button skips animation:**
-- The legacy `popstate` event requires synchronous completion, conflicting with view transitions. Upgrade your router to use the Navigation API for back-button animations.
-
-**Animations from `flushSync` are skipped:**
-- `flushSync` completes synchronously, which prevents view transitions from running. Use `startTransition` instead.
-
-**Enter/exit not firing in a client component (only updates animate):**
-- `startTransition(() => setState(...))` triggers a Transition, but if the new content isn't behind a `<Suspense>` boundary, React treats the swap as an **update** to the existing tree — not an enter/exit. The `<ViewTransition>` sees its children change but never fully unmounts/remounts, so only `update` animations fire. To get true enter/exit, either conditionally render the `<ViewTransition>` itself (so it mounts/unmounts with the content), or wrap the async content in `<Suspense>` so React can treat the reveal as an insertion.
-
-**Competing / double animations on navigation:**
-- Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level one cross-fades the whole page while a page-level one slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level `<ViewTransition>`, or remove it entirely if pages manage their own animations. See "How Multiple `<ViewTransition>`s Interact" above.
-
-**List reorder not animating with `useOptimistic`:**
-- If the optimistic value drives the list sort order, items are already in their final positions before the transition snapshot — there's nothing to animate. Use the optimistic value only for controls (labels, icons) and the committed state (`useState`) for the list sort order.
-
-**TypeScript error: "Property 'default' is missing in type 'ViewTransitionClassPerType'":**
-- When passing an object to `enter`/`exit`/`update`/`share`, TypeScript requires a `default` key in the object. This applies even if the component-level `default` prop is set. Always include `default: 'none'` (or `'auto'`) in type-keyed objects.
-
-**Batching:**
-- If multiple updates occur while an animation is running, React batches them into one. For example: if you navigate A→B, then B→C, then C→D during the first animation, the next animation will go B→D.
-
----
-
 ## Reference Files
 
-- **`references/patterns.md`** — Real-world patterns (searchable grids, expand/collapse, type-safe helpers) and animation timing guidelines.
-- **`references/css-recipes.md`** — Ready-to-use CSS animation recipes (slide, fade, scale, flip, and combined patterns).
+- **`references/patterns.md`** — Real-world patterns (searchable grids, expand/collapse, type-safe helpers), animation timing, view transition events (JavaScript Animations API), and troubleshooting.
+- **`references/css-recipes.md`** — Ready-to-use CSS animation recipes (slide, fade, scale, directional nav, and combined patterns).
 - **`references/nextjs.md`** — Detailed Next.js integration guide with App Router patterns and Server Component considerations.

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -1,0 +1,581 @@
+---
+name: react-view-transition
+description: Guide for implementing smooth, native-feeling animations using React's View Transition API (`<ViewTransition>` component, `addTransitionType`, and CSS view transition pseudo-elements). Use this skill whenever the user wants to add page transitions, animate route changes, create shared element animations, animate enter/exit of components, animate list reorder, implement directional (forward/back) navigation animations, or integrate view transitions in Next.js. Also use when the user mentions view transitions, `startViewTransition`, `ViewTransition`, transition types, or asks about animating between UI states in React without third-party animation libraries.
+---
+
+# React View Transitions
+
+React's View Transition API lets you animate between UI states using the browser's native `document.startViewTransition` under the hood. React manages the lifecycle automatically — you declare *what* to animate with `<ViewTransition>`, trigger *when* to animate through `startTransition` / `useDeferredValue` / `Suspense`, and control *how* to animate with CSS classes or JavaScript via the Web Animations API.
+
+The API adds ~3KB to your bundle, runs on the browser's compositor thread for 60fps animations, and gracefully falls back to instant state changes in unsupported browsers.
+
+## Availability
+
+- `<ViewTransition>` and `addTransitionType` shipped in **React 19.2** (stable).
+- For older React 19 versions, both are available in `react@canary` and `react@experimental`.
+- Browser support: Chromium-based browsers have full support. Firefox and Safari are adding support. The API gracefully degrades — unsupported browsers skip the animation and apply the DOM change instantly.
+
+---
+
+## Core Concepts
+
+### The `<ViewTransition>` Component
+
+Wrap the elements you want to animate:
+
+```jsx
+import { ViewTransition } from 'react';
+
+<ViewTransition>
+  <Component />
+</ViewTransition>
+```
+
+React automatically assigns a unique `view-transition-name` to the nearest DOM node inside each `<ViewTransition>`, and calls `document.startViewTransition` behind the scenes. Never call `startViewTransition` yourself — React coordinates all view transitions and will interrupt external ones.
+
+### Animation Triggers
+
+React decides which type of animation to run based on what changed:
+
+| Trigger | When it fires |
+|---------|--------------|
+| **enter** | A `<ViewTransition>` is first inserted during a Transition |
+| **exit** | A `<ViewTransition>` is first removed during a Transition |
+| **update** | DOM mutations happen inside a `<ViewTransition>`, or the boundary changes size/position due to an immediate sibling |
+| **share** | A named `<ViewTransition>` unmounts and another with the same `name` mounts in the same Transition (shared element transition) |
+
+Only updates wrapped in `startTransition`, `useDeferredValue`, or `Suspense` activate `<ViewTransition>`. Regular `setState` updates immediately and does not animate.
+
+### Critical Placement Rule
+
+`<ViewTransition>` only activates enter/exit if it appears **before any DOM nodes** in the component tree:
+
+```jsx
+// Works — ViewTransition is before the DOM node
+function Item() {
+  return (
+    <ViewTransition enter="auto" exit="auto">
+      <div>Content</div>
+    </ViewTransition>
+  );
+}
+
+// Broken — a <div> wraps the ViewTransition, preventing enter/exit
+function Item() {
+  return (
+    <div>
+      <ViewTransition enter="auto" exit="auto">
+        <div>Content</div>
+      </ViewTransition>
+    </div>
+  );
+}
+```
+
+---
+
+## Styling Animations with View Transition Classes
+
+Rather than using `view-transition-name` in CSS directly, React recommends providing a **View Transition Class** to the activation props. React applies this class to the child elements when the animation activates.
+
+### Props
+
+Each prop controls a different trigger. Values can be:
+
+- `"auto"` — use the browser default cross-fade
+- `"none"` — disable this animation type
+- `"my-class-name"` — a custom CSS class
+- An object `{ [transitionType]: value }` for type-specific animations (see Transition Types below)
+
+```jsx
+<ViewTransition
+  default="none"          // disable everything not explicitly listed
+  enter="slide-in"        // CSS class for enter animations
+  exit="slide-out"        // CSS class for exit animations
+  update="cross-fade"     // CSS class for update animations
+  share="morph"           // CSS class for shared element animations
+/>
+```
+
+If `default` is `"none"`, all triggers are off unless explicitly listed.
+
+### Defining CSS Animations
+
+Use the view transition pseudo-element selectors with the class name:
+
+```css
+::view-transition-old(.slide-in) {
+  animation: 300ms ease-out slide-out-to-left;
+}
+::view-transition-new(.slide-in) {
+  animation: 300ms ease-out slide-in-from-right;
+}
+
+@keyframes slide-out-to-left {
+  to { transform: translateX(-100%); opacity: 0; }
+}
+@keyframes slide-in-from-right {
+  from { transform: translateX(100%); opacity: 0; }
+}
+```
+
+The pseudo-elements available are:
+
+- `::view-transition-group(.class)` — the container for the transition
+- `::view-transition-image-pair(.class)` — contains old and new snapshots
+- `::view-transition-old(.class)` — the outgoing snapshot
+- `::view-transition-new(.class)` — the incoming snapshot
+
+---
+
+## Transition Types with `addTransitionType`
+
+`addTransitionType` lets you tag a transition with a string label so `<ViewTransition>` can pick different animations based on *what caused* the change. This is essential for directional navigation (forward vs. back) or distinguishing user actions (click vs. swipe vs. keyboard).
+
+### Basic Usage
+
+```jsx
+import { startTransition, addTransitionType } from 'react';
+
+function navigate(url, direction) {
+  startTransition(() => {
+    addTransitionType(`navigation-${direction}`); // "navigation-forward" or "navigation-back"
+    setCurrentPage(url);
+  });
+}
+```
+
+You can add multiple types to a single transition, and if multiple transitions are batched, all types are collected.
+
+### Using Types with View Transition Classes
+
+Pass an object instead of a string to any activation prop. Keys are transition type strings, values are CSS class names:
+
+```jsx
+<ViewTransition
+  enter={{
+    'navigation-forward': 'slide-in-from-right',
+    'navigation-back': 'slide-in-from-left',
+    default: 'fade-in',
+  }}
+  exit={{
+    'navigation-forward': 'slide-out-to-left',
+    'navigation-back': 'slide-out-to-right',
+    default: 'fade-out',
+  }}
+>
+  <Page />
+</ViewTransition>
+```
+
+The `default` key inside the object is the fallback when no type matches. If any type has the value `"none"`, the ViewTransition is disabled for that trigger.
+
+### Using Types with CSS `:active-view-transition-type()`
+
+React also adds all transition types as browser view transition types, enabling pure CSS scoping:
+
+```css
+:root:active-view-transition-type(navigation-forward) {
+  &::view-transition-old(*) {
+    animation: 300ms ease-out slide-out-to-left;
+  }
+  &::view-transition-new(*) {
+    animation: 300ms ease-out slide-in-from-right;
+  }
+}
+```
+
+### Using Types with View Transition Events
+
+The `types` array is also available in event callbacks:
+
+```jsx
+<ViewTransition
+  onEnter={(instance, types) => {
+    const duration = types.includes('fast') ? 150 : 500;
+    const anim = instance.new.animate(
+      [{ opacity: 0 }, { opacity: 1 }],
+      { duration, easing: 'ease-out' }
+    );
+    return () => anim.cancel();
+  }}
+>
+```
+
+---
+
+## Shared Element Transitions
+
+Assign the same `name` to two `<ViewTransition>` components — one in the unmounting tree and one in the mounting tree — to animate between them as if they're the same element:
+
+```jsx
+const HERO_IMAGE = 'hero-image';
+
+function ListView({ onSelect }) {
+  return (
+    <ViewTransition name={HERO_IMAGE}>
+      <img src="/thumb.jpg" onClick={() => startTransition(() => onSelect())} />
+    </ViewTransition>
+  );
+}
+
+function DetailView() {
+  return (
+    <ViewTransition name={HERO_IMAGE}>
+      <img src="/full.jpg" />
+    </ViewTransition>
+  );
+}
+```
+
+Rules for shared element transitions:
+- Only one `<ViewTransition>` with a given `name` can be mounted at a time — use globally unique names (namespace with a prefix or module constant).
+- The "share" trigger takes precedence over "enter"/"exit".
+- If either side is outside the viewport, no pair forms and each side animates independently as enter/exit.
+- Use a constant defined in a shared module to avoid name collisions:
+
+```jsx
+// shared-names.ts
+export const HERO_IMAGE = 'hero-image-detail';
+```
+
+---
+
+## View Transition Events (JavaScript Animations)
+
+For imperative control, use the `onEnter`, `onExit`, `onUpdate`, and `onShare` callbacks:
+
+```jsx
+<ViewTransition
+  onEnter={(instance, types) => {
+    const anim = instance.new.animate(
+      [{ transform: 'scale(0.8)', opacity: 0 }, { transform: 'scale(1)', opacity: 1 }],
+      { duration: 300, easing: 'ease-out' }
+    );
+    return () => anim.cancel(); // always return cleanup
+  }}
+  onExit={(instance, types) => {
+    const anim = instance.old.animate(
+      [{ transform: 'scale(1)', opacity: 1 }, { transform: 'scale(0.8)', opacity: 0 }],
+      { duration: 200, easing: 'ease-in' }
+    );
+    return () => anim.cancel();
+  }}
+>
+  <Component />
+</ViewTransition>
+```
+
+The `instance` object provides:
+- `instance.old` — the `::view-transition-old` pseudo-element
+- `instance.new` — the `::view-transition-new` pseudo-element
+- `instance.group` — the `::view-transition-group` pseudo-element
+- `instance.imagePair` — the `::view-transition-image-pair` pseudo-element
+- `instance.name` — the `view-transition-name` string
+
+Always return a cleanup function that cancels the animation so the browser can properly handle interruptions.
+
+Only one event fires per `<ViewTransition>` per Transition. `onShare` takes precedence over `onEnter` and `onExit`.
+
+---
+
+## Common Patterns
+
+### Animate Enter/Exit of a Component
+
+```jsx
+import { ViewTransition, useState, startTransition } from 'react';
+
+function App() {
+  const [show, setShow] = useState(false);
+  return (
+    <>
+      <button onClick={() => startTransition(() => setShow(s => !s))}>
+        Toggle
+      </button>
+      {show && (
+        <ViewTransition enter="fade-in" exit="fade-out">
+          <Panel />
+        </ViewTransition>
+      )}
+    </>
+  );
+}
+```
+
+### Animate List Reorder
+
+Wrap each item (not a wrapper div) in `<ViewTransition>` with a stable `key`:
+
+```jsx
+{items.map(item => (
+  <ViewTransition key={item.id}>
+    <ItemCard item={item} />
+  </ViewTransition>
+))}
+```
+
+Triggering the reorder inside `startTransition` will smoothly animate each item to its new position. Avoid wrapper `<div>`s between the list and `<ViewTransition>` — they block the reorder animation.
+
+### Animate Suspense Fallback to Content
+
+Wrap `<Suspense>` in `<ViewTransition>` to cross-fade from fallback to loaded content:
+
+```jsx
+<ViewTransition>
+  <Suspense fallback={<Skeleton />}>
+    <AsyncContent />
+  </Suspense>
+</ViewTransition>
+```
+
+### Opt Out of Nested Animations
+
+Wrap children in `<ViewTransition update="none">` to prevent them from animating when a parent changes:
+
+```jsx
+<ViewTransition>
+  <div className={theme}>
+    <ViewTransition update="none">
+      {children}
+    </ViewTransition>
+  </div>
+</ViewTransition>
+```
+
+### Preserve State with Activity
+
+Use `<Activity>` with `<ViewTransition>` to animate show/hide while preserving component state:
+
+```jsx
+import { Activity, ViewTransition, startTransition } from 'react';
+
+<Activity mode={isVisible ? 'visible' : 'hidden'}>
+  <ViewTransition enter="slide-in" exit="slide-out">
+    <Sidebar />
+  </ViewTransition>
+</Activity>
+```
+
+---
+
+## Next.js Integration
+
+Next.js supports React View Transitions. Enable it in `next.config.js` (or `next.config.ts`):
+
+```js
+const nextConfig = {
+  experimental: {
+    viewTransition: true,
+  },
+};
+module.exports = nextConfig;
+```
+
+For a detailed guide on Next.js integration, including App Router patterns and Server Component considerations, read `references/nextjs.md`.
+
+Key points:
+- The `<ViewTransition>` component is imported from `react` directly — no Next.js-specific import.
+- The `experimental.viewTransition` flag enables deeper integration with Next.js features beyond what `<ViewTransition>` provides on its own.
+- Wrap page content in `<ViewTransition>` inside the layout to animate route transitions.
+- Works with the App Router and `startTransition` + `router.push()` for programmatic navigation.
+
+### The `transitionTypes` prop on `next/link`
+
+As of Next.js 16.2+, `next/link` supports a native `transitionTypes` prop that eliminates the need for custom `TransitionLink` wrapper components. Instead of intercepting navigation with `onNavigate`, `startTransition`, and `addTransitionType`, you pass transition types directly:
+
+```tsx
+import Link from 'next/link';
+
+// Before (manual wrapper required):
+<TransitionLink href="/products/1" type="transition-to-detail">
+  View Product
+</TransitionLink>
+
+// After (native prop, no wrapper needed):
+<Link href="/products/1" transitionTypes={['transition-to-detail']}>
+  View Product
+</Link>
+```
+
+The `transitionTypes` prop accepts an array of strings — the same types you would pass to `addTransitionType`. This removes the need for `'use client'`, `useRouter`, and custom link components when all you need is to tag a navigation with a transition type. The `<ViewTransition>` components in the tree respond to these types the same way they respond to manual `addTransitionType` calls.
+
+For full examples of `transitionTypes` with shared element transitions and directional animations across routes, see `references/nextjs.md`.
+
+---
+
+## Real-World Patterns
+
+These patterns are drawn from production Next.js apps using View Transitions.
+
+### List-to-Detail with `useDeferredValue` and `ViewTransition`
+
+A common pattern is a client-side searchable grid where items expand into a detail view. Wrap each item in `<ViewTransition>` and use `useDeferredValue` to trigger animated updates as the user types:
+
+```tsx
+'use client';
+
+import { useDeferredValue, useState, ViewTransition, Suspense } from 'react';
+
+export default function TalksExplorer({ talksPromise }) {
+  const [search, setSearch] = useState('');
+  const deferredSearch = useDeferredValue(search);
+
+  return (
+    <>
+      <input
+        value={search}
+        onChange={(e) => setSearch(e.currentTarget.value)}
+        placeholder="Search talks..."
+      />
+      <ViewTransition>
+        <Suspense fallback={<GridSkeleton />}>
+          <TalksGrid talksPromise={talksPromise} search={deferredSearch} />
+        </Suspense>
+      </ViewTransition>
+    </>
+  );
+}
+```
+
+When `deferredSearch` updates (deferred from the search input), React treats it as a transition and the `<ViewTransition>` wrapping the `<Suspense>` boundary cross-fades between the old and new grid content.
+
+### Card Expand/Collapse with `startTransition`
+
+Toggle between a card grid and a detail view using `startTransition` to animate the swap:
+
+```tsx
+'use client';
+
+import { useState, startTransition, ViewTransition } from 'react';
+
+export default function TalksGrid({ talks }) {
+  const [expandedTalkId, setExpandedTalkId] = useState(null);
+
+  return expandedTalkId ? (
+    <ViewTransition enter="slide-up" exit="slide-down">
+      <TalkDetails
+        talk={talks.find(t => t.id === expandedTalkId)}
+        closeAction={() => {
+          startTransition(() => {
+            setExpandedTalkId(null);
+          });
+        }}
+      />
+    </ViewTransition>
+  ) : (
+    <div className="grid grid-cols-3 gap-4">
+      {talks.map(talk => (
+        <ViewTransition key={talk.id}>
+          <TalkCard
+            talk={talk}
+            onSelect={() => {
+              startTransition(() => {
+                setExpandedTalkId(talk.id);
+              });
+            }}
+          />
+        </ViewTransition>
+      ))}
+    </div>
+  );
+}
+```
+
+The CSS for slide-up/slide-down enter/exit:
+
+```css
+::view-transition-old(.slide-down) {
+  animation: 150ms ease-out both fade-out, 150ms ease-out both slide-down;
+}
+::view-transition-new(.slide-up) {
+  animation: 210ms ease-in 150ms both fade-in, 400ms ease-in both slide-up;
+}
+
+@keyframes slide-up {
+  from { transform: translateY(10px); }
+  to { transform: translateY(0); }
+}
+@keyframes slide-down {
+  from { transform: translateY(0); }
+  to { transform: translateY(10px); }
+}
+@keyframes fade-in {
+  from { opacity: 0; }
+}
+@keyframes fade-out {
+  to { opacity: 0; }
+}
+```
+
+### Type-Safe Transition Helpers
+
+For larger apps, define type-safe transition IDs and transition maps to prevent ID clashes and keep animation configurations consistent. Use `as const` arrays for transition IDs, types, and animation classes, then derive types from them:
+
+```tsx
+import { ViewTransition } from 'react';
+
+const transitionTypes = ['default', 'transition-to-detail', 'transition-to-list', 'transition-backwards', 'transition-forwards'] as const;
+const animationTypes = ['auto', 'none', 'animate-slide-from-left', 'animate-slide-from-right', 'animate-slide-to-left', 'animate-slide-to-right'] as const;
+
+type TransitionType = (typeof transitionTypes)[number];
+type AnimationType = (typeof animationTypes)[number];
+type TransitionMap = { default: AnimationType } & Partial<Record<Exclude<TransitionType, 'default'>, AnimationType>>;
+
+export function HorizontalTransition({ children, enter, exit }: {
+  children: React.ReactNode;
+  enter: TransitionMap;
+  exit: TransitionMap;
+}) {
+  return <ViewTransition enter={enter} exit={exit}>{children}</ViewTransition>;
+}
+```
+
+These wrappers enforce that only valid transition IDs and animation classes are used, catching mistakes at compile time. See the Next.js App Router Playground (`vercel/next-app-router-playground`) for a complete example of this pattern.
+
+### Shared Elements Across Routes in Next.js
+
+See `references/nextjs.md` (Shared Elements Across Routes) for complete examples using `transitionTypes` on `next/link` combined with shared element `<ViewTransition name={...}>` for list-to-detail image morph animations.
+
+---
+
+## Accessibility
+
+Always respect `prefers-reduced-motion`. React does not disable animations automatically for this preference. Add this to your global CSS:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation-duration: 0s !important;
+  }
+}
+```
+
+Or disable specific animations conditionally in JavaScript events by checking the media query.
+
+---
+
+## Troubleshooting
+
+**ViewTransition not activating:**
+- Ensure the `<ViewTransition>` comes before any DOM node in the component (not wrapped in a `<div>`).
+- Ensure the state update is inside `startTransition`, not a plain `setState`.
+
+**"Two ViewTransition components with the same name" error:**
+- Each `name` must be globally unique across the entire app at any point in time. Add item IDs: `name={\`hero-${item.id}\`}`.
+
+**Back button skips animation:**
+- The legacy `popstate` event requires synchronous completion, conflicting with view transitions. Upgrade your router to use the Navigation API for back-button animations.
+
+**Animations from `flushSync` are skipped:**
+- `flushSync` completes synchronously, which prevents view transitions from running. Use `startTransition` instead.
+
+**Batching:**
+- If multiple updates occur while an animation is running, React batches them into one. For example: if you navigate A→B, then B→C, then C→D during the first animation, the next animation will go B→D.
+
+---
+
+## CSS Recipe Reference
+
+For ready-to-use CSS animation recipes (slide, fade, scale, flip, and combined patterns), see `references/css-recipes.md`.

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -341,7 +341,17 @@ Triggering the reorder inside `startTransition` will smoothly animate each item 
 
 ### Animate Suspense Fallback to Content
 
-The production pattern is to give the fallback an **exit-only** animation and the content an **enter-only** animation with `default="none"`. This is more intentional than a blanket crossfade and prevents the content VT from re-animating on every subsequent route navigation:
+Wrap `<Suspense>` in `<ViewTransition>` to cross-fade from fallback to loaded content:
+
+```jsx
+<ViewTransition>
+  <Suspense fallback={<Skeleton />}>
+    <AsyncContent />
+  </Suspense>
+</ViewTransition>
+```
+
+For directional motion, give the fallback and content separate VTs with explicit triggers. Use `default="none"` on the content VT to prevent it from re-animating on unrelated transitions:
 
 ```jsx
 <Suspense
@@ -355,18 +365,6 @@ The production pattern is to give the fallback an **exit-only** animation and th
     <AsyncContent />
   </ViewTransition>
 </Suspense>
-```
-
-The skeleton slides down when content replaces it (`exit`). The content slides up when it first appears (`enter`). `default="none"` on the content VT ensures it stays silent during unrelated transitions (e.g., link navigations that trigger the layout-level VT).
-
-For a simple crossfade without directional motion, wrap the whole `<Suspense>` instead:
-
-```jsx
-<ViewTransition>
-  <Suspense fallback={<Skeleton />}>
-    <AsyncContent />
-  </Suspense>
-</ViewTransition>
 ```
 
 ### Opt Out of Nested Animations

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -315,7 +315,17 @@ When the key changes, React unmounts and remounts the `<ViewTransition>`, which 
 
 ### Animate Suspense Fallback to Content
 
-Wrap `<Suspense>` in a bare `<ViewTransition>` for a simple cross-fade, or give fallback and content separate `<ViewTransition>`s for directional motion. Use `default="none"` on the content to prevent re-animation on revalidation:
+The simplest approach: wrap `<Suspense>` in a single `<ViewTransition>` for a zero-config cross-fade from skeleton to content:
+
+```jsx
+<ViewTransition>
+  <Suspense fallback={<Skeleton />}>
+    <Content />
+  </Suspense>
+</ViewTransition>
+```
+
+For directional motion, give the fallback and content separate `<ViewTransition>`s. Use `default="none"` on the content to prevent re-animation on revalidation:
 
 ```jsx
 <Suspense

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -27,14 +27,6 @@ From highest value to lowest — start from the top and only move down if your a
 
 Route-level transitions (#5) are the lowest priority because the URL change already signals a context switch. A blanket cross-fade on every navigation says nothing — it's visual noise. Prefer specific, intentional animations (#1–#4) over ambient page transitions.
 
-### Should This Element Use ViewTransition?
-
-- **Persistent across navigations?** (nav bar, sidebar, header) → Skip VT. Use plain `<Suspense>` if needed.
-- **Expand/collapse that needs to feel spatial?** → Animated collapse with VT + `startTransition`.
-- **Simple show/hide with no spatial meaning?** → Conditional render, no VT.
-- **Already inside a parent VT?** → Check if `default="none"` is needed to avoid double-animation.
-- **Content that changes on route navigation?** → VT with `default="none"` + explicit triggers.
-
 **Rule of thumb:** at any given moment, only one level of the tree should be visually transitioning. If your pages already manage their own Suspense reveals or shared element morphs, adding a layout-level route transition on top produces double-animation where both levels fight for attention.
 
 ---
@@ -493,21 +485,6 @@ Pick the level that carries the most meaning for your app:
 
 The exception is **shared element transitions** — these intentionally span levels (one side unmounts while the other mounts) and don't conflict with other VTs because the `share` trigger takes precedence over `enter`/`exit`.
 
-### Multi-Level Coordination Checklist
-
-When combining directional layout VTs with per-page Suspense VTs, set `default="none"` at **every** level — not just the layout:
-
-1. **Layout VT** (`{children}`): `default="none"` — only fires for explicit `transitionTypes` (e.g., directional navigation)
-2. **Suspense fallback VTs** (skeleton → content): `default="none"` + explicit `exit` — they only need the exit animation (slide-down when content replaces skeleton). Without `default="none"`, the fallback VT would also cross-fade during route transitions triggered by `<Link>`
-3. **Content/item VTs** (per-item, expand/collapse): `default="none"` + explicit `enter`/`exit` — they only fire for their specific `startTransition` triggers
-
-This ensures each VT stays silent except for its intended trigger, even when `viewTransition: true` makes every `<Link>` navigation activate all mounted VTs.
-
-Note: `default="none"` on content VTs is also critical when the content itself contains `<Link>` elements with `transitionTypes`. Without it, clicking a typed link inside the content would cause the content's own VT to re-animate (cross-fade) alongside the layout-level directional slide.
-
-### Persistent Layout Chrome
-
-Nav bars, headers, sidebars, and other layout elements that load once and don't change across navigations should generally **not** be wrapped in `<ViewTransition>`. Even if they're behind `<Suspense>` for initial data loading (auth checks, etc.), the one-time skeleton-to-content swap is barely perceptible. Wrapping them in VT causes them to re-animate on every `<Link>` navigation when `viewTransition: true` is enabled. Use plain `<Suspense fallback={<Skeleton />}>` without VT for these.
 
 ---
 
@@ -735,9 +712,6 @@ Or disable specific animations conditionally in JavaScript events by checking th
 
 **TypeScript error: "Property 'default' is missing in type 'ViewTransitionClassPerType'":**
 - When passing an object to `enter`/`exit`/`update`/`share`, TypeScript requires a `default` key in the object. This applies even if the component-level `default` prop is set. Always include `default: 'none'` (or `'auto'`) in type-keyed objects.
-
-**Orphaned CSS after removing ViewTransition:**
-- When removing `<ViewTransition>` components, remember to clean up corresponding `::view-transition-old(...)` / `::view-transition-new(...)` rules and `@keyframes` definitions. These don't cause build errors so they're easy to forget.
 
 **Batching:**
 - If multiple updates occur while an animation is running, React batches them into one. For example: if you navigate A→B, then B→C, then C→D during the first animation, the next animation will go B→D.

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -311,6 +311,8 @@ Use a `key` prop on `<ViewTransition>` to force an enter/exit animation when a v
 
 When the key changes, React unmounts and remounts the `<ViewTransition>`, which triggers exit on the old instance and enter on the new one. This is useful for animating content swaps driven by URL parameters, tab switches, or any state change where the content identity changes but the component type stays the same.
 
+**Caution with Suspense:** If the `<ViewTransition>` wraps a `<Suspense>`, changing the key remounts the entire Suspense boundary, re-triggering the data fetch. Only use `key` on `<ViewTransition>` outside of Suspense, or accept the refetch.
+
 ### Animate Suspense Fallback to Content
 
 Wrap `<Suspense>` in a bare `<ViewTransition>` for a simple cross-fade, or give fallback and content separate `<ViewTransition>`s for directional motion. Use `default="none"` on the content to prevent re-animation on revalidation:
@@ -330,6 +332,8 @@ Wrap `<Suspense>` in a bare `<ViewTransition>` for a simple cross-fade, or give 
 ```
 
 **Why `exit` on the fallback and `enter` on the content?** When Suspense resolves, two things happen simultaneously in one transition: the fallback unmounts (exit) and the content mounts (enter). The fallback slides down and fades out while the content slides up and fades in — creating a smooth handoff. The staggered CSS timing (`enter` delays by the `exit` duration) ensures the skeleton leaves before new content arrives.
+
+**Skeleton dimensions should closely match the content.** If the skeleton renders 3 single-line items but the content renders 5 two-line items, the size difference between the old/new snapshots produces a jarring stagger rather than a smooth transition.
 
 ### Opt Out of Nested Animations
 

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -343,6 +343,8 @@ Wrap each item (not a wrapper div) in `<ViewTransition>` with a stable `key`:
 
 Triggering the reorder inside `startTransition` will smoothly animate each item to its new position. Avoid wrapper `<div>`s between the list and `<ViewTransition>` — they block the reorder animation.
 
+**How it works:** `startTransition` doesn't need async work to animate. The View Transition API captures a "before" snapshot of the DOM, then React applies the state update, and the API captures an "after" snapshot. As long as items change position between snapshots, the animation runs — even for purely synchronous local state changes like sorting.
+
 ### Animate Suspense Fallback to Content
 
 Wrap `<Suspense>` in `<ViewTransition>` to cross-fade from fallback to loaded content:
@@ -442,6 +444,37 @@ import { Activity, ViewTransition, startTransition } from 'react';
   </ViewTransition>
 </Activity>
 ```
+
+### Exclude Elements from a Transition with `useOptimistic`
+
+When a `startTransition` changes both a control (e.g. a button label) and content (e.g. list order), use `useOptimistic` for the control. The optimistic value updates before React's transition snapshot, so it won't animate. The committed state drives the content, which changes within the transition and animates:
+
+```tsx
+const [sort, setSort] = useState('newest');
+const [optimisticSort, setOptimisticSort] = useOptimistic(sort);
+
+function cycleSort() {
+  const nextSort = getNextSort(optimisticSort);
+  startTransition(() => {
+    setOptimisticSort(nextSort);  // updates before snapshot — no animation
+    setSort(nextSort);            // changes within transition — animates
+  });
+}
+
+// Button uses optimisticSort (instant, excluded from animation)
+<button>Sort: {LABELS[optimisticSort]}</button>
+
+// List uses committed sort (changes between snapshots, animates)
+{items.sort(comparators[sort]).map(item => (
+  <ViewTransition key={item.id}>
+    <ItemCard item={item} />
+  </ViewTransition>
+))}
+```
+
+`useOptimistic` values resolve before the transition snapshot. Any DOM driven by optimistic state is already in its final form when the "before" snapshot is taken, so it doesn't participate in the ViewTransition. Only DOM driven by committed state (via `setState`) changes between snapshots and animates.
+
+**Note:** Always add `prefers-reduced-motion` handling to your global CSS — see the Accessibility section below.
 
 ---
 
@@ -587,6 +620,9 @@ Or disable specific animations conditionally in JavaScript events by checking th
 
 **Competing / double animations on navigation:**
 - Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level VT cross-fades the whole page while a page-level VT slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level VT, or remove it entirely if pages manage their own animations. See "How Multiple ViewTransitions Interact" above.
+
+**List reorder not animating with `useOptimistic`:**
+- If the optimistic value drives the list sort order, items are already in their final positions before the transition snapshot — there's nothing to animate. Use the optimistic value only for controls (labels, icons) and the committed state (`useState`) for the list sort order.
 
 **TypeScript error: "Property 'default' is missing in type 'ViewTransitionClassPerType'":**
 - When passing an object to `enter`/`exit`/`update`/`share`, TypeScript requires a `default` key in the object. This applies even if the component-level `default` prop is set. Always include `default: 'none'` (or `'auto'`) in type-keyed objects.

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -206,6 +206,8 @@ React also adds all transition types as browser view transition types, enabling 
 }
 ```
 
+**Caveat:** `::view-transition-old(*)` and `::view-transition-new(*)` match **all** named view transition elements, not just the one you intend. If a Suspense `<ViewTransition>` has its own class-based animation (e.g., `enter="slide-up"`), the wildcard `*` selector can override it depending on CSS specificity. The class-based approach via `<ViewTransition>` props is safer because it only affects the specific boundary. Prefer class-based props for per-component animations and reserve `:active-view-transition-type()` for global, app-wide rules where you want all elements to animate the same way.
+
 ### Using Types with View Transition Events
 
 The `types` array is also available in event callbacks:
@@ -436,9 +438,9 @@ Without `default="none"`, a `<ViewTransition>` with `default="auto"` (the implic
 
 Pick the level that carries the most meaning for your app:
 
-- **App with per-page Suspense reveals and shared elements:** Don't add a layout-level `<ViewTransition>` on `{children}`. The pages already manage their own transitions. A layout-level cross-fade on top will double-animate.
+- **App with per-page Suspense reveals and shared elements:** Don't add a layout-level `<ViewTransition>` on `{children}`. The pages already manage their own transitions. A layout-level cross-fade on top will double-animate. This includes directional (forward/back) navigation — even with `default="none"`, a layout-level slide fires simultaneously with per-page Suspense slide-ups, producing a diagonal movement.
 - **Simple app with no per-page animations:** A layout-level `<ViewTransition>` with `default="auto"` on `{children}` gives you free cross-fades between routes.
-- **Mixed:** Use `default="none"` at the layout level and only activate it for specific `transitionTypes` (e.g., directional navigation). This way it stays silent during per-page Suspense transitions.
+- **Directional navigation only (no per-page VTs):** Use `default="none"` at the layout level and only activate it for specific `transitionTypes`. This works well when pages have no `<ViewTransition>` components of their own.
 
 The exception is **shared element transitions** — these intentionally span levels (one side unmounts while the other mounts) and don't conflict with other VTs because the `share` trigger takes precedence over `enter`/`exit`.
 

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -31,7 +31,7 @@ Route-level transitions (#5) are the lowest priority because the URL change alre
 
 - **Persistent across navigations?** (nav bar, sidebar, header) → Skip VT. Use plain `<Suspense>` if needed.
 - **Expand/collapse that needs to feel spatial?** → Animated collapse with VT + `startTransition`.
-- **Simple show/hide with no spatial meaning?** → `<details>` or conditional render, no VT.
+- **Simple show/hide with no spatial meaning?** → Conditional render, no VT.
 - **Already inside a parent VT?** → Check if `default="none"` is needed to avoid double-animation.
 - **Content that changes on route navigation?** → VT with `default="none"` + explicit triggers.
 
@@ -424,7 +424,7 @@ function AnimatedCollapse({ open, children }) {
 }
 ```
 
-Use it with `startTransition` on the toggle — never with native `<details>`/`<summary>` (which bypasses React state):
+Use it with `startTransition` on the toggle:
 
 ```jsx
 <button onClick={() => startTransition(() => setOpen(o => !o))}>Toggle</button>
@@ -730,9 +730,6 @@ Or disable specific animations conditionally in JavaScript events by checking th
 **Enter/exit not firing in a client component (only updates animate):**
 - `startTransition(() => setState(...))` triggers a Transition, but if the new content isn't behind a `<Suspense>` boundary, React treats the swap as an **update** to the existing tree — not an enter/exit. The `<ViewTransition>` sees its children change but never fully unmounts/remounts, so only `update` animations fire. To get true enter/exit, either conditionally render the `<ViewTransition>` itself (so it mounts/unmounts with the content), or wrap the async content in `<Suspense>` so React can treat the reveal as an insertion.
 
-**ViewTransition not firing on `<details>` toggle:**
-- Native `<details>`/`<summary>` is browser-controlled — open/close bypasses React, so `startTransition` never wraps the toggle and `<ViewTransition>` never fires. This is a trade-off: `<details>` is simpler and more accessible out of the box, but can't be animated with VT. If you need animated expand/collapse, use controlled state with `useState` + `startTransition`. If you don't need the animation, `<details>` is the simpler choice.
-
 **Competing / double animations on navigation:**
 - Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level VT cross-fades the whole page while a page-level VT slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level VT, or remove it entirely if pages manage their own animations. See "How Multiple ViewTransitions Interact" above.
 
@@ -740,7 +737,7 @@ Or disable specific animations conditionally in JavaScript events by checking th
 - When passing an object to `enter`/`exit`/`update`/`share`, TypeScript requires a `default` key in the object. This applies even if the component-level `default` prop is set. Always include `default: 'none'` (or `'auto'`) in type-keyed objects.
 
 **Orphaned CSS after removing ViewTransition:**
-- When removing `<ViewTransition>` components (e.g., switching animated collapse to `<details>`), remember to clean up corresponding `::view-transition-old(...)` / `::view-transition-new(...)` rules and `@keyframes` definitions. These don't cause build errors so they're easy to forget.
+- When removing `<ViewTransition>` components, remember to clean up corresponding `::view-transition-old(...)` / `::view-transition-new(...)` rules and `@keyframes` definitions. These don't cause build errors so they're easy to forget.
 
 **Batching:**
 - If multiple updates occur while an animation is running, React batches them into one. For example: if you navigate A→B, then B→C, then C→D during the first animation, the next animation will go B→D.

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -9,9 +9,7 @@ metadata:
 
 # React View Transitions
 
-React's View Transition API lets you animate between UI states using the browser's native `document.startViewTransition` under the hood. React manages the lifecycle automatically — you declare *what* to animate with `<ViewTransition>`, trigger *when* to animate through `startTransition` / `useDeferredValue` / `Suspense`, and control *how* to animate with CSS classes or JavaScript via the Web Animations API.
-
-The API adds ~3KB to your bundle, runs on the browser's compositor thread for 60fps animations, and gracefully falls back to instant state changes in unsupported browsers.
+React's View Transition API lets you animate between UI states using the browser's native `document.startViewTransition` under the hood. Declare *what* to animate with `<ViewTransition>`, trigger *when* with `startTransition` / `useDeferredValue` / `Suspense`, and control *how* with CSS classes or the Web Animations API. Unsupported browsers skip the animation and apply the DOM change instantly.
 
 ## When to Animate (and When Not To)
 
@@ -37,9 +35,8 @@ Route-level transitions (#5) are the lowest priority because the URL change alre
 
 ## Availability
 
-- `<ViewTransition>` and `addTransitionType` are currently available in `react@canary` and `react@experimental` only — they are **not yet in a stable release**.
-- Install with `npm install react@canary react-dom@canary` (or `@experimental`).
-- Browser support: Chromium-based browsers have full support. Firefox and Safari are adding support. The API gracefully degrades — unsupported browsers skip the animation and apply the DOM change instantly.
+- `<ViewTransition>` and `addTransitionType` require `react@canary` or `react@experimental`. Check `react --version` — if these APIs are not available, install canary: `npm install react@canary react-dom@canary`.
+- Browser support: Chromium 111+, with Firefox and Safari adding support. The API gracefully degrades — unsupported browsers skip the animation and apply the DOM change instantly.
 
 ---
 
@@ -102,11 +99,9 @@ function Item() {
 
 ## Styling Animations with View Transition Classes
 
-Rather than using `view-transition-name` in CSS directly, React recommends providing a **View Transition Class** to the activation props. React applies this class to the child elements when the animation activates.
-
 ### Props
 
-Each prop controls a different trigger. Values can be:
+Each prop controls a different animation trigger. Values can be:
 
 - `"auto"` — use the browser default cross-fade
 - `"none"` — disable this animation type
@@ -357,7 +352,7 @@ Wrap `<Suspense>` in `<ViewTransition>` to cross-fade from fallback to loaded co
 </ViewTransition>
 ```
 
-For directional motion, give the fallback and content separate VTs with explicit triggers. Use `default="none"` on the content VT to prevent it from re-animating on unrelated transitions:
+For directional motion, give the fallback and content separate `<ViewTransition>`s with explicit triggers. Use `default="none"` on the content one to prevent it from re-animating on unrelated transitions:
 
 ```jsx
 <Suspense
@@ -387,102 +382,15 @@ Wrap children in `<ViewTransition update="none">` to prevent them from animating
 </ViewTransition>
 ```
 
-### Isolate Floating Elements from Parent Animations
-
-Popovers, tooltips, and dropdowns can get captured in a parent's view transition snapshot, causing them to ghost or animate unexpectedly. Give them their own `viewTransitionName` to isolate them into a separate transition group:
-
-```jsx
-<SelectPopover style={{ viewTransitionName: 'popover' }}>
-  {options}
-</SelectPopover>
-```
-
-```css
-::view-transition-group(popover) {
-  z-index: 100;
-}
-```
-
-This creates an independent transition group that renders above other transitioning elements. The element won't be included in its parent's old/new snapshot.
-
-### Reusable Animated Collapse
-
-For apps with many expand/collapse interactions, extract a reusable wrapper instead of repeating the conditional-render-with-VT pattern:
-
-```jsx
-import { ViewTransition } from 'react';
-
-function AnimatedCollapse({ open, children }) {
-  if (!open) return null;
-  return (
-    <ViewTransition enter="expand-in" exit="collapse-out">
-      {children}
-    </ViewTransition>
-  );
-}
-```
-
-Use it with `startTransition` on the toggle:
-
-```jsx
-<button onClick={() => startTransition(() => setOpen(o => !o))}>Toggle</button>
-<AnimatedCollapse open={open}>
-  <SectionContent />
-</AnimatedCollapse>
-```
-
-### Preserve State with Activity
-
-Use `<Activity>` with `<ViewTransition>` to animate show/hide while preserving component state:
-
-```jsx
-import { Activity, ViewTransition, startTransition } from 'react';
-
-<Activity mode={isVisible ? 'visible' : 'hidden'}>
-  <ViewTransition enter="slide-in" exit="slide-out">
-    <Sidebar />
-  </ViewTransition>
-</Activity>
-```
-
-### Exclude Elements from a Transition with `useOptimistic`
-
-When a `startTransition` changes both a control (e.g. a button label) and content (e.g. list order), use `useOptimistic` for the control. The optimistic value updates before React's transition snapshot, so it won't animate. The committed state drives the content, which changes within the transition and animates:
-
-```tsx
-const [sort, setSort] = useState('newest');
-const [optimisticSort, setOptimisticSort] = useOptimistic(sort);
-
-function cycleSort() {
-  const nextSort = getNextSort(optimisticSort);
-  startTransition(() => {
-    setOptimisticSort(nextSort);  // updates before snapshot — no animation
-    setSort(nextSort);            // changes within transition — animates
-  });
-}
-
-// Button uses optimisticSort (instant, excluded from animation)
-<button>Sort: {LABELS[optimisticSort]}</button>
-
-// List uses committed sort (changes between snapshots, animates)
-{items.sort(comparators[sort]).map(item => (
-  <ViewTransition key={item.id}>
-    <ItemCard item={item} />
-  </ViewTransition>
-))}
-```
-
-`useOptimistic` values resolve before the transition snapshot. Any DOM driven by optimistic state is already in its final form when the "before" snapshot is taken, so it doesn't participate in the ViewTransition. Only DOM driven by committed state (via `setState`) changes between snapshots and animates.
-
-**Note:** Always add `prefers-reduced-motion` handling to your global CSS — see the Accessibility section below.
+For more patterns (isolate floating elements, reusable animated collapse, preserve state with `<Activity>`, exclude elements with `useOptimistic`), see `references/patterns.md`.
 
 ---
 
-## How Multiple ViewTransitions Interact
+## How Multiple `<ViewTransition>`s Interact
 
 When a transition fires, **every** `<ViewTransition>` in the tree that matches the trigger participates simultaneously. Each gets its own `view-transition-name`, and the browser animates all of them inside a single `document.startViewTransition` call. They run in parallel, not sequentially.
 
-This means a layout-level VT (whole-page cross-fade) + a page-level VT (Suspense slide-up) + per-item VTs (list reorder) all fire at once. The result is usually competing animations that look broken.
+This means a layout-level `<ViewTransition>` (whole-page cross-fade) + a page-level one (Suspense slide-up) + per-item ones (list reorder) all fire at once. The result is usually competing animations that look broken.
 
 ### Use `default="none"` Liberally
 
@@ -516,8 +424,8 @@ Without `default="none"`, a `<ViewTransition>` with `default="auto"` (the implic
 
 Pick the level that carries the most meaning for your app:
 
-- **App with per-page Suspense reveals and shared elements:** Don't add a layout-level VT on `{children}`. The pages already manage their own transitions. A layout-level cross-fade on top will double-animate.
-- **Simple app with no per-page animations:** A layout-level VT with `default="auto"` on `{children}` gives you free cross-fades between routes.
+- **App with per-page Suspense reveals and shared elements:** Don't add a layout-level `<ViewTransition>` on `{children}`. The pages already manage their own transitions. A layout-level cross-fade on top will double-animate.
+- **Simple app with no per-page animations:** A layout-level `<ViewTransition>` with `default="auto"` on `{children}` gives you free cross-fades between routes.
 - **Mixed:** Use `default="none"` at the layout level and only activate it for specific `transitionTypes` (e.g., directional navigation). This way it stays silent during per-page Suspense transitions.
 
 The exception is **shared element transitions** — these intentionally span levels (one side unmounts while the other mounts) and don't conflict with other VTs because the `share` trigger takes precedence over `enter`/`exit`.
@@ -537,15 +445,9 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-**What this flag does:** It wraps every `<Link>` navigation in `document.startViewTransition`, which means all mounted `<ViewTransition>` components in the tree participate in every link navigation — not just ones triggered by `startTransition` or Suspense. This is important:
+**What this flag does:** It wraps every `<Link>` navigation in `document.startViewTransition`, so all mounted `<ViewTransition>` components participate in every link click — not just `startTransition`/Suspense-triggered ones. This makes the composition rules in "How Multiple `<ViewTransition>`s Interact" especially important: use `default="none"` on layout-level `<ViewTransition>`s to avoid competing animations.
 
-- If you have a layout-level VT with `default: "auto"`, it fires on **every** `<Link>` navigation — even ones you didn't intend to animate.
-- Combined with per-page VTs (Suspense reveals, item animations), you get competing animations.
-- Without this flag, only `Suspense`-triggered and `startTransition`-triggered transitions fire.
-
-If your pages manage their own per-page transitions, either (a) don't use a layout-level `<ViewTransition>` on `{children}`, or (b) set `default="none"` on it so it only activates for explicit `transitionTypes`.
-
-For a detailed guide on Next.js integration, including App Router patterns and Server Component considerations, read `references/nextjs.md`.
+For a detailed guide including App Router patterns and Server Component considerations, see `references/nextjs.md`.
 
 Key points:
 - The `<ViewTransition>` component is imported from `react` directly — no Next.js-specific import.
@@ -553,7 +455,7 @@ Key points:
 
 ### The `transitionTypes` prop on `next/link`
 
-As of Next.js 16.2+, `next/link` supports a native `transitionTypes` prop that eliminates the need for custom `TransitionLink` wrapper components. Instead of intercepting navigation with `onNavigate`, `startTransition`, and `addTransitionType`, you pass transition types directly:
+`next/link` supports a native `transitionTypes` prop that eliminates the need for custom `TransitionLink` wrapper components. Instead of intercepting navigation with `onNavigate`, `startTransition`, and `addTransitionType`, you pass transition types directly:
 
 ```tsx
 import Link from 'next/link';
@@ -569,11 +471,9 @@ import Link from 'next/link';
 </Link>
 ```
 
-The `transitionTypes` prop accepts an array of strings — the same types you would pass to `addTransitionType`. This removes the need for `'use client'`, `useRouter`, and custom link components when all you need is to tag a navigation with a transition type. The `<ViewTransition>` components in the tree respond to these types the same way they respond to manual `addTransitionType` calls.
+The `transitionTypes` prop accepts an array of strings — the same types you would pass to `addTransitionType`. This removes the need for `'use client'`, `useRouter`, and custom link components when all you need is to tag a navigation with a transition type.
 
-**Composition note:** `transitionTypes` on `<Link>` works best when you have a single `<ViewTransition>` at the layout level with `default="none"` (so it only fires for your specific types) and no per-page Suspense VTs competing. If your pages have their own Suspense transitions, use `transitionTypes` at the page level (e.g., to distinguish sources of `startTransition` within a client component) rather than at the layout level, or the layout slide and the page's Suspense reveal will both fire simultaneously.
-
-For full examples of `transitionTypes` with shared element transitions and directional animations across routes, see `references/nextjs.md`.
+For full examples with shared element transitions and directional animations, see `references/nextjs.md`.
 
 ---
 
@@ -619,7 +519,7 @@ Or disable specific animations conditionally in JavaScript events by checking th
 - `startTransition(() => setState(...))` triggers a Transition, but if the new content isn't behind a `<Suspense>` boundary, React treats the swap as an **update** to the existing tree — not an enter/exit. The `<ViewTransition>` sees its children change but never fully unmounts/remounts, so only `update` animations fire. To get true enter/exit, either conditionally render the `<ViewTransition>` itself (so it mounts/unmounts with the content), or wrap the async content in `<Suspense>` so React can treat the reveal as an insertion.
 
 **Competing / double animations on navigation:**
-- Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level VT cross-fades the whole page while a page-level VT slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level VT, or remove it entirely if pages manage their own animations. See "How Multiple ViewTransitions Interact" above.
+- Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level one cross-fades the whole page while a page-level one slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level `<ViewTransition>`, or remove it entirely if pages manage their own animations. See "How Multiple `<ViewTransition>`s Interact" above.
 
 **List reorder not animating with `useOptimistic`:**
 - If the optimistic value drives the list sort order, items are already in their final positions before the transition snapshot — there's nothing to animate. Use the optimistic value only for controls (labels, icons) and the committed state (`useState`) for the list sort order.

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -27,6 +27,14 @@ From highest value to lowest — start from the top and only move down if your a
 
 Route-level transitions (#5) are the lowest priority because the URL change already signals a context switch. A blanket cross-fade on every navigation says nothing — it's visual noise. Prefer specific, intentional animations (#1–#4) over ambient page transitions.
 
+### Should This Element Use ViewTransition?
+
+- **Persistent across navigations?** (nav bar, sidebar, header) → Skip VT. Use plain `<Suspense>` if needed.
+- **Expand/collapse that needs to feel spatial?** → Animated collapse with VT + `startTransition`.
+- **Simple show/hide with no spatial meaning?** → `<details>` or conditional render, no VT.
+- **Already inside a parent VT?** → Check if `default="none"` is needed to avoid double-animation.
+- **Content that changes on route navigation?** → VT with `default="none"` + explicit triggers.
+
 **Rule of thumb:** at any given moment, only one level of the tree should be visually transitioning. If your pages already manage their own Suspense reveals or shared element morphs, adding a layout-level route transition on top produces double-animation where both levels fight for attention.
 
 ---
@@ -495,6 +503,12 @@ When combining directional layout VTs with per-page Suspense VTs, set `default="
 
 This ensures each VT stays silent except for its intended trigger, even when `viewTransition: true` makes every `<Link>` navigation activate all mounted VTs.
 
+Note: `default="none"` on content VTs is also critical when the content itself contains `<Link>` elements with `transitionTypes`. Without it, clicking a typed link inside the content would cause the content's own VT to re-animate (cross-fade) alongside the layout-level directional slide.
+
+### Persistent Layout Chrome
+
+Nav bars, headers, sidebars, and other layout elements that load once and don't change across navigations should generally **not** be wrapped in `<ViewTransition>`. Even if they're behind `<Suspense>` for initial data loading (auth checks, etc.), the one-time skeleton-to-content swap is barely perceptible. Wrapping them in VT causes them to re-animate on every `<Link>` navigation when `viewTransition: true` is enabled. Use plain `<Suspense fallback={<Skeleton />}>` without VT for these.
+
 ---
 
 ## Next.js Integration
@@ -552,18 +566,16 @@ For full examples of `transitionTypes` with shared element transitions and direc
 
 ## Real-World Patterns
 
-These patterns are drawn from production Next.js apps using View Transitions.
+### Searchable Grid with `useDeferredValue`
 
-### List-to-Detail with `useDeferredValue` and `ViewTransition`
-
-A common pattern is a client-side searchable grid where items expand into a detail view. Wrap each item in `<ViewTransition>` and use `useDeferredValue` to trigger animated updates as the user types:
+A client-side searchable grid where the filtered results cross-fade as the user types. `useDeferredValue` makes the filter update a transition, which activates the wrapping `<ViewTransition>`:
 
 ```tsx
 'use client';
 
 import { useDeferredValue, useState, ViewTransition, Suspense } from 'react';
 
-export default function TalksExplorer({ talksPromise }) {
+export default function SearchableGrid({ itemsPromise }) {
   const [search, setSearch] = useState('');
   const deferredSearch = useDeferredValue(search);
 
@@ -572,19 +584,17 @@ export default function TalksExplorer({ talksPromise }) {
       <input
         value={search}
         onChange={(e) => setSearch(e.currentTarget.value)}
-        placeholder="Search talks..."
+        placeholder="Search..."
       />
       <ViewTransition>
         <Suspense fallback={<GridSkeleton />}>
-          <TalksGrid talksPromise={talksPromise} search={deferredSearch} />
+          <ItemGrid itemsPromise={itemsPromise} search={deferredSearch} />
         </Suspense>
       </ViewTransition>
     </>
   );
 }
 ```
-
-When `deferredSearch` updates (deferred from the search input), React treats it as a transition and the `<ViewTransition>` wrapping the `<Suspense>` boundary cross-fades between the old and new grid content.
 
 ### Card Expand/Collapse with `startTransition`
 
@@ -595,29 +605,29 @@ Toggle between a card grid and a detail view using `startTransition` to animate 
 
 import { useState, startTransition, ViewTransition } from 'react';
 
-export default function TalksGrid({ talks }) {
-  const [expandedTalkId, setExpandedTalkId] = useState(null);
+export default function ItemGrid({ items }) {
+  const [expandedId, setExpandedId] = useState(null);
 
-  return expandedTalkId ? (
+  return expandedId ? (
     <ViewTransition enter="slide-up" exit="slide-down">
-      <TalkDetails
-        talk={talks.find(t => t.id === expandedTalkId)}
-        closeAction={() => {
+      <ItemDetail
+        item={items.find(i => i.id === expandedId)}
+        onClose={() => {
           startTransition(() => {
-            setExpandedTalkId(null);
+            setExpandedId(null);
           });
         }}
       />
     </ViewTransition>
   ) : (
     <div className="grid grid-cols-3 gap-4">
-      {talks.map(talk => (
-        <ViewTransition key={talk.id}>
-          <TalkCard
-            talk={talk}
+      {items.map(item => (
+        <ViewTransition key={item.id}>
+          <ItemCard
+            item={item}
             onSelect={() => {
               startTransition(() => {
-                setExpandedTalkId(talk.id);
+                setExpandedId(item.id);
               });
             }}
           />
@@ -721,10 +731,16 @@ Or disable specific animations conditionally in JavaScript events by checking th
 - `startTransition(() => setState(...))` triggers a Transition, but if the new content isn't behind a `<Suspense>` boundary, React treats the swap as an **update** to the existing tree — not an enter/exit. The `<ViewTransition>` sees its children change but never fully unmounts/remounts, so only `update` animations fire. To get true enter/exit, either conditionally render the `<ViewTransition>` itself (so it mounts/unmounts with the content), or wrap the async content in `<Suspense>` so React can treat the reveal as an insertion.
 
 **ViewTransition not firing on `<details>` toggle:**
-- Native `<details>`/`<summary>` elements are browser-controlled — their open/close state bypasses React entirely, so `startTransition` never wraps the toggle and `<ViewTransition>` never fires. Convert to controlled state with `useState` + `startTransition` + a `<button>` for animated expand/collapse (see the "Reusable Animated Collapse" pattern above).
+- Native `<details>`/`<summary>` is browser-controlled — open/close bypasses React, so `startTransition` never wraps the toggle and `<ViewTransition>` never fires. This is a trade-off: `<details>` is simpler and more accessible out of the box, but can't be animated with VT. If you need animated expand/collapse, use controlled state with `useState` + `startTransition`. If you don't need the animation, `<details>` is the simpler choice.
 
 **Competing / double animations on navigation:**
 - Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level VT cross-fades the whole page while a page-level VT slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level VT, or remove it entirely if pages manage their own animations. See "How Multiple ViewTransitions Interact" above.
+
+**TypeScript error: "Property 'default' is missing in type 'ViewTransitionClassPerType'":**
+- When passing an object to `enter`/`exit`/`update`/`share`, TypeScript requires a `default` key in the object. This applies even if the component-level `default` prop is set. Always include `default: 'none'` (or `'auto'`) in type-keyed objects.
+
+**Orphaned CSS after removing ViewTransition:**
+- When removing `<ViewTransition>` components (e.g., switching animated collapse to `<details>`), remember to clean up corresponding `::view-transition-old(...)` / `::view-transition-new(...)` rules and `@keyframes` definitions. These don't cause build errors so they're easy to forget.
 
 **Batching:**
 - If multiple updates occur while an animation is running, React batches them into one. For example: if you navigate A→B, then B→C, then C→D during the first animation, the next animation will go B→D.

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -343,8 +343,6 @@ For directional motion, give the fallback and content separate `<ViewTransition>
 
 **Why `exit` on the fallback and `enter` on the content?** When Suspense resolves, two things happen simultaneously in one transition: the fallback unmounts (exit) and the content mounts (enter). The fallback slides down and fades out while the content slides up and fades in — creating a smooth handoff. The staggered CSS timing (`enter` delays by the `exit` duration) ensures the skeleton leaves before new content arrives.
 
-**Skeleton dimensions should closely match the content.** If the skeleton renders 3 single-line items but the content renders 5 two-line items, the size difference between the old/new snapshots produces a jarring stagger rather than a smooth transition.
-
 ### Opt Out of Nested Animations
 
 Wrap children in `<ViewTransition update="none">` to prevent them from animating when a parent changes:

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -1,17 +1,6 @@
 ---
-name: vercel-react-view-transitions
-description:
-  Guide for implementing smooth, native-feeling animations using React's View
-  Transition API. Use when adding page transitions, animating route changes,
-  creating shared element animations, animating enter/exit of components,
-  list reorder, directional navigation animations, or integrating view
-  transitions in Next.js. Triggers on view transitions, ViewTransition,
-  addTransitionType, transition types, transitionTypes, or animating between
-  UI states in React without third-party animation libraries.
-license: MIT
-metadata:
-  author: vercel
-  version: '1.0.0'
+name: react-view-transition
+description: Guide for implementing smooth, native-feeling animations using React's View Transition API (`<ViewTransition>` component, `addTransitionType`, and CSS view transition pseudo-elements). Use this skill whenever the user wants to add page transitions, animate route changes, create shared element animations, animate enter/exit of components, animate list reorder, implement directional (forward/back) navigation animations, or integrate view transitions in Next.js. Also use when the user mentions view transitions, `startViewTransition`, `ViewTransition`, transition types, or asks about animating between UI states in React without third-party animation libraries.
 ---
 
 # React View Transitions
@@ -19,6 +8,28 @@ metadata:
 React's View Transition API lets you animate between UI states using the browser's native `document.startViewTransition` under the hood. React manages the lifecycle automatically — you declare *what* to animate with `<ViewTransition>`, trigger *when* to animate through `startTransition` / `useDeferredValue` / `Suspense`, and control *how* to animate with CSS classes or JavaScript via the Web Animations API.
 
 The API adds ~3KB to your bundle, runs on the browser's compositor thread for 60fps animations, and gracefully falls back to instant state changes in unsupported browsers.
+
+## When to Animate (and When Not To)
+
+Every `<ViewTransition>` should answer: **what spatial relationship or continuity does this animation communicate to the user?** If you can't articulate it, don't add it.
+
+### Hierarchy of Animation Intent
+
+From highest value to lowest — start from the top and only move down if your app doesn't already have animations at that level:
+
+| Priority | Pattern | What it communicates | Example |
+|----------|---------|---------------------|---------|
+| 1 | **Shared element** (`name`) | "This is the same thing — I'm going deeper" | List thumbnail morphs into detail hero |
+| 2 | **Suspense reveal** | "Data loaded, here's the real content" | Skeleton cross-fades into loaded page |
+| 3 | **List identity** (per-item `key`) | "Same items, new arrangement" | Cards reorder during sort/filter |
+| 4 | **State change** (`enter`/`exit`) | "Something appeared or disappeared" | Panel slides in on toggle |
+| 5 | **Route change** (layout-level) | "Going to a new place" | Cross-fade between pages |
+
+Route-level transitions (#5) are the lowest priority because the URL change already signals a context switch. A blanket cross-fade on every navigation says nothing — it's visual noise. Prefer specific, intentional animations (#1–#4) over ambient page transitions.
+
+**Rule of thumb:** at any given moment, only one level of the tree should be visually transitioning. If your pages already manage their own Suspense reveals or shared element morphs, adding a layout-level route transition on top produces double-animation where both levels fight for attention.
+
+---
 
 ## Availability
 
@@ -370,6 +381,48 @@ import { Activity, ViewTransition, startTransition } from 'react';
 
 ---
 
+## How Multiple ViewTransitions Interact
+
+When a transition fires, **every** `<ViewTransition>` in the tree that matches the trigger participates simultaneously. Each gets its own `view-transition-name`, and the browser animates all of them inside a single `document.startViewTransition` call. They run in parallel, not sequentially.
+
+This means a layout-level VT (whole-page cross-fade) + a page-level VT (Suspense slide-up) + per-item VTs (list reorder) all fire at once. The result is usually competing animations that look broken.
+
+### Use `default="none"` Liberally
+
+Prevent unintended animations by disabling the default trigger on ViewTransitions that should only fire for specific types:
+
+```jsx
+// Only animates when 'navigation-forward' or 'navigation-back' types are present.
+// Silent on all other transitions (Suspense reveals, state changes, etc.)
+<ViewTransition
+  default="none"
+  enter={{
+    'navigation-forward': 'slide-in-from-right',
+    'navigation-back': 'slide-in-from-left',
+  }}
+  exit={{
+    'navigation-forward': 'slide-out-to-left',
+    'navigation-back': 'slide-out-to-right',
+  }}
+>
+  {children}
+</ViewTransition>
+```
+
+Without `default="none"`, a `<ViewTransition>` with `default="auto"` (the implicit default) fires the browser's cross-fade on **every** transition — including ones triggered by child Suspense boundaries, `useDeferredValue` updates, or `startTransition` calls within the page.
+
+### Choosing One Level
+
+Pick the level that carries the most meaning for your app:
+
+- **App with per-page Suspense reveals and shared elements:** Don't add a layout-level VT on `{children}`. The pages already manage their own transitions. A layout-level cross-fade on top will double-animate.
+- **Simple app with no per-page animations:** A layout-level VT with `default="auto"` on `{children}` gives you free cross-fades between routes.
+- **Mixed:** Use `default="none"` at the layout level and only activate it for specific `transitionTypes` (e.g., directional navigation). This way it stays silent during per-page Suspense transitions.
+
+The exception is **shared element transitions** — these intentionally span levels (one side unmounts while the other mounts) and don't conflict with other VTs because the `share` trigger takes precedence over `enter`/`exit`.
+
+---
+
 ## Next.js Integration
 
 Next.js supports React View Transitions. Enable it in `next.config.js` (or `next.config.ts`):
@@ -383,12 +436,18 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
+**What this flag does:** It wraps every `<Link>` navigation in `document.startViewTransition`, which means all mounted `<ViewTransition>` components in the tree participate in every link navigation — not just ones triggered by `startTransition` or Suspense. This is important:
+
+- If you have a layout-level VT with `default: "auto"`, it fires on **every** `<Link>` navigation — even ones you didn't intend to animate.
+- Combined with per-page VTs (Suspense reveals, item animations), you get competing animations.
+- Without this flag, only `Suspense`-triggered and `startTransition`-triggered transitions fire.
+
+If your pages manage their own per-page transitions, either (a) don't use a layout-level `<ViewTransition>` on `{children}`, or (b) set `default="none"` on it so it only activates for explicit `transitionTypes`.
+
 For a detailed guide on Next.js integration, including App Router patterns and Server Component considerations, read `references/nextjs.md`.
 
 Key points:
 - The `<ViewTransition>` component is imported from `react` directly — no Next.js-specific import.
-- The `experimental.viewTransition` flag enables deeper integration with Next.js features beyond what `<ViewTransition>` provides on its own.
-- Wrap page content in `<ViewTransition>` inside the layout to animate route transitions.
 - Works with the App Router and `startTransition` + `router.push()` for programmatic navigation.
 
 ### The `transitionTypes` prop on `next/link`
@@ -410,6 +469,8 @@ import Link from 'next/link';
 ```
 
 The `transitionTypes` prop accepts an array of strings — the same types you would pass to `addTransitionType`. This removes the need for `'use client'`, `useRouter`, and custom link components when all you need is to tag a navigation with a transition type. The `<ViewTransition>` components in the tree respond to these types the same way they respond to manual `addTransitionType` calls.
+
+**Composition note:** `transitionTypes` on `<Link>` works best when you have a single `<ViewTransition>` at the layout level with `default="none"` (so it only fires for your specific types) and no per-page Suspense VTs competing. If your pages have their own Suspense transitions, use `transitionTypes` at the page level (e.g., to distinguish sources of `startTransition` within a client component) rather than at the layout level, or the layout slide and the page's Suspense reveal will both fire simultaneously.
 
 For full examples of `transitionTypes` with shared element transitions and directional animations across routes, see `references/nextjs.md`.
 
@@ -581,6 +642,9 @@ Or disable specific animations conditionally in JavaScript events by checking th
 
 **Animations from `flushSync` are skipped:**
 - `flushSync` completes synchronously, which prevents view transitions from running. Use `startTransition` instead.
+
+**Competing / double animations on navigation:**
+- Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level VT cross-fades the whole page while a page-level VT slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level VT, or remove it entirely if pages manage their own animations. See "How Multiple ViewTransitions Interact" above.
 
 **Batching:**
 - If multiple updates occur while an animation is running, React batches them into one. For example: if you navigate A→B, then B→C, then C→D during the first animation, the next animation will go B→D.

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -340,6 +340,18 @@ Triggering the reorder inside `startTransition` will smoothly animate each item 
 
 **How it works:** `startTransition` doesn't need async work to animate. The View Transition API captures a "before" snapshot of the DOM, then React applies the state update, and the API captures an "after" snapshot. As long as items change position between snapshots, the animation runs — even for purely synchronous local state changes like sorting.
 
+### Force Re-Enter with `key`
+
+Use a `key` prop on `<ViewTransition>` to force an enter/exit animation when a value changes — even if the component itself doesn't unmount:
+
+```jsx
+<ViewTransition key={searchParams.toString()} enter="slide-up" exit="slide-down" default="none">
+  <ResultsGrid results={results} />
+</ViewTransition>
+```
+
+When the key changes, React unmounts and remounts the `<ViewTransition>`, which triggers exit on the old instance and enter on the new one. This is useful for animating content swaps driven by URL parameters, tab switches, or any state change where the content identity changes but the component type stays the same.
+
 ### Animate Suspense Fallback to Content
 
 Wrap `<Suspense>` in `<ViewTransition>` to cross-fade from fallback to loaded content:
@@ -434,7 +446,9 @@ The exception is **shared element transitions** — these intentionally span lev
 
 ## Next.js Integration
 
-Next.js supports React View Transitions. Enable it in `next.config.js` (or `next.config.ts`):
+Next.js supports React View Transitions. `<ViewTransition>` works out of the box for `startTransition`- and `Suspense`-triggered updates — no config needed.
+
+To also animate `<Link>` navigations, enable the experimental flag in `next.config.js` (or `next.config.ts`):
 
 ```js
 const nextConfig = {
@@ -445,7 +459,7 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-**What this flag does:** It wraps every `<Link>` navigation in `document.startViewTransition`, so all mounted `<ViewTransition>` components participate in every link click — not just `startTransition`/Suspense-triggered ones. This makes the composition rules in "How Multiple `<ViewTransition>`s Interact" especially important: use `default="none"` on layout-level `<ViewTransition>`s to avoid competing animations.
+**What this flag does:** It wraps every `<Link>` navigation in `document.startViewTransition`, so all mounted `<ViewTransition>` components participate in every link click. Without this flag, only `startTransition`/`Suspense`-triggered transitions animate. This makes the composition rules in "How Multiple `<ViewTransition>`s Interact" especially important: use `default="none"` on layout-level `<ViewTransition>`s to avoid competing animations.
 
 For a detailed guide including App Router patterns and Server Component considerations, see `references/nextjs.md`.
 
@@ -490,8 +504,10 @@ Always respect `prefers-reduced-motion`. React does not disable animations autom
 ```css
 @media (prefers-reduced-motion: reduce) {
   ::view-transition-old(*),
-  ::view-transition-new(*) {
+  ::view-transition-new(*),
+  ::view-transition-group(*) {
     animation-duration: 0s !important;
+    animation-delay: 0s !important;
   }
 }
 ```

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -643,6 +643,9 @@ Or disable specific animations conditionally in JavaScript events by checking th
 **Animations from `flushSync` are skipped:**
 - `flushSync` completes synchronously, which prevents view transitions from running. Use `startTransition` instead.
 
+**Enter/exit not firing in a client component (only updates animate):**
+- `startTransition(() => setState(...))` triggers a Transition, but if the new content isn't behind a `<Suspense>` boundary, React treats the swap as an **update** to the existing tree — not an enter/exit. The `<ViewTransition>` sees its children change but never fully unmounts/remounts, so only `update` animations fire. To get true enter/exit, either conditionally render the `<ViewTransition>` itself (so it mounts/unmounts with the content), or wrap the async content in `<Suspense>` so React can treat the reveal as an insertion.
+
 **Competing / double animations on navigation:**
 - Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level VT cross-fades the whole page while a page-level VT slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level VT, or remove it entirely if pages manage their own animations. See "How Multiple ViewTransitions Interact" above.
 

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: vercel-react-view-transitions
 description: Guide for implementing smooth, native-feeling animations using React's View Transition API (`<ViewTransition>` component, `addTransitionType`, and CSS view transition pseudo-elements). Use this skill whenever the user wants to add page transitions, animate route changes, create shared element animations, animate enter/exit of components, animate list reorder, implement directional (forward/back) navigation animations, or integrate view transitions in Next.js. Also use when the user mentions view transitions, `startViewTransition`, `ViewTransition`, transition types, or asks about animating between UI states in React without third-party animation libraries.
+license: MIT
+metadata:
+  author: vercel
+  version: "1.0.0"
 ---
 
 # React View Transitions
@@ -485,7 +489,6 @@ Pick the level that carries the most meaning for your app:
 
 The exception is **shared element transitions** — these intentionally span levels (one side unmounts while the other mounts) and don't conflict with other VTs because the `share` trigger takes precedence over `enter`/`exit`.
 
-
 ---
 
 ## Next.js Integration
@@ -543,132 +546,7 @@ For full examples of `transitionTypes` with shared element transitions and direc
 
 ## Real-World Patterns
 
-### Searchable Grid with `useDeferredValue`
-
-A client-side searchable grid where the filtered results cross-fade as the user types. `useDeferredValue` makes the filter update a transition, which activates the wrapping `<ViewTransition>`:
-
-```tsx
-'use client';
-
-import { useDeferredValue, useState, ViewTransition, Suspense } from 'react';
-
-export default function SearchableGrid({ itemsPromise }) {
-  const [search, setSearch] = useState('');
-  const deferredSearch = useDeferredValue(search);
-
-  return (
-    <>
-      <input
-        value={search}
-        onChange={(e) => setSearch(e.currentTarget.value)}
-        placeholder="Search..."
-      />
-      <ViewTransition>
-        <Suspense fallback={<GridSkeleton />}>
-          <ItemGrid itemsPromise={itemsPromise} search={deferredSearch} />
-        </Suspense>
-      </ViewTransition>
-    </>
-  );
-}
-```
-
-### Card Expand/Collapse with `startTransition`
-
-Toggle between a card grid and a detail view using `startTransition` to animate the swap:
-
-```tsx
-'use client';
-
-import { useState, startTransition, ViewTransition } from 'react';
-
-export default function ItemGrid({ items }) {
-  const [expandedId, setExpandedId] = useState(null);
-
-  return expandedId ? (
-    <ViewTransition enter="slide-up" exit="slide-down">
-      <ItemDetail
-        item={items.find(i => i.id === expandedId)}
-        onClose={() => {
-          startTransition(() => {
-            setExpandedId(null);
-          });
-        }}
-      />
-    </ViewTransition>
-  ) : (
-    <div className="grid grid-cols-3 gap-4">
-      {items.map(item => (
-        <ViewTransition key={item.id}>
-          <ItemCard
-            item={item}
-            onSelect={() => {
-              startTransition(() => {
-                setExpandedId(item.id);
-              });
-            }}
-          />
-        </ViewTransition>
-      ))}
-    </div>
-  );
-}
-```
-
-The CSS for slide-up/slide-down enter/exit:
-
-```css
-::view-transition-old(.slide-down) {
-  animation: 150ms ease-out both fade-out, 150ms ease-out both slide-down;
-}
-::view-transition-new(.slide-up) {
-  animation: 210ms ease-in 150ms both fade-in, 400ms ease-in both slide-up;
-}
-
-@keyframes slide-up {
-  from { transform: translateY(10px); }
-  to { transform: translateY(0); }
-}
-@keyframes slide-down {
-  from { transform: translateY(0); }
-  to { transform: translateY(10px); }
-}
-@keyframes fade-in {
-  from { opacity: 0; }
-}
-@keyframes fade-out {
-  to { opacity: 0; }
-}
-```
-
-### Type-Safe Transition Helpers
-
-For larger apps, define type-safe transition IDs and transition maps to prevent ID clashes and keep animation configurations consistent. Use `as const` arrays for transition IDs, types, and animation classes, then derive types from them:
-
-```tsx
-import { ViewTransition } from 'react';
-
-const transitionTypes = ['default', 'transition-to-detail', 'transition-to-list', 'transition-backwards', 'transition-forwards'] as const;
-const animationTypes = ['auto', 'none', 'animate-slide-from-left', 'animate-slide-from-right', 'animate-slide-to-left', 'animate-slide-to-right'] as const;
-
-type TransitionType = (typeof transitionTypes)[number];
-type AnimationType = (typeof animationTypes)[number];
-type TransitionMap = { default: AnimationType } & Partial<Record<Exclude<TransitionType, 'default'>, AnimationType>>;
-
-export function HorizontalTransition({ children, enter, exit }: {
-  children: React.ReactNode;
-  enter: TransitionMap;
-  exit: TransitionMap;
-}) {
-  return <ViewTransition enter={enter} exit={exit}>{children}</ViewTransition>;
-}
-```
-
-These wrappers enforce that only valid transition IDs and animation classes are used, catching mistakes at compile time. See the Next.js App Router Playground (`vercel/next-app-router-playground`) for a complete example of this pattern.
-
-### Shared Elements Across Routes in Next.js
-
-See `references/nextjs.md` (Shared Elements Across Routes) for complete examples using `transitionTypes` on `next/link` combined with shared element `<ViewTransition name={...}>` for list-to-detail image morph animations.
+For complete real-world patterns (searchable grids, card expand/collapse, type-safe transition helpers, shared elements across routes), see `references/patterns.md`.
 
 ---
 
@@ -718,21 +596,8 @@ Or disable specific animations conditionally in JavaScript events by checking th
 
 ---
 
-## Animation Timing Guidelines
+## Reference Files
 
-Match duration to the interaction type — direct user actions need fast feedback, while ambient reveals can be slower:
-
-| Interaction | Duration | Rationale |
-|------------|----------|-----------|
-| Direct toggle (expand/collapse, show/hide) | 100–200ms | Responds to a click — must feel instant |
-| Route transition (directional slide) | 150–250ms | Brief spatial cue, shouldn't delay navigation |
-| Suspense reveal (skeleton → content) | 200–400ms | Soft reveal, content is "arriving" |
-| Shared element morph | 300–500ms | Users watch the morph — give it room to breathe |
-
-These are starting points. Test on low-end devices — animations that feel smooth on a fast machine can feel sluggish on mobile.
-
----
-
-## CSS Recipe Reference
-
-For ready-to-use CSS animation recipes (slide, fade, scale, flip, and combined patterns), see `references/css-recipes.md`.
+- **`references/patterns.md`** — Real-world patterns (searchable grids, expand/collapse, type-safe helpers) and animation timing guidelines.
+- **`references/css-recipes.md`** — Ready-to-use CSS animation recipes (slide, fade, scale, flip, and combined patterns).
+- **`references/nextjs.md`** — Detailed Next.js integration guide with App Router patterns and Server Component considerations.

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -325,7 +325,9 @@ The simplest approach: wrap `<Suspense>` in a single `<ViewTransition>` for a ze
 </ViewTransition>
 ```
 
-For directional motion, give the fallback and content separate `<ViewTransition>`s. Use `default="none"` on the content to prevent re-animation on revalidation:
+**This only works reliably when the page has a single Suspense boundary and no other transitions.** The bare `<ViewTransition>` uses `default="auto"` implicitly, which means it participates in *every* `document.startViewTransition` on the page — not just its own Suspense resolve. If other Suspense boundaries, `useDeferredValue` updates, or navigations fire, this VT re-animates each time. For pages with multiple Suspense boundaries or any client components, use the split pattern below instead.
+
+For directional motion (or multi-Suspense pages), give the fallback and content separate `<ViewTransition>`s. Use `default="none"` on the content to prevent re-animation on revalidation:
 
 ```jsx
 <Suspense

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -50,7 +50,7 @@ When in doubt, use a bare `<ViewTransition>` (default cross-fade) or `default="n
 
 ## Availability
 
-- `<ViewTransition>` and `addTransitionType` require `react@canary` or `react@experimental`. Check `react --version` — if these APIs are not available, install canary: `npm install react@canary react-dom@canary`.
+- `<ViewTransition>` and `addTransitionType` require `react@canary` or `react@experimental`. They are **not** in stable React (including 19.x). Before implementing, verify the project uses canary — check `package.json` for `"react": "canary"` or run `npm ls react`. If on stable, install canary: `npm install react@canary react-dom@canary`.
 - Browser support: Chromium 111+, with Firefox and Safari adding support. The API gracefully degrades — unsupported browsers skip the animation and apply the DOM change instantly.
 
 ---

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -341,7 +341,25 @@ Triggering the reorder inside `startTransition` will smoothly animate each item 
 
 ### Animate Suspense Fallback to Content
 
-Wrap `<Suspense>` in `<ViewTransition>` to cross-fade from fallback to loaded content:
+The production pattern is to give the fallback an **exit-only** animation and the content an **enter-only** animation with `default="none"`. This is more intentional than a blanket crossfade and prevents the content VT from re-animating on every subsequent route navigation:
+
+```jsx
+<Suspense
+  fallback={
+    <ViewTransition exit="slide-down">
+      <Skeleton />
+    </ViewTransition>
+  }
+>
+  <ViewTransition default="none" enter="slide-up">
+    <AsyncContent />
+  </ViewTransition>
+</Suspense>
+```
+
+The skeleton slides down when content replaces it (`exit`). The content slides up when it first appears (`enter`). `default="none"` on the content VT ensures it stays silent during unrelated transitions (e.g., link navigations that trigger the layout-level VT).
+
+For a simple crossfade without directional motion, wrap the whole `<Suspense>` instead:
 
 ```jsx
 <ViewTransition>
@@ -364,6 +382,24 @@ Wrap children in `<ViewTransition update="none">` to prevent them from animating
   </div>
 </ViewTransition>
 ```
+
+### Isolate Floating Elements from Parent Animations
+
+Popovers, tooltips, and dropdowns can get captured in a parent's view transition snapshot, causing them to ghost or animate unexpectedly. Give them their own `viewTransitionName` to isolate them into a separate transition group:
+
+```jsx
+<SelectPopover style={{ viewTransitionName: 'popover' }}>
+  {options}
+</SelectPopover>
+```
+
+```css
+::view-transition-group(popover) {
+  z-index: 100;
+}
+```
+
+This creates an independent transition group that renders above other transitioning elements. The element won't be included in its parent's old/new snapshot.
 
 ### Reusable Animated Collapse
 

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -325,9 +325,7 @@ The simplest approach: wrap `<Suspense>` in a single `<ViewTransition>` for a ze
 </ViewTransition>
 ```
 
-**This only works reliably when the page has a single Suspense boundary and no other transitions.** The bare `<ViewTransition>` uses `default="auto"` implicitly, which means it participates in *every* `document.startViewTransition` on the page — not just its own Suspense resolve. If other Suspense boundaries, `useDeferredValue` updates, or navigations fire, this VT re-animates each time. For pages with multiple Suspense boundaries or any client components, use the split pattern below instead.
-
-For directional motion (or multi-Suspense pages), give the fallback and content separate `<ViewTransition>`s. Use `default="none"` on the content to prevent re-animation on revalidation:
+For directional motion, give the fallback and content separate `<ViewTransition>`s. Use `default="none"` on the content to prevent re-animation on revalidation:
 
 ```jsx
 <Suspense

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: react-view-transition
+name: vercel-react-view-transitions
 description: Guide for implementing smooth, native-feeling animations using React's View Transition API (`<ViewTransition>` component, `addTransitionType`, and CSS view transition pseudo-elements). Use this skill whenever the user wants to add page transitions, animate route changes, create shared element animations, animate enter/exit of components, animate list reorder, implement directional (forward/back) navigation animations, or integrate view transitions in Next.js. Also use when the user mentions view transitions, `startViewTransition`, `ViewTransition`, transition types, or asks about animating between UI states in React without third-party animation libraries.
 ---
 

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -37,8 +37,8 @@ Route-level transitions (#5) are the lowest priority because the URL change alre
 
 ## Availability
 
-- `<ViewTransition>` and `addTransitionType` shipped in **React 19.2** (stable).
-- For older React 19 versions, both are available in `react@canary` and `react@experimental`.
+- `<ViewTransition>` and `addTransitionType` are currently available in `react@canary` and `react@experimental` only — they are **not yet in a stable release**.
+- Install with `npm install react@canary react-dom@canary` (or `@experimental`).
 - Browser support: Chromium-based browsers have full support. Firefox and Safari are adding support. The API gracefully degrades — unsupported browsers skip the animation and apply the DOM change instantly.
 
 ---

--- a/skills/react-view-transitions/metadata.json
+++ b/skills/react-view-transitions/metadata.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.0.0",
+  "organization": "Vercel Engineering",
+  "date": "March 2026",
+  "abstract": "Guide for implementing smooth, native-feeling animations using React's View Transition API. Covers the <ViewTransition> component, addTransitionType, CSS view transition pseudo-elements, shared element transitions, JavaScript animations via Web Animations API, and Next.js integration including the transitionTypes prop on next/link. Includes ready-to-use CSS animation recipes and real-world patterns from production Next.js apps.",
+  "references": [
+    "https://react.dev/reference/react/ViewTransition",
+    "https://react.dev/reference/react/addTransitionType",
+    "https://nextjs.org/docs/app/api-reference/config/next-config-js/viewTransition",
+    "https://github.com/aurorascharff/next16-conferences",
+    "https://github.com/vercel/next-app-router-playground/tree/main/app/view-transitions"
+  ]
+}

--- a/skills/react-view-transitions/references/css-recipes.md
+++ b/skills/react-view-transitions/references/css-recipes.md
@@ -107,7 +107,52 @@ Usage:
 
 ## Directional Navigation
 
-A single CSS class name targets both `::view-transition-old` and `::view-transition-new` with different animations. This keeps the JSX simple — `enter="nav-forward"` / `exit="nav-forward"`:
+### Separate Enter/Exit Classes
+
+Used with the two-layer pattern where `enter` and `exit` map to different class names:
+
+```css
+::view-transition-new(.slide-from-right) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+::view-transition-old(.slide-to-left) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+
+::view-transition-new(.slide-from-left) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+::view-transition-old(.slide-to-right) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+```
+
+Usage with the two-layer pattern:
+```jsx
+<ViewTransition
+  enter={{ "nav-forward": "slide-from-right", default: "none" }}
+  exit={{ "nav-forward": "slide-to-left", default: "none" }}
+  default="none"
+>
+  {children}
+</ViewTransition>
+```
+
+### Single-Class Approach
+
+Alternatively, a single CSS class name targets both `::view-transition-old` and `::view-transition-new` with different animations. This keeps the JSX simple — `enter="nav-forward"` / `exit="nav-forward"`:
 
 ```css
 ::view-transition-old(.nav-forward) {
@@ -224,6 +269,19 @@ Usage:
 Usage:
 ```jsx
 <ViewTransition enter="scale-in" exit="scale-out" />
+```
+
+---
+
+## Persistent Element Isolation
+
+Prevent sticky headers, navbars, and sidebars from being captured in page content's transition snapshot. Give them a `viewTransitionName` in JSX, then disable animation on their group:
+
+```css
+::view-transition-group(dashboard-header) {
+  animation: none;
+  z-index: 100;
+}
 ```
 
 ---

--- a/skills/react-view-transitions/references/css-recipes.md
+++ b/skills/react-view-transitions/references/css-recipes.md
@@ -1,0 +1,303 @@
+# CSS Animation Recipes for View Transitions
+
+Ready-to-use CSS snippets for common view transition animations. Use these class names with `<ViewTransition>` props.
+
+## Table of Contents
+
+1. [Fade](#fade)
+2. [Slide](#slide)
+3. [Scale](#scale)
+4. [Slide + Fade Combined](#slide--fade-combined)
+5. [Directional Navigation (Forward / Back)](#directional-navigation)
+6. [Flip](#flip)
+7. [Reduced Motion](#reduced-motion)
+8. [Slow Cross-Fade](#slow-cross-fade)
+
+---
+
+## Fade
+
+```css
+::view-transition-old(.fade-out) {
+  animation: 200ms ease-out fade-to-hidden;
+}
+::view-transition-new(.fade-in) {
+  animation: 200ms ease-in fade-from-hidden;
+}
+
+@keyframes fade-to-hidden {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+@keyframes fade-from-hidden {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+```
+
+Usage:
+```jsx
+<ViewTransition enter="fade-in" exit="fade-out" />
+```
+
+---
+
+## Slide
+
+```css
+::view-transition-old(.slide-out-left) {
+  animation: 300ms ease-in-out slide-to-left;
+}
+::view-transition-new(.slide-in-from-right) {
+  animation: 300ms ease-in-out slide-from-right;
+}
+::view-transition-old(.slide-out-right) {
+  animation: 300ms ease-in-out slide-to-right;
+}
+::view-transition-new(.slide-in-from-left) {
+  animation: 300ms ease-in-out slide-from-left;
+}
+
+/* Vertical */
+::view-transition-old(.slide-out-up) {
+  animation: 300ms ease-in-out slide-to-top;
+}
+::view-transition-new(.slide-in-from-bottom) {
+  animation: 300ms ease-in-out slide-from-bottom;
+}
+::view-transition-old(.slide-out-down) {
+  animation: 300ms ease-in-out slide-to-bottom;
+}
+::view-transition-new(.slide-in-from-top) {
+  animation: 300ms ease-in-out slide-from-top;
+}
+
+@keyframes slide-to-left {
+  from { transform: translateX(0); }
+  to { transform: translateX(-100%); }
+}
+@keyframes slide-from-right {
+  from { transform: translateX(100%); }
+  to { transform: translateX(0); }
+}
+@keyframes slide-to-right {
+  from { transform: translateX(0); }
+  to { transform: translateX(100%); }
+}
+@keyframes slide-from-left {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(0); }
+}
+@keyframes slide-to-top {
+  from { transform: translateY(0); }
+  to { transform: translateY(-100%); }
+}
+@keyframes slide-from-bottom {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
+}
+@keyframes slide-to-bottom {
+  from { transform: translateY(0); }
+  to { transform: translateY(100%); }
+}
+@keyframes slide-from-top {
+  from { transform: translateY(-100%); }
+  to { transform: translateY(0); }
+}
+```
+
+Usage:
+```jsx
+<ViewTransition enter="slide-in-from-right" exit="slide-out-left" />
+```
+
+---
+
+## Scale
+
+```css
+::view-transition-old(.scale-out) {
+  animation: 250ms ease-in scale-down;
+}
+::view-transition-new(.scale-in) {
+  animation: 250ms ease-out scale-up;
+}
+
+@keyframes scale-down {
+  from { transform: scale(1); opacity: 1; }
+  to { transform: scale(0.85); opacity: 0; }
+}
+@keyframes scale-up {
+  from { transform: scale(0.85); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+```
+
+Usage:
+```jsx
+<ViewTransition enter="scale-in" exit="scale-out" />
+```
+
+---
+
+## Slide + Fade Combined
+
+```css
+::view-transition-old(.slide-fade-out) {
+  animation: 300ms ease-in-out slide-fade-exit;
+}
+::view-transition-new(.slide-fade-in) {
+  animation: 300ms ease-in-out slide-fade-enter;
+}
+
+@keyframes slide-fade-exit {
+  from { transform: translateY(0); opacity: 1; }
+  to { transform: translateY(-20px); opacity: 0; }
+}
+@keyframes slide-fade-enter {
+  from { transform: translateY(20px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+```
+
+Usage:
+```jsx
+<ViewTransition enter="slide-fade-in" exit="slide-fade-out" />
+```
+
+---
+
+## Directional Navigation
+
+A complete setup for forward/back page transitions using `addTransitionType`:
+
+```css
+/* Forward navigation: content slides left */
+::view-transition-old(.nav-forward-exit) {
+  animation: 350ms ease-in-out nav-slide-out-left;
+}
+::view-transition-new(.nav-forward-enter) {
+  animation: 350ms ease-in-out nav-slide-in-from-right;
+}
+
+/* Back navigation: content slides right */
+::view-transition-old(.nav-back-exit) {
+  animation: 350ms ease-in-out nav-slide-out-right;
+}
+::view-transition-new(.nav-back-enter) {
+  animation: 350ms ease-in-out nav-slide-in-from-left;
+}
+
+@keyframes nav-slide-out-left {
+  from { transform: translateX(0); opacity: 1; }
+  to { transform: translateX(-30%); opacity: 0; }
+}
+@keyframes nav-slide-in-from-right {
+  from { transform: translateX(30%); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+@keyframes nav-slide-out-right {
+  from { transform: translateX(0); opacity: 1; }
+  to { transform: translateX(30%); opacity: 0; }
+}
+@keyframes nav-slide-in-from-left {
+  from { transform: translateX(-30%); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+```
+
+Usage with transition types:
+```jsx
+<ViewTransition
+  enter={{
+    'navigation-forward': 'nav-forward-enter',
+    'navigation-back': 'nav-back-enter',
+    default: 'auto',
+  }}
+  exit={{
+    'navigation-forward': 'nav-forward-exit',
+    'navigation-back': 'nav-back-exit',
+    default: 'auto',
+  }}
+>
+  <Page />
+</ViewTransition>
+```
+
+Triggering:
+```jsx
+startTransition(() => {
+  addTransitionType('navigation-forward');
+  router.push('/next-page');
+});
+```
+
+---
+
+## Flip
+
+```css
+::view-transition-old(.flip-out) {
+  animation: 400ms ease-in flip-exit;
+  backface-visibility: hidden;
+}
+::view-transition-new(.flip-in) {
+  animation: 400ms ease-out flip-enter;
+  backface-visibility: hidden;
+}
+
+@keyframes flip-exit {
+  from { transform: rotateY(0deg); opacity: 1; }
+  to { transform: rotateY(-90deg); opacity: 0; }
+}
+@keyframes flip-enter {
+  from { transform: rotateY(90deg); opacity: 0; }
+  to { transform: rotateY(0deg); opacity: 1; }
+}
+```
+
+Usage:
+```jsx
+<ViewTransition enter="flip-in" exit="flip-out" />
+```
+
+---
+
+## Reduced Motion
+
+Always include this in your global stylesheet to respect user preferences:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(*),
+  ::view-transition-new(*),
+  ::view-transition-group(*) {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+  }
+}
+```
+
+---
+
+## Slow Cross-Fade
+
+Override the browser default timing for a slower, more cinematic cross-fade:
+
+```css
+::view-transition-old(.slow-fade) {
+  animation-duration: 600ms;
+  animation-timing-function: ease-in-out;
+}
+::view-transition-new(.slow-fade) {
+  animation-duration: 600ms;
+  animation-timing-function: ease-in-out;
+}
+```
+
+Usage:
+```jsx
+<ViewTransition default="slow-fade">
+  <Content />
+</ViewTransition>
+```

--- a/skills/react-view-transitions/references/css-recipes.md
+++ b/skills/react-view-transitions/references/css-recipes.md
@@ -4,14 +4,52 @@ Ready-to-use CSS snippets for common view transition animations. Use these class
 
 ## Table of Contents
 
-1. [Fade](#fade)
-2. [Slide](#slide)
-3. [Scale](#scale)
-4. [Slide + Fade Combined](#slide--fade-combined)
-5. [Directional Navigation (Forward / Back)](#directional-navigation)
-6. [Flip](#flip)
+1. [Timing Variables](#timing-variables)
+2. [Fade](#fade)
+3. [Slide (Vertical)](#slide-vertical)
+4. [Directional Navigation (Forward / Back)](#directional-navigation)
+5. [Shared Element Morph](#shared-element-morph)
+6. [Scale](#scale)
 7. [Reduced Motion](#reduced-motion)
-8. [Slow Cross-Fade](#slow-cross-fade)
+
+---
+
+## Timing Variables
+
+Define timing as CSS custom properties so durations are adjustable in one place. Use staggered timing — the enter animation delays by the exit duration so the old content leaves before the new content appears:
+
+```css
+:root {
+  --duration-exit: 150ms;
+  --duration-enter: 210ms;
+  --duration-move: 400ms;
+}
+```
+
+All recipes below reference these variables.
+
+### Shared Keyframes
+
+These reusable keyframes are used across multiple recipes:
+
+```css
+@keyframes fade {
+  from { filter: blur(3px); opacity: 0; }
+  to { filter: blur(0); opacity: 1; }
+}
+
+@keyframes slide {
+  from { translate: var(--slide-offset); }
+  to { translate: 0; }
+}
+
+@keyframes slide-y {
+  from { transform: translateY(var(--slide-y-offset, 10px)); }
+  to { transform: translateY(0); }
+}
+```
+
+The `slide` keyframe uses a CSS variable for direction — set `--slide-offset: -60px` for left, `60px` for right. The same keyframe with `animation-direction: reverse` handles the exit.
 
 ---
 
@@ -19,19 +57,10 @@ Ready-to-use CSS snippets for common view transition animations. Use these class
 
 ```css
 ::view-transition-old(.fade-out) {
-  animation: 200ms ease-out fade-to-hidden;
+  animation: var(--duration-exit) ease-in fade reverse;
 }
 ::view-transition-new(.fade-in) {
-  animation: 200ms ease-in fade-from-hidden;
-}
-
-@keyframes fade-to-hidden {
-  from { opacity: 1; }
-  to { opacity: 0; }
-}
-@keyframes fade-from-hidden {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  animation: var(--duration-enter) ease-out var(--duration-exit) both fade;
 }
 ```
 
@@ -42,73 +71,132 @@ Usage:
 
 ---
 
-## Slide
+## Slide (Vertical)
+
+Slide down on exit, slide up on enter — the most common pattern for Suspense fallback-to-content transitions. Uses staggered timing with a fade:
 
 ```css
-::view-transition-old(.slide-out-left) {
-  animation: 300ms ease-in-out slide-to-left;
+::view-transition-old(.slide-down) {
+  animation:
+    var(--duration-exit) ease-out both fade reverse,
+    var(--duration-exit) ease-out both slide-y reverse;
 }
-::view-transition-new(.slide-in-from-right) {
-  animation: 300ms ease-in-out slide-from-right;
-}
-::view-transition-old(.slide-out-right) {
-  animation: 300ms ease-in-out slide-to-right;
-}
-::view-transition-new(.slide-in-from-left) {
-  animation: 300ms ease-in-out slide-from-left;
-}
-
-/* Vertical */
-::view-transition-old(.slide-out-up) {
-  animation: 300ms ease-in-out slide-to-top;
-}
-::view-transition-new(.slide-in-from-bottom) {
-  animation: 300ms ease-in-out slide-from-bottom;
-}
-::view-transition-old(.slide-out-down) {
-  animation: 300ms ease-in-out slide-to-bottom;
-}
-::view-transition-new(.slide-in-from-top) {
-  animation: 300ms ease-in-out slide-from-top;
-}
-
-@keyframes slide-to-left {
-  from { transform: translateX(0); }
-  to { transform: translateX(-100%); }
-}
-@keyframes slide-from-right {
-  from { transform: translateX(100%); }
-  to { transform: translateX(0); }
-}
-@keyframes slide-to-right {
-  from { transform: translateX(0); }
-  to { transform: translateX(100%); }
-}
-@keyframes slide-from-left {
-  from { transform: translateX(-100%); }
-  to { transform: translateX(0); }
-}
-@keyframes slide-to-top {
-  from { transform: translateY(0); }
-  to { transform: translateY(-100%); }
-}
-@keyframes slide-from-bottom {
-  from { transform: translateY(100%); }
-  to { transform: translateY(0); }
-}
-@keyframes slide-to-bottom {
-  from { transform: translateY(0); }
-  to { transform: translateY(100%); }
-}
-@keyframes slide-from-top {
-  from { transform: translateY(-100%); }
-  to { transform: translateY(0); }
+::view-transition-new(.slide-up) {
+  animation:
+    var(--duration-enter) ease-in var(--duration-exit) both fade,
+    var(--duration-move) ease-in both slide-y;
 }
 ```
 
 Usage:
 ```jsx
-<ViewTransition enter="slide-in-from-right" exit="slide-out-left" />
+<Suspense
+  fallback={
+    <ViewTransition exit="slide-down">
+      <Skeleton />
+    </ViewTransition>
+  }
+>
+  <ViewTransition default="none" enter="slide-up">
+    <Content />
+  </ViewTransition>
+</Suspense>
+```
+
+---
+
+## Directional Navigation
+
+A single CSS class name targets both `::view-transition-old` and `::view-transition-new` with different animations. This keeps the JSX simple — `enter="nav-forward"` / `exit="nav-forward"`:
+
+```css
+::view-transition-old(.nav-forward) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+::view-transition-new(.nav-forward) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+
+::view-transition-old(.nav-back) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+::view-transition-new(.nav-back) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+```
+
+Usage with transition types:
+```jsx
+<ViewTransition
+  default="none"
+  enter={{
+    'nav-forward': 'nav-forward',
+    'nav-back': 'nav-back',
+    default: 'none',
+  }}
+  exit={{
+    'nav-forward': 'nav-forward',
+    'nav-back': 'nav-back',
+    default: 'none',
+  }}
+>
+  {children}
+</ViewTransition>
+```
+
+Triggering with `transitionTypes` on `next/link`:
+```jsx
+<Link href="/products/1" transitionTypes={['nav-forward']}>Next</Link>
+<Link href="/products" transitionTypes={['nav-back']}>Back</Link>
+```
+
+Or programmatically:
+```jsx
+startTransition(() => {
+  addTransitionType('nav-forward');
+  router.push('/next-page');
+});
+```
+
+---
+
+## Shared Element Morph
+
+For shared element transitions, control the morph duration on `::view-transition-group` and add a motion blur on `::view-transition-image-pair` to smooth fast-moving elements:
+
+```css
+::view-transition-group(.morph) {
+  animation-duration: var(--duration-move);
+}
+
+::view-transition-image-pair(.morph) {
+  animation-name: via-blur;
+}
+
+@keyframes via-blur {
+  30% { filter: blur(3px); }
+}
+```
+
+The blur at 30% creates a subtle motion-blur effect — fast-moving elements can be visually jarring, and this smooths the transition without adding perceptible delay.
+
+Usage:
+```jsx
+<ViewTransition name={`product-${id}`} share="morph">
+  <Image src={product.image} alt={product.name} />
+</ViewTransition>
 ```
 
 ---
@@ -117,10 +205,10 @@ Usage:
 
 ```css
 ::view-transition-old(.scale-out) {
-  animation: 250ms ease-in scale-down;
+  animation: var(--duration-exit) ease-in scale-down;
 }
 ::view-transition-new(.scale-in) {
-  animation: 250ms ease-out scale-up;
+  animation: var(--duration-enter) ease-out var(--duration-exit) both scale-up;
 }
 
 @keyframes scale-down {
@@ -140,129 +228,6 @@ Usage:
 
 ---
 
-## Slide + Fade Combined
-
-```css
-::view-transition-old(.slide-fade-out) {
-  animation: 300ms ease-in-out slide-fade-exit;
-}
-::view-transition-new(.slide-fade-in) {
-  animation: 300ms ease-in-out slide-fade-enter;
-}
-
-@keyframes slide-fade-exit {
-  from { transform: translateY(0); opacity: 1; }
-  to { transform: translateY(-20px); opacity: 0; }
-}
-@keyframes slide-fade-enter {
-  from { transform: translateY(20px); opacity: 0; }
-  to { transform: translateY(0); opacity: 1; }
-}
-```
-
-Usage:
-```jsx
-<ViewTransition enter="slide-fade-in" exit="slide-fade-out" />
-```
-
----
-
-## Directional Navigation
-
-A complete setup for forward/back page transitions using `addTransitionType`:
-
-```css
-/* Forward navigation: content slides left */
-::view-transition-old(.nav-forward-exit) {
-  animation: 350ms ease-in-out nav-slide-out-left;
-}
-::view-transition-new(.nav-forward-enter) {
-  animation: 350ms ease-in-out nav-slide-in-from-right;
-}
-
-/* Back navigation: content slides right */
-::view-transition-old(.nav-back-exit) {
-  animation: 350ms ease-in-out nav-slide-out-right;
-}
-::view-transition-new(.nav-back-enter) {
-  animation: 350ms ease-in-out nav-slide-in-from-left;
-}
-
-@keyframes nav-slide-out-left {
-  from { transform: translateX(0); opacity: 1; }
-  to { transform: translateX(-30%); opacity: 0; }
-}
-@keyframes nav-slide-in-from-right {
-  from { transform: translateX(30%); opacity: 0; }
-  to { transform: translateX(0); opacity: 1; }
-}
-@keyframes nav-slide-out-right {
-  from { transform: translateX(0); opacity: 1; }
-  to { transform: translateX(30%); opacity: 0; }
-}
-@keyframes nav-slide-in-from-left {
-  from { transform: translateX(-30%); opacity: 0; }
-  to { transform: translateX(0); opacity: 1; }
-}
-```
-
-Usage with transition types:
-```jsx
-<ViewTransition
-  enter={{
-    'navigation-forward': 'nav-forward-enter',
-    'navigation-back': 'nav-back-enter',
-    default: 'auto',
-  }}
-  exit={{
-    'navigation-forward': 'nav-forward-exit',
-    'navigation-back': 'nav-back-exit',
-    default: 'auto',
-  }}
->
-  <Page />
-</ViewTransition>
-```
-
-Triggering:
-```jsx
-startTransition(() => {
-  addTransitionType('navigation-forward');
-  router.push('/next-page');
-});
-```
-
----
-
-## Flip
-
-```css
-::view-transition-old(.flip-out) {
-  animation: 400ms ease-in flip-exit;
-  backface-visibility: hidden;
-}
-::view-transition-new(.flip-in) {
-  animation: 400ms ease-out flip-enter;
-  backface-visibility: hidden;
-}
-
-@keyframes flip-exit {
-  from { transform: rotateY(0deg); opacity: 1; }
-  to { transform: rotateY(-90deg); opacity: 0; }
-}
-@keyframes flip-enter {
-  from { transform: rotateY(90deg); opacity: 0; }
-  to { transform: rotateY(0deg); opacity: 1; }
-}
-```
-
-Usage:
-```jsx
-<ViewTransition enter="flip-in" exit="flip-out" />
-```
-
----
-
 ## Reduced Motion
 
 Always include this in your global stylesheet to respect user preferences:
@@ -276,28 +241,4 @@ Always include this in your global stylesheet to respect user preferences:
     animation-delay: 0s !important;
   }
 }
-```
-
----
-
-## Slow Cross-Fade
-
-Override the browser default timing for a slower, more cinematic cross-fade:
-
-```css
-::view-transition-old(.slow-fade) {
-  animation-duration: 600ms;
-  animation-timing-function: ease-in-out;
-}
-::view-transition-new(.slow-fade) {
-  animation-duration: 600ms;
-  animation-timing-function: ease-in-out;
-}
-```
-
-Usage:
-```jsx
-<ViewTransition default="slow-fade">
-  <Content />
-</ViewTransition>
 ```

--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -249,10 +249,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           enter={{
             'navigation-forward': 'slide-in-from-right',
             'navigation-back': 'slide-in-from-left',
+            default: 'none',
           }}
           exit={{
             'navigation-forward': 'slide-out-to-left',
             'navigation-back': 'slide-out-to-right',
+            default: 'none',
           }}
         >
           {children}

--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -3,14 +3,13 @@
 ## Table of Contents
 
 1. [Setup](#setup)
-2. [Basic Route Transitions](#basic-route-transitions)
-3. [Layout-Level ViewTransition](#layout-level-viewtransition)
-4. [The transitionTypes Prop on next/link](#the-transitiontypes-prop-on-nextlink)
-5. [Programmatic Navigation with Transitions](#programmatic-navigation-with-transitions)
-6. [Transition Types for Navigation Direction](#transition-types-for-navigation-direction)
-7. [Shared Elements Across Routes](#shared-elements-across-routes)
-8. [Combining with Suspense and Loading States](#combining-with-suspense-and-loading-states)
-9. [Server Components Considerations](#server-components-considerations)
+2. [Layout-Level ViewTransition](#layout-level-viewtransition)
+3. [The transitionTypes Prop on next/link](#the-transitiontypes-prop-on-nextlink)
+4. [Programmatic Navigation with Transitions](#programmatic-navigation-with-transitions)
+5. [Transition Types for Navigation Direction](#transition-types-for-navigation-direction)
+6. [Shared Elements Across Routes](#shared-elements-across-routes)
+7. [Combining with Suspense and Loading States](#combining-with-suspense-and-loading-states)
+8. [Server Components Considerations](#server-components-considerations)
 
 ---
 
@@ -73,10 +72,12 @@ This works for simple apps where pages have **no** `<ViewTransition>` components
 
 **But the moment any page adds its own `<ViewTransition>` (a Suspense slide-up, an item reorder, a shared element), remove the layout-level one or set `default="none"` on it.** Otherwise both levels animate in parallel, not sequentially.
 
-For apps that need layout-level control, use `default="none"` and only activate for specific `transitionTypes`:
+**Layouts persist across navigations — they never unmount/remount.** `enter`/`exit` props on a `<ViewTransition>` inside a layout only fire when the layout itself first mounts, not on subsequent route changes. Do not use type-keyed `enter`/`exit` maps in a layout for directional navigation — they won't fire.
+
+If you need the layout to stay silent while pages manage their own animations, use `default="none"`:
 
 ```tsx
-// app/dashboard/layout.tsx
+// app/dashboard/layout.tsx — prevents layout from interfering with per-page VTs
 import { ViewTransition } from 'react';
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
@@ -84,19 +85,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     <div className="dashboard">
       <Sidebar />
       <main>
-        <ViewTransition
-          default="none"
-          enter={{
-            'nav-forward': 'nav-forward',
-            'nav-back': 'nav-back',
-            default: 'none',
-          }}
-          exit={{
-            'nav-forward': 'nav-forward',
-            'nav-back': 'nav-back',
-            default: 'none',
-          }}
-        >
+        <ViewTransition default="none">
           {children}
         </ViewTransition>
       </main>
@@ -105,9 +94,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 }
 ```
 
-Only the content area animates, only when explicit navigation types are present, and the sidebar stays static.
-
-**Even with `default="none"`, a layout-level directional slide will fire simultaneously with any per-page Suspense `<ViewTransition>`s.** If a page has `<ViewTransition enter="slide-up">` on a Suspense boundary, and the layout slides in from the right, both run at once — producing a diagonal movement. If your pages use Suspense reveals with `<ViewTransition>`, directional layout transitions usually hurt more than they help — the Suspense slide-up/slide-down already communicates "new content loading."
+This ensures the layout doesn't fire the default cross-fade on every navigation, while still allowing per-page `<ViewTransition>` components to work independently.
 
 ---
 
@@ -192,7 +179,7 @@ Wrapping `router.push()` in `startTransition` is what activates the `<ViewTransi
 
 ## Transition Types for Navigation Direction
 
-A common pattern is to animate differently for forward vs. backward navigation.
+Directional transitions animate forward/backward navigation with horizontal slides. They can coexist with Suspense reveals on the same page when properly isolated — see the two-layer pattern below.
 
 ### Using `transitionTypes` on `next/link` (preferred)
 
@@ -244,9 +231,63 @@ export function NavigateButton({
 }
 ```
 
-Configure `<ViewTransition>` in the layout to respond to these types. See the Layout-Level ViewTransition section above for the `default="none"` pattern with type-keyed `enter`/`exit` maps.
+Place a `<ViewTransition>` with type-keyed `enter`/`exit` on each **page** (not in a layout — layouts persist and don't trigger enter/exit on navigation):
 
-**When to skip directional nav transitions:** If your pages already use Suspense reveals with `<ViewTransition>` (priority #2 in the Hierarchy of Animation Intent), adding route-level directional transitions (priority #5) usually hurts more than it helps. The Suspense slide-up/slide-down already communicates "new content loading" — adding a horizontal slide on top produces a diagonal movement where both animations fight for attention. Prefer shared element transitions (#1) or just let Suspense handle it.
+```tsx
+// In each page component — NOT in layout.tsx
+<ViewTransition
+  default="none"
+  enter={{
+    'transition-forwards': 'slide-in-from-right',
+    'transition-backwards': 'slide-in-from-left',
+    default: 'none',
+  }}
+  exit={{
+    'transition-forwards': 'slide-out-to-left',
+    'transition-backwards': 'slide-out-to-right',
+    default: 'none',
+  }}
+>
+  <PageContent />
+</ViewTransition>
+```
+
+### Two-Layer Pattern: Directional Nav + Suspense Reveals
+
+Directional nav slides and Suspense content reveals can coexist on the same page because they fire at **different moments**: the nav slide fires during navigation (when the `transitionTypes` type is present), and the Suspense reveal fires later when streamed data loads (a separate transition with no type). `default="none"` on both layers prevents cross-interference:
+
+```tsx
+export default function DetailPage() {
+  return (
+    <ViewTransition
+      enter={{ "nav-forward": "slide-from-right", default: "none" }}
+      exit={{ "nav-forward": "slide-to-left", default: "none" }}
+      default="none"
+    >
+      <div>
+        <Suspense fallback={
+          <ViewTransition exit="slide-down"><HeaderSkeleton /></ViewTransition>
+        }>
+          <ViewTransition enter="slide-up" default="none">
+            <Header />
+          </ViewTransition>
+        </Suspense>
+        <Suspense fallback={
+          <ViewTransition exit="slide-down"><ContentSkeleton /></ViewTransition>
+        }>
+          <ViewTransition enter="slide-up" default="none">
+            <Content />
+          </ViewTransition>
+        </Suspense>
+      </div>
+    </ViewTransition>
+  );
+}
+```
+
+The outer `<ViewTransition>` only fires when `nav-forward` is present — it stays silent during Suspense resolves (no type, `default: "none"`). The inner `<ViewTransition>`s use simple string props — they fire on Suspense resolve regardless of type.
+
+Place the outer wrapper in each **page component**, not in `layout.tsx` (layouts persist, enter/exit won't fire).
 
 ---
 
@@ -327,7 +368,9 @@ Next.js `loading.tsx` files create `<Suspense>` boundaries. Wrap them with `<Vie
 
 The skeleton slides out, then the content slides in. `default="none"` on the content prevents it from re-animating on unrelated transitions.
 
-**Do not combine this with a layout-level `<ViewTransition>` that has `default="auto"`.** Both will fire simultaneously — the layout cross-fades the whole page while the Suspense boundary slides up content, producing a broken double-animation. If you need both, set `default="none"` on the layout-level one and only activate it for specific `transitionTypes`.
+**Do not combine this with a layout-level `<ViewTransition>` that has `default="auto"`.** Both fire during the same transition — the layout cross-fades while the Suspense boundary slides up, producing competing animations. Use `default="none"` on layout-level `<ViewTransition>`s, or remove them entirely.
+
+Directional navigation transitions (via `transitionTypes`) can coexist with Suspense reveals when placed as an outer wrapper in the page component with `default="none"` and type-keyed enter/exit — they fire at different moments (see "Two-Layer Pattern" in Transition Types for Navigation Direction).
 
 ---
 

--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -45,12 +45,14 @@ npm install react@canary react-dom@canary
 
 ---
 
-## Basic Route Transitions
+## Layout-Level ViewTransition
 
-The simplest approach is wrapping your page content in `<ViewTransition>` inside a layout:
+**If your pages already have `<ViewTransition>` components (Suspense reveals, item reorder, shared elements), do NOT add a layout-level `<ViewTransition>` wrapping `{children}` with `default="auto"`.** Both levels fire simultaneously inside a single `document.startViewTransition` — the layout cross-fades the entire old page while the new page's own animations run at the same time. The result is competing, broken-looking animations.
+
+This is the most common view transition mistake in Next.js. Every developer tries this first:
 
 ```tsx
-// app/layout.tsx
+// app/layout.tsx — ONLY use this if pages have NO per-page ViewTransitions
 import { ViewTransition } from 'react';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -67,17 +69,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 }
 ```
 
-When users navigate between routes using `<Link>`, Next.js triggers a transition internally. The `<ViewTransition>` wrapping `{children}` detects the content swap and animates it with the default cross-fade.
+This works for simple apps where pages have **no** `<ViewTransition>` components of their own. The layout detects the content swap on navigation and applies the default cross-fade.
 
-> **Warning:** This is an either/or choice with per-page animations. If your pages already have their own `<ViewTransition>` components (Suspense reveals, item reorder, shared elements), a layout-level VT on `{children}` produces double-animation — the layout cross-fades the entire old page while the new page's own entrance animations run simultaneously. Both levels get independent `view-transition-name`s, and the browser animates them in parallel, not sequentially.
->
-> Use this pattern only in apps where pages have **no** per-page view transitions. Otherwise, either remove the layout-level VT or set `default="none"` on it.
+**But the moment any page adds its own `<ViewTransition>` (a Suspense slide-up, an item reorder, a shared element), remove the layout-level one or set `default="none"` on it.** Otherwise both levels animate in parallel, not sequentially.
 
----
-
-## Layout-Level ViewTransition
-
-For more control, place `<ViewTransition>` at different levels of the layout hierarchy:
+For apps that need layout-level control, use `default="none"` and only activate for specific `transitionTypes`:
 
 ```tsx
 // app/dashboard/layout.tsx
@@ -87,17 +83,31 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   return (
     <div className="dashboard">
       <Sidebar />
-      <ViewTransition enter="slide-up" exit="fade-out">
-        <main>{children}</main>
-      </ViewTransition>
+      <main>
+        <ViewTransition
+          default="none"
+          enter={{
+            'nav-forward': 'nav-forward',
+            'nav-back': 'nav-back',
+            default: 'none',
+          }}
+          exit={{
+            'nav-forward': 'nav-forward',
+            'nav-back': 'nav-back',
+            default: 'none',
+          }}
+        >
+          {children}
+        </ViewTransition>
+      </main>
     </div>
   );
 }
 ```
 
-Only the `<main>` content animates when navigating between dashboard sub-routes. The sidebar stays static.
+Only the content area animates, only when explicit navigation types are present, and the sidebar stays static.
 
-> **Caution:** The same composition rule applies here — if the pages rendered inside `{children}` have their own `<ViewTransition>` components (Suspense boundaries, item animations), both levels will fire simultaneously. Use `default="none"` on the layout VT and only activate it for specific `transitionTypes` to avoid conflicts.
+**Even with `default="none"`, a layout-level directional slide will fire simultaneously with any per-page Suspense `<ViewTransition>`s.** If a page has `<ViewTransition enter="slide-up">` on a Suspense boundary, and the layout slides in from the right, both run at once — producing a diagonal movement. If your pages use Suspense reveals with `<ViewTransition>`, directional layout transitions usually hurt more than they help — the Suspense slide-up/slide-down already communicates "new content loading."
 
 ---
 
@@ -234,36 +244,9 @@ export function NavigateButton({
 }
 ```
 
-Configure `<ViewTransition>` to respond to these types. Use `default="none"` so the layout VT stays silent during per-page Suspense transitions and only fires for explicit navigation types:
+Configure `<ViewTransition>` in the layout to respond to these types. See the Layout-Level ViewTransition section above for the `default="none"` pattern with type-keyed `enter`/`exit` maps.
 
-```tsx
-// app/layout.tsx
-import { ViewTransition } from 'react';
-
-export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <html lang="en">
-      <body>
-        <ViewTransition
-          default="none"
-          enter={{
-            'navigation-forward': 'slide-in-from-right',
-            'navigation-back': 'slide-in-from-left',
-            default: 'none',
-          }}
-          exit={{
-            'navigation-forward': 'slide-out-to-left',
-            'navigation-back': 'slide-out-to-right',
-            default: 'none',
-          }}
-        >
-          {children}
-        </ViewTransition>
-      </body>
-    </html>
-  );
-}
-```
+**When to skip directional nav transitions:** If your pages already use Suspense reveals with `<ViewTransition>` (priority #2 in the Hierarchy of Animation Intent), adding route-level directional transitions (priority #5) usually hurts more than it helps. The Suspense slide-up/slide-down already communicates "new content loading" — adding a horizontal slide on top produces a diagonal movement where both animations fight for attention. Prefer shared element transitions (#1) or just let Suspense handle it.
 
 ---
 
@@ -325,30 +308,26 @@ Only one `<ViewTransition>` with a given name can be mounted at a time. Since Ne
 
 ## Combining with Suspense and Loading States
 
-Next.js `loading.tsx` files create `<Suspense>` boundaries. Wrap them with `<ViewTransition>` for smooth fallback-to-content reveals:
+Next.js `loading.tsx` files create `<Suspense>` boundaries. Wrap them with `<ViewTransition>` for smooth fallback-to-content reveals. Place the Suspense `<ViewTransition>` in the page, not alongside a layout-level one:
 
 ```tsx
-// app/dashboard/layout.tsx
-import { ViewTransition } from 'react';
-import { Suspense } from 'react';
-
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="dashboard">
-      <Sidebar />
-      <ViewTransition>
-        <Suspense fallback={<DashboardSkeleton />}>
-          {children}
-        </Suspense>
-      </ViewTransition>
-    </div>
-  );
-}
+// In a page or page-level component — NOT in a layout that also has a ViewTransition on {children}
+<Suspense
+  fallback={
+    <ViewTransition exit="slide-down">
+      <DashboardSkeleton />
+    </ViewTransition>
+  }
+>
+  <ViewTransition default="none" enter="slide-up">
+    <DashboardContent />
+  </ViewTransition>
+</Suspense>
 ```
 
-The skeleton cross-fades into the actual content once it loads.
+The skeleton slides out, then the content slides in. `default="none"` on the content prevents it from re-animating on unrelated transitions.
 
-> **Important:** If you also have a layout-level `<ViewTransition>` wrapping `{children}` with `default="auto"`, it will fire simultaneously with this Suspense VT on every navigation, producing a double-animation. Either remove the layout-level VT, or set `default="none"` on it so it only responds to explicit `transitionTypes`.
+**Do not combine this with a layout-level `<ViewTransition>` that has `default="auto"`.** Both will fire simultaneously — the layout cross-fades the whole page while the Suspense boundary slides up content, producing a broken double-animation. If you need both, set `default="none"` on the layout-level one and only activate it for specific `transitionTypes`.
 
 ---
 

--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -1,0 +1,346 @@
+# View Transitions in Next.js
+
+## Table of Contents
+
+1. [Setup](#setup)
+2. [Basic Route Transitions](#basic-route-transitions)
+3. [Layout-Level ViewTransition](#layout-level-viewtransition)
+4. [The transitionTypes Prop on next/link](#the-transitiontypes-prop-on-nextlink)
+5. [Programmatic Navigation with Transitions](#programmatic-navigation-with-transitions)
+6. [Transition Types for Navigation Direction](#transition-types-for-navigation-direction)
+7. [Shared Elements Across Routes](#shared-elements-across-routes)
+8. [Combining with Suspense and Loading States](#combining-with-suspense-and-loading-states)
+9. [Server Components Considerations](#server-components-considerations)
+
+---
+
+## Setup
+
+Enable the experimental flag in `next.config.js` (or `next.config.ts`):
+
+```js
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    viewTransition: true,
+  },
+};
+module.exports = nextConfig;
+```
+
+This flag enables deeper integration with Next.js features beyond what React's `<ViewTransition>` component provides on its own. The `<ViewTransition>` component itself is available from `react` in canary/experimental channels or React 19.2+.
+
+Install React canary if you're not yet on 19.2+:
+
+```bash
+npm install react@canary react-dom@canary
+```
+
+---
+
+## Basic Route Transitions
+
+The simplest approach is wrapping your page content in `<ViewTransition>` inside a layout:
+
+```tsx
+// app/layout.tsx
+import { ViewTransition } from 'react';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <nav>{/* navigation links */}</nav>
+        <ViewTransition>
+          {children}
+        </ViewTransition>
+      </body>
+    </html>
+  );
+}
+```
+
+When users navigate between routes using `<Link>`, Next.js triggers a transition internally. The `<ViewTransition>` wrapping `{children}` detects the content swap and animates it with the default cross-fade.
+
+---
+
+## Layout-Level ViewTransition
+
+For more control, place `<ViewTransition>` at different levels of the layout hierarchy:
+
+```tsx
+// app/dashboard/layout.tsx
+import { ViewTransition } from 'react';
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="dashboard">
+      <Sidebar />
+      <ViewTransition enter="slide-up" exit="fade-out">
+        <main>{children}</main>
+      </ViewTransition>
+    </div>
+  );
+}
+```
+
+Only the `<main>` content animates when navigating between dashboard sub-routes. The sidebar stays static.
+
+---
+
+## The `transitionTypes` Prop on `next/link`
+
+As of Next.js 16.2+, `next/link` supports a native `transitionTypes` prop. This eliminates the need for custom wrapper components that intercept navigation with `onNavigate` + `startTransition` + `addTransitionType` + `router.push()`.
+
+### Before (manual wrapper, requires `'use client'`)
+
+```tsx
+'use client';
+
+import { addTransitionType, startTransition } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+export function TransitionLink({ type, ...props }: { type: string } & React.ComponentProps<typeof Link>) {
+  const router = useRouter();
+
+  return (
+    <Link
+      onNavigate={(event) => {
+        event.preventDefault();
+        startTransition(() => {
+          addTransitionType(type);
+          router.push(props.href as string);
+        });
+      }}
+      {...props}
+    />
+  );
+}
+```
+
+### After (native prop, no wrapper needed, works in Server Components)
+
+```tsx
+import Link from 'next/link';
+
+<Link href="/products/1" transitionTypes={['transition-to-detail']}>
+  View Product
+</Link>
+```
+
+The `transitionTypes` prop accepts an array of strings. These types are passed to the View Transition system the same way `addTransitionType` would. `<ViewTransition>` components in the tree respond to these types identically.
+
+This is the recommended approach for link-based navigation transitions. Reserve manual `startTransition` + `addTransitionType` for programmatic navigation (buttons, form submissions, etc.) where `next/link` isn't used.
+
+---
+
+## Programmatic Navigation with Transitions
+
+Use `startTransition` with Next.js's `router.push()` to trigger view transitions from code:
+
+```tsx
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { startTransition, addTransitionType } from 'react';
+
+export function NavigateButton({ href }: { href: string }) {
+  const router = useRouter();
+
+  return (
+    <button
+      onClick={() => {
+        startTransition(() => {
+          addTransitionType('navigation-forward');
+          router.push(href);
+        });
+      }}
+    >
+      Go to {href}
+    </button>
+  );
+}
+```
+
+Wrapping `router.push()` in `startTransition` is what activates the `<ViewTransition>` boundaries in the tree.
+
+---
+
+## Transition Types for Navigation Direction
+
+A common pattern is to animate differently for forward vs. backward navigation.
+
+### Using `transitionTypes` on `next/link` (preferred)
+
+```tsx
+import Link from 'next/link';
+
+// Forward navigation
+<Link href="/products/1" transitionTypes={['transition-forwards']}>
+  Next →
+</Link>
+
+// Backward navigation
+<Link href="/products" transitionTypes={['transition-backwards']}>
+  ← Back
+</Link>
+```
+
+### Using `startTransition` + `addTransitionType` (for programmatic navigation)
+
+```tsx
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { startTransition, addTransitionType } from 'react';
+
+export function NavigateButton({
+  href,
+  direction = 'forward',
+  children,
+}: {
+  href: string;
+  direction?: 'forward' | 'back';
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+
+  return (
+    <button
+      onClick={() => {
+        startTransition(() => {
+          addTransitionType(`navigation-${direction}`);
+          router.push(href);
+        });
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+```
+
+Configure `<ViewTransition>` to respond to these types:
+
+```tsx
+// app/layout.tsx
+import { ViewTransition } from 'react';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <ViewTransition
+          enter={{
+            'navigation-forward': 'slide-in-from-right',
+            'navigation-back': 'slide-in-from-left',
+            default: 'auto',
+          }}
+          exit={{
+            'navigation-forward': 'slide-out-to-left',
+            'navigation-back': 'slide-out-to-right',
+            default: 'auto',
+          }}
+        >
+          {children}
+        </ViewTransition>
+      </body>
+    </html>
+  );
+}
+```
+
+---
+
+## Shared Elements Across Routes
+
+Animate a thumbnail expanding into a full image across route transitions. Use `transitionTypes` on the link to tag the navigation direction:
+
+```tsx
+// app/products/page.tsx (list page)
+import { ViewTransition } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+
+export default function ProductList({ products }) {
+  return (
+    <div className="grid grid-cols-3 gap-6">
+      {products.map((product) => (
+        <Link
+          key={product.id}
+          href={`/products/${product.id}`}
+          transitionTypes={['transition-to-detail']}
+        >
+          <ViewTransition name={`product-${product.id}`}>
+            <Image src={product.image} alt={product.name} width={400} height={300} />
+          </ViewTransition>
+          <p>{product.name}</p>
+        </Link>
+      ))}
+    </div>
+  );
+}
+```
+
+```tsx
+// app/products/[id]/page.tsx (detail page)
+import { ViewTransition } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+
+export default function ProductDetail({ product }) {
+  return (
+    <article>
+      <Link href="/products" transitionTypes={['transition-to-list']}>
+        ← Back to Products
+      </Link>
+      <ViewTransition name={`product-${product.id}`}>
+        <Image src={product.image} alt={product.name} width={800} height={600} />
+      </ViewTransition>
+      <h1>{product.name}</h1>
+      <p>{product.description}</p>
+    </article>
+  );
+}
+```
+
+Only one `<ViewTransition>` with a given name can be mounted at a time. Since Next.js unmounts the old page and mounts the new page within the same transition, the two `product-${product.id}` boundaries form a shared element pair and the image morphs from its thumbnail size to its full size.
+
+---
+
+## Combining with Suspense and Loading States
+
+Next.js `loading.tsx` files create `<Suspense>` boundaries. Wrap them with `<ViewTransition>` for smooth fallback-to-content reveals:
+
+```tsx
+// app/dashboard/layout.tsx
+import { ViewTransition } from 'react';
+import { Suspense } from 'react';
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="dashboard">
+      <Sidebar />
+      <ViewTransition>
+        <Suspense fallback={<DashboardSkeleton />}>
+          {children}
+        </Suspense>
+      </ViewTransition>
+    </div>
+  );
+}
+```
+
+The skeleton cross-fades into the actual content once it loads.
+
+---
+
+## Server Components Considerations
+
+- `<ViewTransition>` can be used in both Server and Client Components — it renders no DOM of its own.
+- `<Link>` with `transitionTypes` works in Server Components — no `'use client'` directive needed for link-based transitions.
+- `addTransitionType` must be called from a Client Component (inside an event handler with `startTransition`).
+- `startTransition` for programmatic navigation must be called from a Client Component.
+- Navigation via `<Link>` from `next/link` triggers transitions automatically when the experimental flag is enabled.
+- Prefer `transitionTypes` on `<Link>` over custom wrapper components. Only use manual `startTransition` + `addTransitionType` + `router.push()` for non-link interactions (buttons, form submissions, etc.).

--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -28,7 +28,14 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-This flag enables deeper integration with Next.js features beyond what React's `<ViewTransition>` component provides on its own. The `<ViewTransition>` component itself is available from `react` in canary/experimental channels or React 19.2+.
+**What this flag does at runtime:** It wraps every `<Link>` navigation in `document.startViewTransition`. This means all mounted `<ViewTransition>` components in the tree participate in every link navigation — not just transitions triggered by `startTransition` or `Suspense`.
+
+Implications:
+- Any `<ViewTransition>` with `default="auto"` (the implicit default) fires the browser's cross-fade on **every** `<Link>` navigation.
+- Combined with per-page `<ViewTransition>` components (Suspense reveals, item animations), this produces competing animations.
+- Without this flag, only `Suspense`-triggered and `startTransition`-triggered transitions fire.
+
+The `<ViewTransition>` component itself is available from `react` in canary/experimental channels or React 19.2+.
 
 Install React canary if you're not yet on 19.2+:
 
@@ -62,6 +69,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
 When users navigate between routes using `<Link>`, Next.js triggers a transition internally. The `<ViewTransition>` wrapping `{children}` detects the content swap and animates it with the default cross-fade.
 
+> **Warning:** This is an either/or choice with per-page animations. If your pages already have their own `<ViewTransition>` components (Suspense reveals, item reorder, shared elements), a layout-level VT on `{children}` produces double-animation — the layout cross-fades the entire old page while the new page's own entrance animations run simultaneously. Both levels get independent `view-transition-name`s, and the browser animates them in parallel, not sequentially.
+>
+> Use this pattern only in apps where pages have **no** per-page view transitions. Otherwise, either remove the layout-level VT or set `default="none"` on it.
+
 ---
 
 ## Layout-Level ViewTransition
@@ -85,6 +96,8 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 ```
 
 Only the `<main>` content animates when navigating between dashboard sub-routes. The sidebar stays static.
+
+> **Caution:** The same composition rule applies here — if the pages rendered inside `{children}` have their own `<ViewTransition>` components (Suspense boundaries, item animations), both levels will fire simultaneously. Use `default="none"` on the layout VT and only activate it for specific `transitionTypes` to avoid conflicts.
 
 ---
 
@@ -221,7 +234,7 @@ export function NavigateButton({
 }
 ```
 
-Configure `<ViewTransition>` to respond to these types:
+Configure `<ViewTransition>` to respond to these types. Use `default="none"` so the layout VT stays silent during per-page Suspense transitions and only fires for explicit navigation types:
 
 ```tsx
 // app/layout.tsx
@@ -232,15 +245,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <body>
         <ViewTransition
+          default="none"
           enter={{
             'navigation-forward': 'slide-in-from-right',
             'navigation-back': 'slide-in-from-left',
-            default: 'auto',
           }}
           exit={{
             'navigation-forward': 'slide-out-to-left',
             'navigation-back': 'slide-out-to-right',
-            default: 'auto',
           }}
         >
           {children}
@@ -333,6 +345,8 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 ```
 
 The skeleton cross-fades into the actual content once it loads.
+
+> **Important:** If you also have a layout-level `<ViewTransition>` wrapping `{children}` with `default="auto"`, it will fire simultaneously with this Suspense VT on every navigation, producing a double-animation. Either remove the layout-level VT, or set `default="none"` on it so it only responds to explicit `transitionTypes`.
 
 ---
 

--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -16,7 +16,9 @@
 
 ## Setup
 
-Enable the experimental flag in `next.config.js` (or `next.config.ts`):
+`<ViewTransition>` works in Next.js out of the box for `startTransition`- and `Suspense`-triggered updates — no config flag is needed for those.
+
+To also animate `<Link>` navigations, enable the experimental flag in `next.config.js` (or `next.config.ts`):
 
 ```js
 /** @type {import('next').NextConfig} */
@@ -33,7 +35,7 @@ module.exports = nextConfig;
 Implications:
 - Any `<ViewTransition>` with `default="auto"` (the implicit default) fires the browser's cross-fade on **every** `<Link>` navigation.
 - Combined with per-page `<ViewTransition>` components (Suspense reveals, item animations), this produces competing animations.
-- Without this flag, only `Suspense`-triggered and `startTransition`-triggered transitions fire.
+- Without this flag, `<ViewTransition>` still works for all `startTransition`- and `Suspense`-triggered updates — only `<Link>` navigations won't participate.
 
 The `<ViewTransition>` component is currently available in `react@canary` and `react@experimental` only:
 
@@ -101,7 +103,7 @@ Only the `<main>` content animates when navigating between dashboard sub-routes.
 
 ## The `transitionTypes` Prop on `next/link`
 
-As of Next.js 16.2+, `next/link` supports a native `transitionTypes` prop. This eliminates the need for custom wrapper components that intercept navigation with `onNavigate` + `startTransition` + `addTransitionType` + `router.push()`.
+`next/link` supports a native `transitionTypes` prop. This eliminates the need for custom wrapper components that intercept navigation with `onNavigate` + `startTransition` + `addTransitionType` + `router.push()`.
 
 ### Before (manual wrapper, requires `'use client'`)
 

--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -35,9 +35,7 @@ Implications:
 - Combined with per-page `<ViewTransition>` components (Suspense reveals, item animations), this produces competing animations.
 - Without this flag, only `Suspense`-triggered and `startTransition`-triggered transitions fire.
 
-The `<ViewTransition>` component itself is available from `react` in canary/experimental channels or React 19.2+.
-
-Install React canary if you're not yet on 19.2+:
+The `<ViewTransition>` component is currently available in `react@canary` and `react@experimental` only:
 
 ```bash
 npm install react@canary react-dom@canary

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -104,9 +104,32 @@ These wrappers enforce that only valid transition IDs and animation classes are 
 
 See `nextjs.md` (Shared Elements Across Routes) for complete examples using `transitionTypes` on `next/link` combined with shared element `<ViewTransition name={...}>` for list-to-detail image morph animations.
 
-## Isolate Floating Elements from Parent Animations
+## Isolate Elements from Parent Animations
 
-Popovers, tooltips, and dropdowns can get captured in a parent's view transition snapshot, causing them to ghost or animate unexpectedly. Give them their own `viewTransitionName` to isolate them into a separate transition group:
+### Persistent Layout Elements (Headers, Sidebars)
+
+Sticky headers, navbars, and sidebars that persist across navigations get captured in the page content's transition snapshot. When a directional slide animates the page, the header slides away with it — which looks broken.
+
+Fix: give persistent elements their own `viewTransitionName` and disable animation on their transition group:
+
+```jsx
+<header style={{ viewTransitionName: "dashboard-header" }}>
+  {/* header content */}
+</header>
+```
+
+```css
+::view-transition-group(dashboard-header) {
+  animation: none;
+  z-index: 100;
+}
+```
+
+This isolates the header into its own transition group that stays static during page slides. The element won't be included in the page content's old/new snapshot.
+
+### Floating Elements (Popovers, Tooltips)
+
+Popovers, tooltips, and dropdowns can also get captured in a parent's view transition snapshot, causing them to ghost or animate unexpectedly. The same pattern applies — give them their own `viewTransitionName`:
 
 ```jsx
 <SelectPopover style={{ viewTransitionName: 'popover' }}>
@@ -119,8 +142,6 @@ Popovers, tooltips, and dropdowns can get captured in a parent's view transition
   z-index: 100;
 }
 ```
-
-This creates an independent transition group that renders above other transitioning elements. The element won't be included in its parent's old/new snapshot.
 
 For a global fix that ensures all view transition groups render above normal content, use the wildcard selector:
 
@@ -201,6 +222,61 @@ function cycleSort() {
 
 ---
 
+## View Transition Events (JavaScript Animations)
+
+For imperative control, use the `onEnter`, `onExit`, `onUpdate`, and `onShare` callbacks:
+
+```jsx
+<ViewTransition
+  onEnter={(instance, types) => {
+    const anim = instance.new.animate(
+      [{ transform: 'scale(0.8)', opacity: 0 }, { transform: 'scale(1)', opacity: 1 }],
+      { duration: 300, easing: 'ease-out' }
+    );
+    return () => anim.cancel();
+  }}
+  onExit={(instance, types) => {
+    const anim = instance.old.animate(
+      [{ transform: 'scale(1)', opacity: 1 }, { transform: 'scale(0.8)', opacity: 0 }],
+      { duration: 200, easing: 'ease-in' }
+    );
+    return () => anim.cancel();
+  }}
+>
+  <Component />
+</ViewTransition>
+```
+
+The `instance` object provides:
+- `instance.old` — the `::view-transition-old` pseudo-element
+- `instance.new` — the `::view-transition-new` pseudo-element
+- `instance.group` — the `::view-transition-group` pseudo-element
+- `instance.imagePair` — the `::view-transition-image-pair` pseudo-element
+- `instance.name` — the `view-transition-name` string
+
+Always return a cleanup function that cancels the animation so the browser can properly handle interruptions.
+
+Only one event fires per `<ViewTransition>` per Transition. `onShare` takes precedence over `onEnter` and `onExit`.
+
+### Using Types in Event Callbacks
+
+The `types` array is available as the second argument to all event callbacks:
+
+```jsx
+<ViewTransition
+  onEnter={(instance, types) => {
+    const duration = types.includes('fast') ? 150 : 500;
+    const anim = instance.new.animate(
+      [{ opacity: 0 }, { opacity: 1 }],
+      { duration, easing: 'ease-out' }
+    );
+    return () => anim.cancel();
+  }}
+>
+```
+
+---
+
 ## Animation Timing Guidelines
 
 Match duration to the interaction type — direct user actions need fast feedback, while ambient reveals can be slower:
@@ -213,3 +289,38 @@ Match duration to the interaction type — direct user actions need fast feedbac
 | Shared element morph | 300–500ms | Users watch the morph — give it room to breathe |
 
 These are starting points. Test on low-end devices — animations that feel smooth on a fast machine can feel sluggish on mobile.
+
+---
+
+## Troubleshooting
+
+**ViewTransition not activating:**
+- Ensure the `<ViewTransition>` comes before any DOM node in the component (not wrapped in a `<div>`).
+- Ensure the state update is inside `startTransition`, not a plain `setState`.
+
+**"Two ViewTransition components with the same name" error:**
+- Each `name` must be globally unique across the entire app at any point in time. Add item IDs: `` name={`hero-${item.id}`} ``.
+
+**Back button skips animation:**
+- The legacy `popstate` event requires synchronous completion, conflicting with view transitions. Upgrade your router to use the Navigation API for back-button animations.
+
+**Animations from `flushSync` are skipped:**
+- `flushSync` completes synchronously, which prevents view transitions from running. Use `startTransition` instead.
+
+**Enter/exit not firing in a client component (only updates animate):**
+- `startTransition(() => setState(...))` triggers a Transition, but if the new content isn't behind a `<Suspense>` boundary, React treats the swap as an **update** to the existing tree — not an enter/exit. The `<ViewTransition>` sees its children change but never fully unmounts/remounts, so only `update` animations fire. To get true enter/exit, either conditionally render the `<ViewTransition>` itself (so it mounts/unmounts with the content), or wrap the async content in `<Suspense>` so React can treat the reveal as an insertion.
+
+**Competing / double animations on navigation:**
+- Multiple `<ViewTransition>` components at different tree levels (layout + page + items) all fire simultaneously inside a single `document.startViewTransition`. If a layout-level one cross-fades the whole page while a page-level one slides up content, both run at once and fight for attention. Fix: use `default="none"` on the layout-level `<ViewTransition>`, or remove it entirely if pages manage their own animations.
+
+**List reorder not animating with `useOptimistic`:**
+- If the optimistic value drives the list sort order, items are already in their final positions before the transition snapshot — there's nothing to animate. Use the optimistic value only for controls (labels, icons) and the committed state (`useState`) for the list sort order.
+
+**TypeScript error: "Property 'default' is missing in type 'ViewTransitionClassPerType'":**
+- When passing an object to `enter`/`exit`/`update`/`share`, TypeScript requires a `default` key in the object. This applies even if the component-level `default` prop is set. Always include `default: 'none'` (or `'auto'`) in type-keyed objects.
+
+**Hash fragments cause scroll jumps during view transitions:**
+- Links with URL hash fragments (e.g., `/page#section`) trigger the browser's native scroll-to-anchor behavior during the navigation transition. This interferes with directional slide animations — the page scrolls to the anchor while simultaneously sliding horizontally, producing a diagonal jump. If you need to link to a specific section on a detail page, navigate without the hash and handle scroll/expansion programmatically after navigation completes.
+
+**Batching:**
+- If multiple updates occur while an animation is running, React batches them into one. For example: if you navigate A→B, then B→C, then C→D during the first animation, the next animation will go B→D.

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -127,6 +127,93 @@ These wrappers enforce that only valid transition IDs and animation classes are 
 
 See `nextjs.md` (Shared Elements Across Routes) for complete examples using `transitionTypes` on `next/link` combined with shared element `<ViewTransition name={...}>` for list-to-detail image morph animations.
 
+## Isolate Floating Elements from Parent Animations
+
+Popovers, tooltips, and dropdowns can get captured in a parent's view transition snapshot, causing them to ghost or animate unexpectedly. Give them their own `viewTransitionName` to isolate them into a separate transition group:
+
+```jsx
+<SelectPopover style={{ viewTransitionName: 'popover' }}>
+  {options}
+</SelectPopover>
+```
+
+```css
+::view-transition-group(popover) {
+  z-index: 100;
+}
+```
+
+This creates an independent transition group that renders above other transitioning elements. The element won't be included in its parent's old/new snapshot.
+
+## Reusable Animated Collapse
+
+For apps with many expand/collapse interactions, extract a reusable wrapper instead of repeating the conditional-render-with-`<ViewTransition>` pattern:
+
+```jsx
+import { ViewTransition } from 'react';
+
+function AnimatedCollapse({ open, children }) {
+  if (!open) return null;
+  return (
+    <ViewTransition enter="expand-in" exit="collapse-out">
+      {children}
+    </ViewTransition>
+  );
+}
+```
+
+Use it with `startTransition` on the toggle:
+
+```jsx
+<button onClick={() => startTransition(() => setOpen(o => !o))}>Toggle</button>
+<AnimatedCollapse open={open}>
+  <SectionContent />
+</AnimatedCollapse>
+```
+
+## Preserve State with Activity
+
+Use `<Activity>` with `<ViewTransition>` to animate show/hide while preserving component state:
+
+```jsx
+import { Activity, ViewTransition, startTransition } from 'react';
+
+<Activity mode={isVisible ? 'visible' : 'hidden'}>
+  <ViewTransition enter="slide-in" exit="slide-out">
+    <Sidebar />
+  </ViewTransition>
+</Activity>
+```
+
+## Exclude Elements from a Transition with `useOptimistic`
+
+When a `startTransition` changes both a control (e.g. a button label) and content (e.g. list order), use `useOptimistic` for the control. The optimistic value updates before React's transition snapshot, so it won't animate. The committed state drives the content, which changes within the transition and animates:
+
+```tsx
+const [sort, setSort] = useState('newest');
+const [optimisticSort, setOptimisticSort] = useOptimistic(sort);
+
+function cycleSort() {
+  const nextSort = getNextSort(optimisticSort);
+  startTransition(() => {
+    setOptimisticSort(nextSort);  // updates before snapshot — no animation
+    setSort(nextSort);            // changes within transition — animates
+  });
+}
+
+// Button uses optimisticSort (instant, excluded from animation)
+<button>Sort: {LABELS[optimisticSort]}</button>
+
+// List uses committed sort (changes between snapshots, animates)
+{items.sort(comparators[sort]).map(item => (
+  <ViewTransition key={item.id}>
+    <ItemCard item={item} />
+  </ViewTransition>
+))}
+```
+
+`useOptimistic` values resolve before the transition snapshot. Any DOM driven by optimistic state is already in its final form when the "before" snapshot is taken, so it doesn't participate in the `<ViewTransition>`. Only DOM driven by committed state (via `setState`) changes between snapshots and animates.
+
 ---
 
 ## Animation Timing Guidelines

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -319,6 +319,12 @@ These are starting points. Test on low-end devices — animations that feel smoo
 **TypeScript error: "Property 'default' is missing in type 'ViewTransitionClassPerType'":**
 - When passing an object to `enter`/`exit`/`update`/`share`, TypeScript requires a `default` key in the object. This applies even if the component-level `default` prop is set. Always include `default: 'none'` (or `'auto'`) in type-keyed objects.
 
+**Sibling Suspense boundaries re-trigger each other's view transitions:**
+- With `experimental: { viewTransition: true }`, each Suspense resolution fires its own `document.startViewTransition`. A `<ViewTransition>` with `default="auto"` participates in **all** transitions on the page — not just its own Suspense resolve. If three Suspense boundaries resolve at different times, each one re-triggers every `default="auto"` VT on the page, producing repeated or staggered animations. Fix: use the split pattern with `default="none"` on the content `<ViewTransition>` and explicit `enter`/`exit` props — never rely on `default="auto"` on pages with multiple Suspense boundaries.
+
+**Cross-fade looks like a jump / stagger:**
+- If the Suspense fallback (skeleton) and the resolved content have different dimensions, the view transition captures different-sized before/after snapshots. The size change during the cross-fade produces a jarring shift. Fix: match the skeleton's item count, line heights, and overall dimensions to the real content as closely as possible.
+
 **Hash fragments cause scroll jumps during view transitions:**
 - Links with URL hash fragments (e.g., `/page#section`) trigger the browser's native scroll-to-anchor behavior during the navigation transition. This interferes with directional slide animations — the page scrolls to the anchor while simultaneously sliding horizontally, producing a diagonal jump. If you need to link to a specific section on a detail page, navigate without the hash and handle scroll/expansion programmatically after navigation completes.
 

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -1,0 +1,143 @@
+# Patterns and Guidelines
+
+## Searchable Grid with `useDeferredValue`
+
+A client-side searchable grid where the filtered results cross-fade as the user types. `useDeferredValue` makes the filter update a transition, which activates the wrapping `<ViewTransition>`:
+
+```tsx
+'use client';
+
+import { useDeferredValue, useState, ViewTransition, Suspense } from 'react';
+
+export default function SearchableGrid({ itemsPromise }) {
+  const [search, setSearch] = useState('');
+  const deferredSearch = useDeferredValue(search);
+
+  return (
+    <>
+      <input
+        value={search}
+        onChange={(e) => setSearch(e.currentTarget.value)}
+        placeholder="Search..."
+      />
+      <ViewTransition>
+        <Suspense fallback={<GridSkeleton />}>
+          <ItemGrid itemsPromise={itemsPromise} search={deferredSearch} />
+        </Suspense>
+      </ViewTransition>
+    </>
+  );
+}
+```
+
+## Card Expand/Collapse with `startTransition`
+
+Toggle between a card grid and a detail view using `startTransition` to animate the swap:
+
+```tsx
+'use client';
+
+import { useState, startTransition, ViewTransition } from 'react';
+
+export default function ItemGrid({ items }) {
+  const [expandedId, setExpandedId] = useState(null);
+
+  return expandedId ? (
+    <ViewTransition enter="slide-up" exit="slide-down">
+      <ItemDetail
+        item={items.find(i => i.id === expandedId)}
+        onClose={() => {
+          startTransition(() => {
+            setExpandedId(null);
+          });
+        }}
+      />
+    </ViewTransition>
+  ) : (
+    <div className="grid grid-cols-3 gap-4">
+      {items.map(item => (
+        <ViewTransition key={item.id}>
+          <ItemCard
+            item={item}
+            onSelect={() => {
+              startTransition(() => {
+                setExpandedId(item.id);
+              });
+            }}
+          />
+        </ViewTransition>
+      ))}
+    </div>
+  );
+}
+```
+
+The CSS for slide-up/slide-down enter/exit:
+
+```css
+::view-transition-old(.slide-down) {
+  animation: 150ms ease-out both fade-out, 150ms ease-out both slide-down;
+}
+::view-transition-new(.slide-up) {
+  animation: 210ms ease-in 150ms both fade-in, 400ms ease-in both slide-up;
+}
+
+@keyframes slide-up {
+  from { transform: translateY(10px); }
+  to { transform: translateY(0); }
+}
+@keyframes slide-down {
+  from { transform: translateY(0); }
+  to { transform: translateY(10px); }
+}
+@keyframes fade-in {
+  from { opacity: 0; }
+}
+@keyframes fade-out {
+  to { opacity: 0; }
+}
+```
+
+## Type-Safe Transition Helpers
+
+For larger apps, define type-safe transition IDs and transition maps to prevent ID clashes and keep animation configurations consistent. Use `as const` arrays for transition IDs, types, and animation classes, then derive types from them:
+
+```tsx
+import { ViewTransition } from 'react';
+
+const transitionTypes = ['default', 'transition-to-detail', 'transition-to-list', 'transition-backwards', 'transition-forwards'] as const;
+const animationTypes = ['auto', 'none', 'animate-slide-from-left', 'animate-slide-from-right', 'animate-slide-to-left', 'animate-slide-to-right'] as const;
+
+type TransitionType = (typeof transitionTypes)[number];
+type AnimationType = (typeof animationTypes)[number];
+type TransitionMap = { default: AnimationType } & Partial<Record<Exclude<TransitionType, 'default'>, AnimationType>>;
+
+export function HorizontalTransition({ children, enter, exit }: {
+  children: React.ReactNode;
+  enter: TransitionMap;
+  exit: TransitionMap;
+}) {
+  return <ViewTransition enter={enter} exit={exit}>{children}</ViewTransition>;
+}
+```
+
+These wrappers enforce that only valid transition IDs and animation classes are used, catching mistakes at compile time.
+
+## Shared Elements Across Routes in Next.js
+
+See `nextjs.md` (Shared Elements Across Routes) for complete examples using `transitionTypes` on `next/link` combined with shared element `<ViewTransition name={...}>` for list-to-detail image morph animations.
+
+---
+
+## Animation Timing Guidelines
+
+Match duration to the interaction type — direct user actions need fast feedback, while ambient reveals can be slower:
+
+| Interaction | Duration | Rationale |
+|------------|----------|-----------|
+| Direct toggle (expand/collapse, show/hide) | 100–200ms | Responds to a click — must feel instant |
+| Route transition (directional slide) | 150–250ms | Brief spatial cue, shouldn't delay navigation |
+| Suspense reveal (skeleton → content) | 200–400ms | Soft reveal, content is "arriving" |
+| Shared element morph | 300–500ms | Users watch the morph — give it room to breathe |
+
+These are starting points. Test on low-end devices — animations that feel smooth on a fast machine can feel sluggish on mobile.

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -32,23 +32,25 @@ export default function SearchableGrid({ itemsPromise }) {
 
 ## Card Expand/Collapse with `startTransition`
 
-Toggle between a card grid and a detail view using `startTransition` to animate the swap:
+Toggle between a card grid and a detail view using `startTransition` to animate the swap. Add a shared element `name` to morph the card into the detail view:
 
 ```tsx
 'use client';
 
-import { useState, startTransition, ViewTransition } from 'react';
+import { useState, useRef, startTransition, ViewTransition } from 'react';
 
 export default function ItemGrid({ items }) {
   const [expandedId, setExpandedId] = useState(null);
+  const scrollRef = useRef(0);
 
   return expandedId ? (
-    <ViewTransition enter="slide-up" exit="slide-down">
+    <ViewTransition enter="slide-in" name={`item-${expandedId}`}>
       <ItemDetail
         item={items.find(i => i.id === expandedId)}
         onClose={() => {
           startTransition(() => {
             setExpandedId(null);
+            setTimeout(() => window.scrollTo({ behavior: 'smooth', top: scrollRef.current }), 100);
           });
         }}
       />
@@ -56,13 +58,12 @@ export default function ItemGrid({ items }) {
   ) : (
     <div className="grid grid-cols-3 gap-4">
       {items.map(item => (
-        <ViewTransition key={item.id}>
+        <ViewTransition key={item.id} name={`item-${item.id}`}>
           <ItemCard
             item={item}
             onSelect={() => {
-              startTransition(() => {
-                setExpandedId(item.id);
-              });
+              scrollRef.current = window.scrollY;
+              startTransition(() => setExpandedId(item.id));
             }}
           />
         </ViewTransition>
@@ -72,31 +73,7 @@ export default function ItemGrid({ items }) {
 }
 ```
 
-The CSS for slide-up/slide-down enter/exit:
-
-```css
-::view-transition-old(.slide-down) {
-  animation: 150ms ease-out both fade-out, 150ms ease-out both slide-down;
-}
-::view-transition-new(.slide-up) {
-  animation: 210ms ease-in 150ms both fade-in, 400ms ease-in both slide-up;
-}
-
-@keyframes slide-up {
-  from { transform: translateY(10px); }
-  to { transform: translateY(0); }
-}
-@keyframes slide-down {
-  from { transform: translateY(0); }
-  to { transform: translateY(10px); }
-}
-@keyframes fade-in {
-  from { opacity: 0; }
-}
-@keyframes fade-out {
-  to { opacity: 0; }
-}
-```
+The shared `name={`item-${id}`}` on both the card and detail `<ViewTransition>` creates a shared element pair — the card morphs into the detail view. The `scrollRef` saves and restores scroll position so users return to where they were in the grid. See `css-recipes.md` for the slide-up/slide-down CSS.
 
 ## Type-Safe Transition Helpers
 
@@ -144,6 +121,14 @@ Popovers, tooltips, and dropdowns can get captured in a parent's view transition
 ```
 
 This creates an independent transition group that renders above other transitioning elements. The element won't be included in its parent's old/new snapshot.
+
+For a global fix that ensures all view transition groups render above normal content, use the wildcard selector:
+
+```css
+::view-transition-group(*) {
+  z-index: 100;
+}
+```
 
 ## Reusable Animated Collapse
 

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -319,12 +319,6 @@ These are starting points. Test on low-end devices — animations that feel smoo
 **TypeScript error: "Property 'default' is missing in type 'ViewTransitionClassPerType'":**
 - When passing an object to `enter`/`exit`/`update`/`share`, TypeScript requires a `default` key in the object. This applies even if the component-level `default` prop is set. Always include `default: 'none'` (or `'auto'`) in type-keyed objects.
 
-**Sibling Suspense boundaries re-trigger each other's view transitions:**
-- With `experimental: { viewTransition: true }`, each Suspense resolution fires its own `document.startViewTransition`. A `<ViewTransition>` with `default="auto"` participates in **all** transitions on the page — not just its own Suspense resolve. If three Suspense boundaries resolve at different times, each one re-triggers every `default="auto"` VT on the page, producing repeated or staggered animations. Fix: use the split pattern with `default="none"` on the content `<ViewTransition>` and explicit `enter`/`exit` props — never rely on `default="auto"` on pages with multiple Suspense boundaries.
-
-**Cross-fade looks like a jump / stagger:**
-- If the Suspense fallback (skeleton) and the resolved content have different dimensions, the view transition captures different-sized before/after snapshots. The size change during the cross-fade produces a jarring shift. Fix: match the skeleton's item count, line heights, and overall dimensions to the real content as closely as possible.
-
 **Hash fragments cause scroll jumps during view transitions:**
 - Links with URL hash fragments (e.g., `/page#section`) trigger the browser's native scroll-to-anchor behavior during the navigation transition. This interferes with directional slide animations — the page scrolls to the anchor while simultaneously sliding horizontally, producing a diagonal jump. If you need to link to a specific section on a detail page, navigate without the hash and handle scroll/expansion programmatically after navigation completes.
 


### PR DESCRIPTION
## Summary

Adds a `vercel-react-view-transitions` skill for React's View Transition API and Next.js integration.

Covers `<ViewTransition>`, `addTransitionType`, shared elements, transition types, CSS pseudo-elements, composition rules (`default="none"`, two-layer pattern), and Next.js `transitionTypes` on `next/link`.

## Test output

Skill was used to implement view transitions in a Next.js app from scratch:
https://github.com/aurorascharff/view-transitions-demo/pull/1/changes

Also validated against [next16-conferences](https://github.com/aurorascharff/next16-conferences), [next16-async-react-blog](https://github.com/aurorascharff/next16-async-react-blog), and the [Next.js App Router Playground](https://github.com/vercel/next-app-router-playground/pull/210).

## Structure

- `SKILL.md` — Core skill (491 lines)
- `references/patterns.md` — Patterns, animation timing, events API, troubleshooting
- `references/css-recipes.md` — Copy-paste CSS recipes
- `references/nextjs.md` — Next.js App Router integration
- `AGENTS.md` — Compiled single-file version