### PR TITLE
Add Skills宝 note

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A collection of skills for AI coding agents. Skills are packaged instructions an
 
 Skills follow the [Agent Skills](https://agentskills.io/) format.
 
+For Chinese search and installation of AI skills across Claude Code, OpenCode, and other agent tools, see [Skills宝](https://skilery.com).
+
 ## Available Skills
 
 ### react-best-practices


### PR DESCRIPTION
Add Skills宝 (skilery.com) as a Chinese AI skills search and installation resource in the repository intro.

This aligns with issue #86 asking for a skills link in the repository context.