### PR TITLE
Add domain-finder skill — verified availability + aftermarket pricing via Fastly

### DIFF
--- a/skills/domain-finder/LICENSE
+++ b/skills/domain-finder/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jan Kuppens
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/domain-finder/README.md
+++ b/skills/domain-finder/README.md
@@ -1,0 +1,159 @@
+# domain-finder
+
+A Claude Code skill that finds available domain names with **real-time verified availability** via Fastly's Domain Research API. No more "AI suggested foo.com, but it's actually taken." Also surfaces **aftermarket pricing** when a domain is squatter-held — so you know whether `aimascot.com` is free, or held by HugeDomains for $2,495.
+
+Works inside Claude Code as a skill, or standalone as a Node CLI.
+
+## Install (as a Claude Code skill)
+
+```bash
+npx skills add kups-nl/domain-finder
+```
+
+The interactive installer asks for a **scope** (Project or User) and which **agents** to install for. Files land in `<scope>/.agents/skills/domain-finder/` — the canonical universal path that skill-aware agents read from (Claude Code, Cursor, Codex, Amp, Cline, OpenCode, Warp, +others).
+
+| Scope     | Install path                                | When to pick                              |
+|-----------|---------------------------------------------|-------------------------------------------|
+| **User**  | `~/.agents/skills/domain-finder/`           | Always available, in every project        |
+| **Project** | `<your-project>/.agents/skills/domain-finder/` | Scoped to one codebase                 |
+
+## One-time setup
+
+### 1. Get a Fastly API token
+
+1. Go to <https://manage.fastly.com/account/personal/tokens>
+2. Create a token (the default read scope is enough)
+3. Copy it
+
+The free tier covers the Domain Research API at a generous rate limit.
+
+### 2. Set the env var
+
+Either export globally (recommended):
+
+```bash
+echo 'export FASTLY_KEY=<your-token>' >> ~/.zshrc
+source ~/.zshrc
+```
+
+Or drop it in `.env.local` (or `.env`) in any project directory — the script walks up from `cwd` looking for it:
+
+```
+FASTLY_KEY=<your-token>
+```
+
+### 3. Verify
+
+```bash
+SCRIPT=$(ls ~/.agents/skills/domain-finder/scripts/check.mjs ./.agents/skills/domain-finder/scripts/check.mjs 2>/dev/null | head -1)
+echo "google.com" | node "$SCRIPT"
+```
+
+Expected:
+
+```
+Checking 1 domain(s) via Fastly...
+[1/1]    · registered google.com
+
+0 available · 0 for sale · 1 registered · 0 errors
+```
+
+If you see `error: FASTLY_KEY not set` → env var didn't load. Re-run `source ~/.zshrc` or open a new terminal.
+
+## Usage inside Claude Code
+
+The skill activates automatically when Claude sees you asking for a brand/domain. Trigger phrases include:
+
+- "find me a domain for X"
+- "is foo.com available?"
+- "I need a brand name for my new project"
+- "what should I call this?"
+- "rebrand from X to something else"
+
+Claude then runs a brief discovery (audience, vibe, constraints), brainstorms 30–80 candidates, runs them through `scripts/check.mjs`, and presents grouped results with aftermarket pricing.
+
+## Direct CLI use (without Claude)
+
+```bash
+# from file
+node scripts/check.mjs --file candidates.txt
+
+# from stdin
+cat candidates.txt | node scripts/check.mjs
+
+# inline
+node scripts/check.mjs mascot.com mascot.ai mascot.studio
+
+# JSON for scripting / agent parsing
+node scripts/check.mjs --file in.txt --json --available-only > free.json
+```
+
+### Example output
+
+```
+$ echo -e "anthropic.com\nopenai.com\naimascot.com\nfreshlybaked123xyz.com" | node scripts/check.mjs
+
+Checking 4 domain(s) via Fastly...
+[1/4]    · registered anthropic.com
+[2/4]    · registered openai.com
+[3/4]    $ FOR_SALE   aimascot.com  USD 2,495 (HugeDomains)
+[4/4]    ✓ AVAILABLE  freshlybaked123xyz.com
+
+1 available · 1 for sale · 2 registered · 0 errors
+```
+
+## What you get back per domain
+
+```json
+{
+  "domain": "aimascot.com",
+  "status": "marketed priced active",
+  "zone": "...",
+  "tags": ["..."],
+  "offers": [{ "price": 2495, "currency": "USD", "vendor": "HugeDomains" }],
+  "category": "for_sale"
+}
+```
+
+Four `category` values:
+
+| Category     | Meaning                                                  |
+|--------------|----------------------------------------------------------|
+| `available`  | Free to register at any registrar                        |
+| `for_sale`   | Squatter is selling, `offers[]` has the price            |
+| `registered` | Active site, not for sale                                |
+| `error`      | Transient HTTP/network issue or rate-limit (retry/skip)  |
+
+## Why this beats WHOIS / TransIP / generic AI naming tools
+
+- **No key signing, no IP whitelist** — just one HTTP header
+- **Works for any TLD** — Fastly is a registry-data API, not a registrar
+- **Includes aftermarket pricing** — you instantly know if `aimascot.com` is held by HugeDomains for $2,495, vs an active business
+- **Rate-limit aware** — 250 ms pacing handles 100+ domain batches; 5× retry on 429 with `retry-after` honoring
+- **No hallucinations** — the skill is built around the rule that nothing is presented as "available" without a verified API response
+
+## CLI flag reference
+
+```
+node scripts/check.mjs <domain>...           # check positional args
+node scripts/check.mjs --file <path>         # check from file (one per line, # comments OK)
+echo "..." | node scripts/check.mjs          # check from stdin
+node scripts/check.mjs --json                # JSON output instead of human-readable
+node scripts/check.mjs --available-only      # only print free ones
+node scripts/check.mjs --delay 400           # ms between calls (default 250)
+```
+
+## Known gotchas
+
+- Fastly status strings are space-separated tag bags (e.g. `"marketed priced active"`). Use the `category` field in the output, don't parse `status` yourself.
+- Rate limit: ~25 reqs/burst, then 429. Script handles this with backoff using the `retry-after` header.
+- Some ccTLDs return ambiguous statuses due to limited registry visibility. Treat `unknown` as "verify at the registry directly."
+- The free tier of the Fastly API is generous but not unlimited. Large batches (500+ checks/day) may exceed it.
+
+## Agent portability
+
+The Claude Code skill workflow uses `AskUserQuestion`, `WebSearch`, and `WebFetch` for the discovery and pre-flight steps — those are Claude-Code-specific. The core `scripts/check.mjs` script is plain Node ESM with no dependencies, so it works in any agent harness that can shell out, or as a regular CLI for humans.
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/skills/domain-finder/SKILL.md
+++ b/skills/domain-finder/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: domain-finder
+description: Verify domain availability in real time via Fastly's Domain Research API across every TLD — and surface aftermarket prices when a domain is squatter-held. Triggers on any brand-name, domain, URL, "is X.com taken," rebrand, or naming question. Never claim a domain is available without running the verified check first.
+license: MIT
+metadata:
+  author: kups-nl
+  version: '1.0.0'
+---
+
+# Domain Finder
+
+You help the user find a brand/domain name that is **actually available right now**, not hallucinated. The Fastly Domain Research API in `scripts/check.mjs` is the verified source of truth. It also returns aftermarket pricing when a domain is held by a squatter (HugeDomains, Sedo, etc.), so you can give the user both a "free to register" list *and* a "for sale at $X" list — a unique capability versus other AI naming tools.
+
+## When to Apply
+
+Invoke this skill when:
+
+- The user asks for a brand name, domain name, or URL for a project ("find me a domain for X")
+- The user wants to verify a specific domain ("is foo.com available?", "is X.com taken?")
+- The user is rebranding, renaming, or starting a new product
+- The user mentions naming, branding, or "what should I call this"
+- The user asks for variants across TLDs (`.ai`, `.studio`, `.app`, `.com`, etc.)
+- The user asks about aftermarket pricing or whether a squatter holds a domain
+
+## Setup
+
+### Script path
+
+- User-scope install (default for `npx skills add`): `~/.agents/skills/domain-finder/scripts/check.mjs`
+- Project-scope install: `./.agents/skills/domain-finder/scripts/check.mjs`
+
+Examples below use the user-scope path — substitute if the user is project-scoped.
+
+### FASTLY_KEY
+
+If the env var isn't set, the script prints full setup instructions in its error message. Relay them. Offer to write `FASTLY_KEY=<token>` to `.env.local` in the user's working directory (the script walks parent dirs), or to `~/.zshrc` for persistence. Free token: <https://manage.fastly.com/account/personal/tokens>.
+
+## Workflow
+
+### 1. Get the brief
+
+If the user gave a brief, parse it. If not, ask 1–3 short questions (use `AskUserQuestion` when available):
+
+- **Audience** (developers, marketers, SMB owners, kids, B2B, etc.)
+- **Vibe** (descriptive vs brandable; playful vs professional; abstract vs concrete)
+- **Constraints** (must have `.com`? must include "AI"? no `-ly` suffix? no fake-foreign suffixes?)
+- **Examples of names they like/dislike** if available
+
+Don't over-interrogate. 2 questions max if you have to ask at all.
+
+### 2. Generate candidates
+
+Brainstorm 30–80 candidates **before** any availability check. Spread across categories so you can learn the user's taste from their reactions:
+
+- **Descriptive compound** (`mascotbuilder`, `charactermaker`, `mintforge`)
+- **Single-word abstract** (`forge`, `castable`, `guise`)
+- **Invented / portmanteau** (`castyra`, `mascotello`, `heronix`)
+- **TLD hacks** (`mascot.to`, `for.ge`, `char.it`) — only when the split reads naturally as the word
+- **Short 4–5 letter brandable** (`vixa`, `zexa`, `ruvi` — Pika/Sora-tier)
+
+Pick TLDs to test based on the brief:
+- AI tool → always include `.ai` plus `.app` + `.studio`
+- General SaaS → `.com` + `.app` + `.io`
+- Marketing/agency → `.com` + `.studio` + `.co`
+
+### 3. Verify with the script
+
+Write candidates to a temp file (one per line, `#` comments allowed), then:
+
+```bash
+node ~/.agents/skills/domain-finder/scripts/check.mjs --file /tmp/candidates.txt --json
+```
+
+Or pipe directly:
+
+```bash
+echo "foo.com
+bar.ai
+baz.studio" | node ~/.agents/skills/domain-finder/scripts/check.mjs --json
+```
+
+Parse the JSON, group by `category`:
+- `"category": "available"` — free to register **(safe to present as available)**
+- `"category": "for_sale"` — squatter-held, has `offers[]` with pricing
+- `"category": "registered"` — in active use
+- `"category": "error"` — retry or skip
+
+**Never claim a name is available unless `category === "available"` in this session's JSON output.**
+
+### 4. Present results
+
+Use a master-list format with TLDs as columns next to each base name, plus a "Top picks" section at the top. Surface aftermarket prices for popular names — they're useful intel even if expensive:
+
+```
+🏆 Top picks
+- mascotbuilder.ai  (descriptive + AI signal, on-narrative)
+- castcraft.studio  (brandable + broader than "mascot")
+
+✓ Available
+mascotbuilder    .studio  .app  .ai
+charactermaker   .studio  .app
+...
+
+$ For sale on aftermarket (cheapest first)
+| Domain          | Price       | Vendor       |
+|-----------------|-------------|--------------|
+| aimascot.com    | USD 2,495   | HugeDomains  |
+| brandmascot.com | USD 1,200   | Sedo         |
+```
+
+For each top pick, give a one-line justification tied to the user's brief.
+
+### 5. Iterate
+
+The user's reaction is the most valuable signal. When they react:
+
+- **"Too X"** → drop the X-tagged candidates, regenerate with that constraint
+- **"I like [name]"** → save it as a north star; future suggestions should pattern-match
+- **"`X.com` is actually taken"** → trust them, drop X, update mental model
+
+Persist the running constraints **in this conversation** (no DB needed). Re-state them before each new candidate batch so the user can correct.
+
+## Pre-flight (optional, when user is near-committed)
+
+When the user has narrowed to 1–3 finalists, offer to pre-flight:
+
+1. **SERP collision** — `WebSearch` `"<name>" company product app` to check for active brands using the same name
+2. **`<name>.com` redirect check** — Fastly's API already tells you if it's for-sale and what the price is; cross-check with a `WebFetch` to see what landing page is served
+3. **Social handles** — `WebFetch` `instagram.com/<name>`, `github.com/<name>`, `twitter.com/<name>` for handle availability
+4. **Trademark** — point them to <https://tmsearch.uspto.gov> and <https://www.euipo.europa.eu> — actual trademark search is hard to automate cleanly
+
+Skip pre-flight on early candidates — it's wasted effort until the user has narrowed.
+
+## Hard rules
+
+- **NEVER fabricate availability.** If you haven't run the script for a name in this session, you don't know its status. Run it.
+- **`for_sale` ≠ available.** Surface the price honestly. A $2,495 domain is buyable but not "free to register" — the user should know the difference.
+- **Respect rejections.** If a user says "no -ly suffix," don't try to slip one in three rounds later.
+- **Don't over-search.** If `.com` is taken (or for-sale aftermarket) across the first 25 short brandable candidates, stop trying — short `.com`s are basically all gone. Pivot to other TLDs.
+- **The check is the moat.** Every name you present as available must have a `category: "available"` entry in the most recent script output.
+
+## Script flag reference
+
+```
+node scripts/check.mjs <domain>...                  # check positional args
+node scripts/check.mjs --file <path>                # check from file
+echo "..." | node scripts/check.mjs                 # check from stdin
+node scripts/check.mjs --json                       # JSON output instead of human
+node scripts/check.mjs --available-only             # only print free
+node scripts/check.mjs --delay 400                  # ms between calls (default 250)
+```
+
+Rate-limit aware: 5× retry on 429 honoring the `retry-after` header. 15 s per-request timeout via `AbortSignal`. Default 250 ms pacing handles batches of 100+ cleanly.

--- a/skills/domain-finder/scripts/check.mjs
+++ b/skills/domain-finder/scripts/check.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+// Portable Fastly Domain Research API checker.
+//
+// Auth: one env var — FASTLY_KEY.
+// Get one at: https://manage.fastly.com/account/personal/tokens
+//
+// Input: domains via stdin (newline-separated), CLI args, or --file <path>
+//   echo "foo.com\nbar.ai" | node check.mjs
+//   node check.mjs foo.com bar.ai
+//   node check.mjs --file candidates.txt
+//
+// Output:
+//   default → human-readable: "✓ AVAILABLE  foo.com" / "$ FOR_SALE  foo.com  USD 2495 (HugeDomains)"
+//   --json  → machine: {"results":[{"domain":"foo.com","category":"available", ...}, ...]}
+//   --available-only → only print free ones (works in both modes)
+//
+// Fastly status decoding:
+//   "undelegated inactive"           → available (free to register)
+//   "marketed priced active"         → for_sale (aftermarket; offers[] has price)
+//   "active" / contains "active"     → registered (in active use)
+//   anything else (rate_limited etc) → error
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, dirname, join } from "node:path";
+import { homedir } from "node:os";
+
+const args = process.argv.slice(2);
+const VALUE_FLAGS = new Set(["--file", "--delay"]);
+const flag = (name) => args.includes(name);
+const flagValue = (name) => {
+  const i = args.indexOf(name);
+  return i >= 0 && i + 1 < args.length ? args[i + 1] : null;
+};
+const positional = [];
+for (let i = 0; i < args.length; i++) {
+  const a = args[i];
+  if (a.startsWith("--")) {
+    if (VALUE_FLAGS.has(a)) i++; // skip the flag's value
+    continue;
+  }
+  positional.push(a);
+}
+
+const JSON_OUT = flag("--json");
+const AVAILABLE_ONLY = flag("--available-only");
+const DELAY_MS = Number(flagValue("--delay") ?? 250);
+
+// ── Auth ────────────────────────────────────────────────────────────────
+loadKeyFromEnvFiles();
+const FASTLY_KEY = process.env.FASTLY_KEY;
+if (!FASTLY_KEY) {
+  die(
+    [
+      "FASTLY_KEY not set. Set it one of these ways:",
+      "",
+      "  1. Export in your shell (persist in ~/.zshrc or ~/.bashrc):",
+      "     export FASTLY_KEY=<your-token>",
+      "",
+      "  2. Drop into a .env.local or .env file in this dir or any parent dir:",
+      "     FASTLY_KEY=<your-token>",
+      "",
+      "Get a free token: https://manage.fastly.com/account/personal/tokens",
+    ].join("\n"),
+  );
+}
+
+// ── Read input ──────────────────────────────────────────────────────────
+const domains = await collectDomains(positional, flagValue("--file"));
+if (domains.length === 0) die("No domains given. Pipe via stdin, pass args, or use --file.");
+
+// ── Run ─────────────────────────────────────────────────────────────────
+if (!JSON_OUT) process.stderr.write(`Checking ${domains.length} domain(s) via Fastly...\n`);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const results = [];
+
+for (let i = 0; i < domains.length; i++) {
+  let r;
+  try {
+    r = await checkOne(domains[i]);
+  } catch (e) {
+    r = { domain: domains[i], status: "fetch_error", error: String(e).slice(0, 200) };
+  }
+  const category = classify(r);
+  const enriched = { ...r, category };
+  results.push(enriched);
+  if (!JSON_OUT) printLine(i + 1, domains.length, enriched);
+  if (i + 1 < domains.length) await sleep(DELAY_MS);
+}
+
+// ── Output ──────────────────────────────────────────────────────────────
+if (JSON_OUT) {
+  const filtered = AVAILABLE_ONLY ? results.filter((r) => r.category === "available") : results;
+  process.stdout.write(`${JSON.stringify({ results: filtered }, null, 2)}\n`);
+} else {
+  const counts = countByCategory(results);
+  process.stderr.write(
+    `\n${counts.available} available · ${counts.for_sale} for sale · ${counts.registered} registered · ${counts.error} errors\n`,
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// helpers
+
+function die(msg) {
+  process.stderr.write(`error: ${msg}\n`);
+  process.exit(1);
+}
+
+// Walk from cwd up to home (or root) looking for .env.local / .env with FASTLY_KEY.
+// Stops at the first file that contains the key, so closer files win.
+function loadKeyFromEnvFiles() {
+  if (process.env.FASTLY_KEY) return;
+  const stop = homedir();
+  let dir = process.cwd();
+  const filenames = [".env.local", ".env"];
+  // Hard cap on dir-walk depth as a safety net.
+  for (let i = 0; i < 12; i++) {
+    for (const name of filenames) {
+      const path = join(dir, name);
+      if (existsSync(path) && readKeyFromFile(path)) return;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    if (dir === stop) break;
+    dir = parent;
+  }
+  // Also try ~/.config/domain-finder/key (one-line file).
+  const xdg = join(homedir(), ".config", "domain-finder", "key");
+  if (existsSync(xdg)) {
+    try {
+      const v = readFileSync(xdg, "utf8").trim();
+      if (v) process.env.FASTLY_KEY = v;
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+function readKeyFromFile(path) {
+  try {
+    const text = readFileSync(path, "utf8");
+    for (const line of text.split("\n")) {
+      const m = line.match(/^\s*FASTLY_KEY\s*=\s*(.+?)\s*$/);
+      if (m) {
+        process.env.FASTLY_KEY = m[1].replace(/^["']|["']$/g, "");
+        return true;
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+  return false;
+}
+
+async function collectDomains(positional, filePath) {
+  const out = [];
+  if (filePath) {
+    const text = readFileSync(resolve(filePath), "utf8");
+    for (const line of text.split("\n")) {
+      const t = line.trim();
+      if (t && !t.startsWith("#")) out.push(t);
+    }
+  }
+  if (positional.length) out.push(...positional);
+  if (!process.stdin.isTTY) {
+    const chunks = [];
+    for await (const c of process.stdin) chunks.push(c);
+    const text = Buffer.concat(chunks).toString("utf8");
+    for (const line of text.split("\n")) {
+      const t = line.trim();
+      if (t && !t.startsWith("#")) out.push(t);
+    }
+  }
+  return [...new Set(out)];
+}
+
+async function checkOne(domain) {
+  const url = `https://api.fastly.com/domain-management/v1/tools/status?domain=${encodeURIComponent(domain)}`;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const res = await fetch(url, {
+      headers: { "Fastly-Key": FASTLY_KEY, Accept: "application/json" },
+      signal: AbortSignal.timeout(15000),
+    });
+    if (res.status === 429) {
+      const retryAfter = Number(res.headers.get("retry-after") || "2") * 1000;
+      await sleep(retryAfter * (attempt + 1));
+      continue;
+    }
+    if (!res.ok) {
+      return {
+        domain,
+        status: `http_${res.status}`,
+        error: (await res.text()).slice(0, 200),
+      };
+    }
+    return await res.json(); // { domain, zone, status, tags, offers? }
+  }
+  return { domain, status: "rate_limited" };
+}
+
+function classify(r) {
+  const s = String(r.status ?? "");
+  if (s.startsWith("http_") || s === "rate_limited" || s === "fetch_error") return "error";
+  if (s.includes("marketed")) return "for_sale";
+  if (s === "undelegated inactive" || s === "inactive undelegated") return "available";
+  if (s.includes("undelegated") && !s.includes("active")) return "available";
+  if (s.includes("active")) return "registered";
+  return "unknown";
+}
+
+function printLine(idx, total, r) {
+  const cat = r.category;
+  if (AVAILABLE_ONLY && cat !== "available") return;
+  const prefix = `[${idx}/${total}]`.padEnd(8);
+  const sym =
+    cat === "available"
+      ? "✓ AVAILABLE  "
+      : cat === "for_sale"
+        ? "$ FOR_SALE   "
+        : cat === "registered"
+          ? "· registered "
+          : cat === "error"
+            ? "! ERROR      "
+            : "? unknown    ";
+  let extra = "";
+  if (cat === "for_sale" && Array.isArray(r.offers) && r.offers.length > 0) {
+    const cheapest = r.offers.reduce((a, b) =>
+      Number(a.price) < Number(b.price) ? a : b,
+    );
+    extra = `  ${cheapest.currency} ${Number(cheapest.price).toLocaleString()} (${cheapest.vendor})`;
+  } else if (cat === "error") {
+    extra = `  ${r.status}${r.error ? ` — ${r.error.slice(0, 60)}` : ""}`;
+  }
+  process.stdout.write(`${prefix} ${sym}${r.domain}${extra}\n`);
+}
+
+function countByCategory(results) {
+  const c = { available: 0, for_sale: 0, registered: 0, error: 0, unknown: 0 };
+  for (const r of results) c[r.category] = (c[r.category] || 0) + 1;
+  return c;
+}


### PR DESCRIPTION
# Title

Add domain-finder skill — verified availability + aftermarket pricing via Fastly

# Body

## Summary

- Adds **domain-finder** skill — verifies domain availability in real time against Fastly's Domain Research API across every TLD
- Surfaces **aftermarket pricing** (HugeDomains, Sedo, etc.) when a domain is squatter-held — distinguishes "free to register" from "for sale at $2,495"
- Built around a hard rule: nothing is presented as "available" without a verified API response in the current session
- Triggers on any brand-name, domain, URL, "is X.com taken?", rebrand, or naming question

## Skill Details

| Field    | Value         |
|----------|---------------|
| Name     | `domain-finder` |
| Author   | kups-nl       |
| Version  | 1.0.0         |
| License  | MIT           |
| Category | Domain availability / naming |

## What it does

Common agent failure mode: "AI suggests `foo.com`" → user checks → "actually taken." This skill fixes that by routing every availability claim through a verified check.

It uses [Fastly's Domain Research API](https://www.fastly.com/documentation/reference/api/domain-management/domain-research/), which returns one of four states for any domain across any TLD:

- `available` → free to register
- `for_sale` → squatter-held, with `offers[]` listing price + vendor
- `registered` → in active use
- `error` → transient / rate-limit / unknown TLD

For aftermarket-held domains, the script returns the offer price — so the agent can present an honest split: "`X.ai` is free to register; `X.com` is buyable for $2,495 from HugeDomains."

The workflow inside Claude Code:

1. **Brief** — quick discovery of audience, vibe, constraints (uses `AskUserQuestion`)
2. **Generate** — brainstorm 30–80 candidates spread across descriptive / abstract / portmanteau / TLD-hack / 4–5-letter-brandable categories
3. **Verify** — pipe candidates through `scripts/check.mjs --json`, group by `category`
4. **Present** — Top picks + Available master-list + Aftermarket-pricing table
5. **Iterate** — track user reactions as running constraints, regenerate

## Coverage

Works for any TLD Fastly indexes — `.com`, `.ai`, `.io`, `.studio`, `.app`, `.co`, `.to`, country codes (`.it`, `.ge`, `.eu`, `.nl`), and the long tail. The script auto-classifies status strings into the four-category enum, so the agent doesn't have to parse Fastly's space-separated tag bags like `"marketed priced active"`.

## Resilience

- 5× retry on `429` honoring the `retry-after` header
- 15 s per-request timeout via `AbortSignal.timeout(15000)`
- 250 ms default pacing between calls — handles batches of 100+ cleanly
- Zero runtime dependencies (plain Node ESM, `fetch` + `node:fs` + `node:path` + `node:os`)

## Testing

```bash
# Install
npx skills add kups-nl/domain-finder

# Get a free Fastly API token (read scope is enough)
# https://manage.fastly.com/account/personal/tokens
export FASTLY_KEY=<your-token>

# Smoke
echo "anthropic.com" | node ~/.agents/skills/domain-finder/scripts/check.mjs
# expected: · registered anthropic.com
```

Inside Claude Code, the trigger is any naming or domain question: "find me a domain for X", "is foo.com taken?", "rebrand from X", "what should I call this?"

## Files

```
skills/domain-finder/
├── SKILL.md       (name, description, license, metadata frontmatter)
├── README.md      (install + setup + CLI usage)
├── LICENSE        (MIT)
└── scripts/
    └── check.mjs  (Fastly API client; ~250 LOC, no deps)
```

## Source

- Standalone repo: <https://github.com/kups-nl/domain-finder>
- Author: [@JanKups](https://github.com/JanKups)
- License: MIT