### PR TITLE
Normalized agent skill names

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Review UI code for compliance with web interface best practices. Audits your cod
 - Touch & Interaction (touch-action, tap-highlight)
 - Locale & i18n (Intl.DateTimeFormat, Intl.NumberFormat)
 
-### react-native-guidelines
+### react-native-skills
 
 React Native best practices optimized for AI agents. Contains 16 rules across 7 sections covering performance, architecture, and platform-specific patterns.
 
@@ -106,7 +106,7 @@ React composition patterns that scale. Helps avoid boolean prop proliferation th
 - Composing internals for flexibility
 - Avoiding prop drilling
 
-### vercel-deploy-claimable
+### deploy-to-vercel
 
 Deploy applications and websites to Vercel instantly. Designed for use with claude.ai and Claude Desktop to enable deployments directly from conversations. Deployments are "claimable" - users can transfer ownership to their own Vercel account.
 

--- a/skills/composition-patterns/SKILL.md
+++ b/skills/composition-patterns/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: vercel-composition-patterns
+name: composition-patterns
 description:
   React composition patterns that scale. Use when refactoring components with
   boolean prop proliferation, building flexible component libraries, or

--- a/skills/react-best-practices/SKILL.md
+++ b/skills/react-best-practices/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: vercel-react-best-practices
+name: react-best-practices
 description: React and Next.js performance optimization guidelines from Vercel Engineering. This skill should be used when writing, reviewing, or refactoring React/Next.js code to ensure optimal performance patterns. Triggers on tasks involving React components, Next.js pages, data fetching, bundle optimization, or performance improvements.
 license: MIT
 metadata:

--- a/skills/react-native-skills/SKILL.md
+++ b/skills/react-native-skills/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: vercel-react-native-skills
+name: react-native-skills
 description:
   React Native and Expo best practices for building performant mobile apps. Use
   when building React Native components, optimizing list performance,

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: vercel-react-view-transitions
+name: react-view-transitions
 description: Guide for implementing smooth, native-feeling animations using React's View Transition API (`<ViewTransition>` component, `addTransitionType`, and CSS view transition pseudo-elements). Use this skill whenever the user wants to add page transitions, animate route changes, create shared element animations, animate enter/exit of components, animate list reorder, implement directional (forward/back) navigation animations, or integrate view transitions in Next.js. Also use when the user mentions view transitions, `startViewTransition`, `ViewTransition`, transition types, or asks about animating between UI states in React without third-party animation libraries.
 license: MIT
 metadata:


### PR DESCRIPTION
Summary
This PR normalizes skill naming so identifiers are consistent across skill frontmatter and top-level documentation.

Changes
Updated skill frontmatter name values to canonical identifiers:
vercel-composition-patterns -> composition-patterns
vercel-react-best-practices -> react-best-practices
vercel-react-native-skills -> react-native-skills
vercel-react-view-transitions -> react-view-transitions
Updated README skill headings for consistency:
react-native-guidelines -> react-native-skills
vercel-deploy-claimable -> deploy-to-vercel

Closes #235