### PR TITLE
Tighten Vercel Optimize data gaps and account scope

### DIFF
--- a/packages/vercel-optimize-tests/test/collect-framework-preflight.test.mjs
+++ b/packages/vercel-optimize-tests/test/collect-framework-preflight.test.mjs
@@ -97,10 +97,19 @@ if (args[0] === 'api') {
     json({ id: 'team_hobby', slug: 'fixture', billing: { plan: 'hobby' } });
   }
 }
+function requireScope(expected) {
+  const i = args.indexOf('--scope');
+  if (i === -1 || args[i + 1] !== expected) {
+    process.stderr.write('missing expected scope ' + expected + ': ' + args.join(' ') + '\\n');
+    process.exit(67);
+  }
+}
 if (args[0] === 'contract') {
+  requireScope('fixture');
   json({ context: 'fixture', commitments: [], totalCommitments: 0 });
 }
 if (args[0] === 'usage') {
+  requireScope('fixture');
   json({
     context: 'fixture',
     groupBy: { dimension: 'project', data: [] },
@@ -121,9 +130,114 @@ process.exit(66);
     const out = JSON.parse(stdout);
     assert.equal(out.plan.plan, 'hobby');
     assert.match(out.plan.reason, /team\.billing\.plan=hobby/);
+    assert.equal(out.commandScope.cliScope, 'fixture');
+    assert.equal(out.commandScope.source, 'team-api');
     assert.deepEqual(out.contract, { context: 'fixture', commitments: [], totalCommitments: 0 });
     assert.equal(out.usageError, null);
     assert.doesNotMatch(stderr, /unexpected vercel call/);
+    assert.doesNotMatch(stderr, /missing expected scope/);
+  } finally {
+    await rm(scratch, { recursive: true, force: true });
+  }
+});
+
+test('collect-signals: scopes metrics, contract, and usage to the linked team slug', async () => {
+  const scratch = await mkdtemp(join(tmpdir(), 'vo-command-scope-'));
+  const bin = join(scratch, 'bin');
+  try {
+    await mkdir(bin, { recursive: true });
+    await mkdir(join(scratch, '.vercel'), { recursive: true });
+    await writeFile(join(scratch, 'package.json'), JSON.stringify({
+      dependencies: { next: '^15.3.0' },
+    }), 'utf-8');
+    await writeFile(join(scratch, '.vercel', 'project.json'), JSON.stringify({
+      projectId: 'prj_scope',
+      orgId: 'team_scope',
+    }), 'utf-8');
+    const fakeVercel = join(bin, 'vercel');
+    await writeFile(fakeVercel, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+function json(value, code = 0) {
+  process.stdout.write(JSON.stringify(value, null, 2) + '\\n');
+  process.exit(code);
+}
+function requireScope(expected) {
+  const i = args.indexOf('--scope');
+  if (i === -1 || args[i + 1] !== expected || args.includes('team_scope')) {
+    process.stderr.write('missing expected scope ' + expected + ': ' + args.join(' ') + '\\n');
+    process.exit(67);
+  }
+}
+if (args[0] === '--version') {
+  process.stdout.write('54.1.0\\n');
+  process.exit(0);
+}
+if (args[0] === 'whoami' && args[1] === '--format') {
+  json({
+    username: 'test-user',
+    team: { id: 'team_other', slug: 'other-team', name: 'Other Team' },
+  });
+}
+if (args[0] === 'whoami') {
+  process.stdout.write('test-user\\n');
+  process.exit(0);
+}
+if (args[0] === 'api') {
+  const path = args[1];
+  if (path.startsWith('/v1/observability/manage/configuration/projects')) {
+    json({ disabledProjects: [] });
+  }
+  if (path === '/v9/projects/prj_scope?teamId=team_scope') {
+    json({ id: 'prj_scope', name: 'fixture-site' });
+  }
+  if (path === '/v2/teams/team_scope') {
+    json({ id: 'team_scope', slug: 'team-scope', billing: { plan: 'pro' } });
+  }
+}
+if (args[0] === 'metrics') {
+  requireScope('team-scope');
+  json({ summary: [], data: [], statistics: {} });
+}
+if (args[0] === 'contract') {
+  requireScope('team-scope');
+  json({ context: 'team-scope', commitments: [], totalCommitments: 0 });
+}
+if (args[0] === 'usage') {
+  requireScope('team-scope');
+  json({
+    context: 'team-scope',
+    groupBy: {
+      dimension: 'project',
+      data: [{
+        projectId: 'prj_scope',
+        name: 'fixture-site',
+        services: [{ name: 'Function Invocations', billedCost: 3 }],
+        totals: { billedCost: 3 },
+      }],
+    },
+    services: [{ name: 'Function Invocations', billedCost: 3 }],
+    totals: { billedCost: 3 },
+  });
+}
+process.stderr.write('unexpected vercel call: ' + args.join(' ') + '\\n');
+process.exit(66);
+`, 'utf-8');
+    await chmod(fakeVercel, 0o755);
+
+    const { stdout, stderr } = await exec('node', [COLLECT], {
+      cwd: scratch,
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    const out = JSON.parse(stdout);
+    assert.equal(out.commandScope.cliScope, 'team-scope');
+    assert.equal(out.commandScope.source, 'team-api');
+    assert.equal(out.usageScope, 'project');
+    assert.equal(out.usageError, null);
+    assert.equal(out.usage.project.projectId, 'prj_scope');
+    assert.match(out.plan.reason, /team\.billing\.plan=pro/);
+    assert.doesNotMatch(stderr, /unexpected vercel call/);
+    assert.doesNotMatch(stderr, /missing expected scope/);
   } finally {
     await rm(scratch, { recursive: true, force: true });
   }
@@ -168,7 +282,7 @@ if (args[0] === 'api') {
   if (path === '/v9/projects/prj_test') {
     json({ id: 'prj_test', name: 'fixture-site' });
   }
-  if (path === '/v2/teams/team_current') {
+  if (path === '/v2/teams/current-team') {
     json({ id: 'team_current', slug: 'current-team', billing: { plan: 'pro' } });
   }
   if (path === '/v2/user') {

--- a/packages/vercel-optimize-tests/test/collect-framework-preflight.test.mjs
+++ b/packages/vercel-optimize-tests/test/collect-framework-preflight.test.mjs
@@ -243,8 +243,8 @@ process.exit(66);
   }
 });
 
-test('collect-signals: no orgId uses current CLI team billing.plan before user billing.plan', async () => {
-  const scratch = await mkdtemp(join(tmpdir(), 'vo-current-team-plan-'));
+test('collect-signals: missing orgId stops before scoped Vercel calls', async () => {
+  const scratch = await mkdtemp(join(tmpdir(), 'vo-missing-scope-'));
   const bin = join(scratch, 'bin');
   try {
     await mkdir(bin, { recursive: true });
@@ -266,55 +266,79 @@ if (args[0] === '--version') {
   process.stdout.write('54.1.0\\n');
   process.exit(0);
 }
-if (args[0] === 'whoami' && args[1] === '--format') {
-  json({
-    username: 'test-user',
-    billing: { plan: 'hobby' },
-    team: { id: 'team_current', slug: 'current-team', name: 'Current Team' },
-  });
-}
-if (args[0] === 'whoami') {
+if (args[0] === 'whoami' && args.length === 1) {
   process.stdout.write('test-user\\n');
   process.exit(0);
-}
-if (args[0] === 'api') {
-  const path = args[1];
-  if (path === '/v9/projects/prj_test') {
-    json({ id: 'prj_test', name: 'fixture-site' });
-  }
-  if (path === '/v2/teams/current-team') {
-    json({ id: 'team_current', slug: 'current-team', billing: { plan: 'pro' } });
-  }
-  if (path === '/v2/user') {
-    json({ user: { username: 'test-user', billing: { plan: 'hobby' } } });
-  }
-}
-if (args[0] === 'contract') {
-  json({ context: 'current-team', commitments: [], totalCommitments: 0 });
-}
-if (args[0] === 'usage') {
-  json({
-    context: 'current-team',
-    groupBy: { dimension: 'project', data: [] },
-    services: [],
-    totals: { billedCost: 0 },
-  });
 }
 process.stderr.write('unexpected vercel call: ' + args.join(' ') + '\\n');
 process.exit(66);
 `, 'utf-8');
     await chmod(fakeVercel, 0o755);
 
-    const { stdout, stderr } = await exec('node', [COLLECT, '--continue-without-observability'], {
-      cwd: scratch,
-      env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
-      maxBuffer: 8 * 1024 * 1024,
-    });
-    const out = JSON.parse(stdout);
-    assert.equal(out.plan.plan, 'pro');
-    assert.match(out.plan.reason, /team\.billing\.plan=pro/);
-    assert.equal(out.orgId, null);
-    assert.doesNotMatch(stderr, /unexpected vercel call/);
+    let err;
+    try {
+      await exec('node', [COLLECT, '--continue-without-observability'], {
+        cwd: scratch,
+        env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+        maxBuffer: 8 * 1024 * 1024,
+      });
+    } catch (e) {
+      err = e;
+    }
+    assert.ok(err, 'collector should stop when project scope is ambiguous');
+    assert.equal(err.code, 1);
+    assert.equal(err.stdout, '');
+    assert.match(err.stderr, /PROJECT_SCOPE_UNRESOLVED/);
+    assert.doesNotMatch(err.stderr, /unexpected vercel call/);
+    assert.doesNotMatch(err.stderr, /whoami --format/);
+  } finally {
+    await rm(scratch, { recursive: true, force: true });
+  }
+});
+
+test('collect-signals: multi-project repo.json stops instead of choosing the first project', async () => {
+  const scratch = await mkdtemp(join(tmpdir(), 'vo-ambiguous-repo-'));
+  const bin = join(scratch, 'bin');
+  try {
+    await mkdir(bin, { recursive: true });
+    await mkdir(join(scratch, '.vercel'), { recursive: true });
+    await writeFile(join(scratch, '.vercel', 'repo.json'), JSON.stringify({
+      projects: [
+        { id: 'prj_first', orgId: 'team_first' },
+        { id: 'prj_second', orgId: 'team_second' },
+      ],
+    }), 'utf-8');
+    const fakeVercel = join(bin, 'vercel');
+    await writeFile(fakeVercel, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  process.stdout.write('54.1.0\\n');
+  process.exit(0);
+}
+if (args[0] === 'whoami' && args.length === 1) {
+  process.stdout.write('test-user\\n');
+  process.exit(0);
+}
+process.stderr.write('unexpected vercel call: ' + args.join(' ') + '\\n');
+process.exit(66);
+`, 'utf-8');
+    await chmod(fakeVercel, 0o755);
+
+    let err;
+    try {
+      await exec('node', [COLLECT], {
+        cwd: scratch,
+        env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+        maxBuffer: 8 * 1024 * 1024,
+      });
+    } catch (e) {
+      err = e;
+    }
+    assert.ok(err, 'collector should stop on ambiguous repo links');
+    assert.equal(err.code, 1);
+    assert.equal(err.stdout, '');
+    assert.match(err.stderr, /AMBIGUOUS_PROJECT_LINK/);
+    assert.doesNotMatch(err.stderr, /unexpected vercel call/);
   } finally {
     await rm(scratch, { recursive: true, force: true });
   }

--- a/packages/vercel-optimize-tests/test/collect-framework-preflight.test.mjs
+++ b/packages/vercel-optimize-tests/test/collect-framework-preflight.test.mjs
@@ -243,6 +243,115 @@ process.exit(66);
   }
 });
 
+test('collect-signals: user-owned projects use username scope without teamId query params', async () => {
+  const scratch = await mkdtemp(join(tmpdir(), 'vo-user-scope-'));
+  const bin = join(scratch, 'bin');
+  try {
+    await mkdir(bin, { recursive: true });
+    await mkdir(join(scratch, '.vercel'), { recursive: true });
+    await writeFile(join(scratch, 'package.json'), JSON.stringify({
+      dependencies: { next: '^15.3.0' },
+    }), 'utf-8');
+    await writeFile(join(scratch, '.vercel', 'project.json'), JSON.stringify({
+      projectId: 'prj_user',
+      orgId: 'usr_personal',
+    }), 'utf-8');
+    const fakeVercel = join(bin, 'vercel');
+    await writeFile(fakeVercel, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+function json(value, code = 0) {
+  process.stdout.write(JSON.stringify(value, null, 2) + '\\n');
+  process.exit(code);
+}
+function requireScope(expected) {
+  const i = args.indexOf('--scope');
+  if (i === -1 || args[i + 1] !== expected || args.includes('usr_personal')) {
+    process.stderr.write('missing expected scope ' + expected + ': ' + args.join(' ') + '\\n');
+    process.exit(67);
+  }
+}
+if (args[0] === '--version') {
+  process.stdout.write('54.1.0\\n');
+  process.exit(0);
+}
+if (args[0] === 'whoami' && args[1] === '--format') {
+  json({
+    user: { id: 'usr_personal', username: 'personal-user', billing: { plan: 'pro' } },
+  });
+}
+if (args[0] === 'whoami') {
+  process.stdout.write('personal-user\\n');
+  process.exit(0);
+}
+if (args[0] === 'metrics' && args[1] === 'schema') {
+  requireScope('personal-user');
+  json({ error: { code: 'OPLUS_REQUIRED', message: 'Observability Plus is not enabled' } }, 1);
+}
+if (args[0] === 'api') {
+  const path = args[1];
+  if (path.startsWith('/v1/observability/manage/configuration/projects')) {
+    process.stderr.write('unexpected team Observability configuration probe for user-owned project\\n');
+    process.exit(68);
+  }
+  if (path.startsWith('/v9/projects/prj_user?teamId=')) {
+    process.stderr.write('unexpected user project teamId query: ' + path + '\\n');
+    process.exit(69);
+  }
+  if (path === '/v9/projects/prj_user') {
+    json({ id: 'prj_user', name: 'personal-site' });
+  }
+  if (path === '/v2/user') {
+    json({ user: { username: 'personal-user', billing: { plan: 'pro' } } });
+  }
+}
+if (args[0] === 'contract') {
+  requireScope('personal-user');
+  json({ context: 'personal-user', commitments: [], totalCommitments: 0 });
+}
+if (args[0] === 'usage') {
+  requireScope('personal-user');
+  json({
+    context: 'personal-user',
+    groupBy: {
+      dimension: 'project',
+      data: [{
+        projectId: 'prj_user',
+        name: 'personal-site',
+        services: [{ name: 'Function Invocations', billedCost: 4 }],
+        totals: { billedCost: 4 },
+      }],
+    },
+    services: [{ name: 'Function Invocations', billedCost: 4 }],
+    totals: { billedCost: 4 },
+  });
+}
+process.stderr.write('unexpected vercel call: ' + args.join(' ') + '\\n');
+process.exit(66);
+`, 'utf-8');
+    await chmod(fakeVercel, 0o755);
+
+    const { stdout, stderr } = await exec('node', [COLLECT, '--continue-without-observability'], {
+      cwd: scratch,
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    const out = JSON.parse(stdout);
+    assert.equal(out.commandScope.cliScope, 'personal-user');
+    assert.equal(out.commandScope.source, 'whoami-user');
+    assert.equal(out.usageScope, 'project');
+    assert.equal(out.usageError, null);
+    assert.equal(out.usage.project.projectId, 'prj_user');
+    assert.equal(out.project.id, 'prj_user');
+    assert.equal(out.plan.plan, 'pro');
+    assert.match(out.observabilityPlusPreflight.detail, /user-owned project/);
+    assert.doesNotMatch(stderr, /unexpected vercel call/);
+    assert.doesNotMatch(stderr, /missing expected scope/);
+    assert.doesNotMatch(stderr, /teamId query/);
+  } finally {
+    await rm(scratch, { recursive: true, force: true });
+  }
+});
+
 test('collect-signals: missing orgId stops before scoped Vercel calls', async () => {
   const scratch = await mkdtemp(join(tmpdir(), 'vo-missing-scope-'));
   const bin = join(scratch, 'bin');

--- a/packages/vercel-optimize-tests/test/deep-dive.test.mjs
+++ b/packages/vercel-optimize-tests/test/deep-dive.test.mjs
@@ -1,6 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
@@ -18,6 +21,8 @@ import { gates } from '../../../skills/vercel-optimize/lib/gates/index.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FX = join(HERE, 'fixtures', 'real-cli-output', 'deep-dive');
+const SCRIPT = join(HERE, '../../../skills/vercel-optimize/scripts/deep-dive.mjs');
+const exec = promisify(execFile);
 
 test('deep-dive: specsForCandidate(slow_route) is deterministic', () => {
   const c = { kind: 'slow_route', route: '/dashboard/[sessionId]' };
@@ -219,4 +224,90 @@ test('deep-dive: slow_route fixture filter matches the spec generator output', a
   const specs = specsForCandidate({ kind: 'slow_route', route: '/dashboard/[sessionId]' });
   const perDep = specs.find((s) => s.id === 'perDeployment');
   assert.equal(perDep.filter, raw.query.filter);
+});
+
+test('deep-dive runner scopes metrics to the linked team slug', async () => {
+  const scratch = await mkdtemp(join(tmpdir(), 'vo-deep-dive-scope-'));
+  const bin = join(scratch, 'bin');
+  try {
+    await mkdir(bin, { recursive: true });
+    await mkdir(join(scratch, '.vercel'), { recursive: true });
+    await writeFile(join(scratch, '.vercel', 'project.json'), JSON.stringify({
+      projectId: 'prj_scope',
+      orgId: 'team_scope',
+    }), 'utf-8');
+    await writeFile(join(scratch, 'merged.json'), JSON.stringify({
+      schemaVersion: '1.2',
+      projectId: 'prj_scope',
+      orgId: 'team_scope',
+      metrics: {},
+    }), 'utf-8');
+    await writeFile(join(scratch, 'gate.json'), JSON.stringify({
+      toLaunch: [{ kind: 'route_errors', scope: 'route', route: '/api/fail', priority: 10 }],
+      platform: [],
+    }), 'utf-8');
+
+    const fakeVercel = join(bin, 'vercel');
+    await writeFile(fakeVercel, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+function json(value, code = 0) {
+  process.stdout.write(JSON.stringify(value, null, 2) + '\\n');
+  process.exit(code);
+}
+function requireScope(expected) {
+  const i = args.indexOf('--scope');
+  if (i === -1 || args[i + 1] !== expected || args.includes('team_scope')) {
+    process.stderr.write('missing expected scope ' + expected + ': ' + args.join(' ') + '\\n');
+    process.exit(67);
+  }
+}
+if (args[0] === 'whoami' && args[1] === '--format') {
+  json({
+    username: 'test-user',
+    team: { id: 'team_other', slug: 'other-team', name: 'Other Team' },
+  });
+}
+if (args[0] === 'api' && args[1] === '/v2/teams/team_scope') {
+  json({ id: 'team_scope', slug: 'team-scope', name: 'Team Scope' });
+}
+if (args[0] === 'metrics') {
+  requireScope('team-scope');
+  const metric = args[1];
+  const aggIndex = args.indexOf('-a');
+  const aggregation = aggIndex === -1 ? 'sum' : args[aggIndex + 1];
+  const field = metric.replace(/\\./g, '_') + '_' + aggregation;
+  json({
+    summary: [{
+      [field]: 5,
+      http_status: '500',
+      error_code: 'ERR_TEST',
+      deployment_id: 'dpl_test',
+    }],
+  });
+}
+process.stderr.write('unexpected vercel call: ' + args.join(' ') + '\\n');
+process.exit(66);
+`, 'utf-8');
+    await chmod(fakeVercel, 0o755);
+
+    const { stdout, stderr } = await exec('node', [
+      SCRIPT,
+      join(scratch, 'merged.json'),
+      join(scratch, 'gate.json'),
+      '--cwd',
+      scratch,
+    ], {
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+      maxBuffer: 8 * 1024 * 1024,
+    });
+
+    const out = JSON.parse(stdout);
+    assert.equal(out.queriesRun, 3);
+    assert.deepEqual(out.errors, []);
+    assert.equal(out.toLaunch[0].evidence.deepDive.errorStatusPattern[0].http_status, '500');
+    assert.doesNotMatch(stderr, /unexpected vercel call/);
+    assert.doesNotMatch(stderr, /missing expected scope/);
+  } finally {
+    await rm(scratch, { recursive: true, force: true });
+  }
 });

--- a/packages/vercel-optimize-tests/test/deep-dive.test.mjs
+++ b/packages/vercel-optimize-tests/test/deep-dive.test.mjs
@@ -355,3 +355,51 @@ test('deep-dive runner stops when cwd scope differs from collected signals', asy
     await rm(scratch, { recursive: true, force: true });
   }
 });
+
+test('deep-dive runner stops when commandScope account differs from cwd link', async () => {
+  const scratch = await mkdtemp(join(tmpdir(), 'vo-deep-dive-command-scope-mismatch-'));
+  try {
+    await mkdir(join(scratch, '.vercel'), { recursive: true });
+    await writeFile(join(scratch, '.vercel', 'project.json'), JSON.stringify({
+      projectId: 'prj_scope',
+      orgId: 'team_other',
+    }), 'utf-8');
+    await writeFile(join(scratch, 'merged.json'), JSON.stringify({
+      schemaVersion: '1.2',
+      projectId: 'prj_scope',
+      commandScope: {
+        ok: true,
+        cliScope: 'team-scope',
+        source: 'team-api',
+        teamId: 'team_scope',
+      },
+      metrics: {},
+    }), 'utf-8');
+    await writeFile(join(scratch, 'gate.json'), JSON.stringify({
+      toLaunch: [{ kind: 'route_errors', scope: 'route', route: '/api/fail', priority: 10 }],
+      platform: [],
+    }), 'utf-8');
+
+    let err;
+    try {
+      await exec('node', [
+        SCRIPT,
+        join(scratch, 'merged.json'),
+        join(scratch, 'gate.json'),
+        '--cwd',
+        scratch,
+      ], {
+        maxBuffer: 8 * 1024 * 1024,
+      });
+    } catch (e) {
+      err = e;
+    }
+
+    assert.ok(err, 'deep-dive should stop when persisted commandScope targets another account');
+    assert.equal(err.code, 2);
+    assert.equal(err.stdout, '');
+    assert.match(err.stderr, /different Vercel scope than commandScope/);
+  } finally {
+    await rm(scratch, { recursive: true, force: true });
+  }
+});

--- a/packages/vercel-optimize-tests/test/deep-dive.test.mjs
+++ b/packages/vercel-optimize-tests/test/deep-dive.test.mjs
@@ -311,3 +311,47 @@ process.exit(66);
     await rm(scratch, { recursive: true, force: true });
   }
 });
+
+test('deep-dive runner stops when cwd scope differs from collected signals', async () => {
+  const scratch = await mkdtemp(join(tmpdir(), 'vo-deep-dive-scope-mismatch-'));
+  try {
+    await mkdir(join(scratch, '.vercel'), { recursive: true });
+    await writeFile(join(scratch, '.vercel', 'project.json'), JSON.stringify({
+      projectId: 'prj_scope',
+      orgId: 'team_other',
+    }), 'utf-8');
+    await writeFile(join(scratch, 'merged.json'), JSON.stringify({
+      schemaVersion: '1.2',
+      projectId: 'prj_scope',
+      orgId: 'team_scope',
+      commandScope: { ok: true, cliScope: 'team-scope', source: 'team-api' },
+      metrics: {},
+    }), 'utf-8');
+    await writeFile(join(scratch, 'gate.json'), JSON.stringify({
+      toLaunch: [{ kind: 'route_errors', scope: 'route', route: '/api/fail', priority: 10 }],
+      platform: [],
+    }), 'utf-8');
+
+    let err;
+    try {
+      await exec('node', [
+        SCRIPT,
+        join(scratch, 'merged.json'),
+        join(scratch, 'gate.json'),
+        '--cwd',
+        scratch,
+      ], {
+        maxBuffer: 8 * 1024 * 1024,
+      });
+    } catch (e) {
+      err = e;
+    }
+
+    assert.ok(err, 'deep-dive should stop when cwd is linked to a different scope');
+    assert.equal(err.code, 2);
+    assert.equal(err.stdout, '');
+    assert.match(err.stderr, /different Vercel scope/);
+  } finally {
+    await rm(scratch, { recursive: true, force: true });
+  }
+});

--- a/packages/vercel-optimize-tests/test/fixtures/real-cli-output/README.md
+++ b/packages/vercel-optimize-tests/test/fixtures/real-cli-output/README.md
@@ -9,7 +9,7 @@ Sanitized from Vercel CLI v53.4.0 output against a fixture project. Identifiers,
 - **Status filter**: field is `http_status` (not `status`). Both `http_status eq '500'` and `http_status ge 500` work.
 - **Group by**: dimensions are documented in error response `allowedValues[]`. Available for `vercel.request.count` include `route`, `http_status`, `cache_result`, `request_path`, etc.
 - **External API group-by**: `origin_hostname` (not `hostname`).
-- **Project API**: `vercel api /v9/projects/<id>` returns 404 unless scoped to the team that owns the project. Pass `?teamId=<orgId>` from `.vercel/repo.json`.
+- **Project API**: `vercel api /v9/projects/<id>` returns 404 unless scoped to the team that owns the project. Pass `?teamId=<orgId>` for team-owned projects from `.vercel/repo.json`; omit it for user-owned `usr_...` projects.
 - **Project schema**: `resourceConfig.fluid` is the Fluid Compute flag. Bot Protection state is `security.botIdEnabled` (top-level boolean) and `security.managedRules.bot_filter.active` (challenge action). Top-level `framework` is `"nextjs"` (NOT `"next"`).
 - **Contract**: shape is `{context, commitments, totalCommitments}`. On this team `commitments=[]`. Plan-from-commitments is unreliable — fall back to "uncertain".
 - **Usage**: returns `Error: Costs not found (404)` on teams without the Costs feature enabled. The skill must degrade gracefully.

--- a/packages/vercel-optimize-tests/test/render-report.test.mjs
+++ b/packages/vercel-optimize-tests/test/render-report.test.mjs
@@ -135,8 +135,126 @@ test('renderReport: falls back to o11y-derived ranking when usage missing', () =
     },
   };
   const md = renderReport({ recommendations: [], gated: [], signals });
-  assert.match(md, /ranking by `function_duration_gbhr`/);
+  assert.match(md, /Ranking by `function_duration_gbhr`/);
   assert.match(md, /\| \/x \| 0\.5000 \|/);
+});
+
+test('renderReport: Observability Plus blocker does not invent billing or Speed Insights gaps', () => {
+  const signals = {
+    ...baseSignals,
+    observabilityPlus: true,
+    observabilityPlusUsable: false,
+    observabilityPlusBlocker: 'payment_required',
+    observabilityPlusBlockerDetail: 'Route-level metrics were recognized for this team, but these queries are not usable.',
+    usage: null,
+    usageError: 'NOT_COLLECTED_OBSERVABILITY_BLOCKED',
+    metrics: {
+      observabilityPlusCanary: {
+        ok: false,
+        code: 'OPLUS_REQUIRED',
+      },
+    },
+  };
+  const md = renderReport({ recommendations: [], gated: [], signals });
+
+  assert.match(md, /Per-route metrics unavailable/);
+  assert.match(md, /Observability Plus metrics were not usable for this scope/);
+  assert.match(md, /`vercel usage` was not collected because the audit paused before billing collection/);
+  assert.doesNotMatch(md, /Observability Plus enabled — per-route metrics included/);
+  assert.doesNotMatch(md, /analysis based on billing/);
+  assert.doesNotMatch(md, /free-tier|Costs feature disabled/);
+  assert.doesNotMatch(md, /Observability Plus blocker:/);
+  assert.doesNotMatch(md, /cost breakdown derived from observability/);
+  assert.doesNotMatch(md, /No Speed Insights measurements|Core Web Vitals analysis dormant/);
+  assert.doesNotMatch(md, /No ISR activity observed/);
+  assert.doesNotMatch(md, /No image transformations observed/);
+  assert.doesNotMatch(md, /No middleware invocations/);
+});
+
+test('renderReport: unsupported-framework preflight does not claim Observability Plus was checked', () => {
+  const signals = {
+    ...baseSignals,
+    observabilityPlus: null,
+    observabilityPlusUsable: null,
+    frameworkSupportBlocker: 'unsupported_framework',
+    usage: null,
+    usageError: 'NOT_COLLECTED_UNSUPPORTED_FRAMEWORK',
+    metrics: {},
+  };
+  const md = renderReport({ recommendations: [], gated: [], signals });
+
+  assert.match(md, /Not checked — audit paused at unsupported-framework preflight/);
+  assert.match(md, /`vercel usage` was not collected because the audit paused at the unsupported-framework preflight/);
+  assert.doesNotMatch(md, /Observability Plus enabled — per-route metrics included/);
+  assert.doesNotMatch(md, /Observability Plus not enabled/);
+});
+
+test('renderReport: limited audit after Observability blocker is not described as paused', () => {
+  const signals = {
+    ...baseSignals,
+    observabilityPlus: false,
+    observabilityPlusUsable: false,
+    observabilityPlusBlocker: 'no_oplus_probe',
+    usage: null,
+    usageError: 'USAGE_UNAVAILABLE',
+    metrics: {},
+  };
+  const md = renderReport({ recommendations: [], gated: [], signals });
+
+  assert.match(md, /Per-route metrics unavailable — limited analysis based on scanner findings/);
+  assert.match(md, /Observability Plus was not detected for this scope/);
+  assert.match(md, /`vercel usage` returned `USAGE_UNAVAILABLE`; no billing breakdown was available/);
+  assert.doesNotMatch(md, /audit paused before metric-backed route ranking/);
+  assert.doesNotMatch(md, /Observability Plus blocker:/);
+});
+
+test('renderReport: usage unavailable copy is reserved for an actual usage error', () => {
+  const signals = {
+    ...baseSignals,
+    usage: null,
+    usageError: 'USAGE_UNAVAILABLE',
+    metrics: {
+      ...baseSignals.metrics,
+      fnGbHrByRoute: { rows: [] },
+    },
+  };
+  const md = renderReport({ recommendations: [], gated: [], signals });
+
+  assert.match(md, /`vercel usage` returned `USAGE_UNAVAILABLE`; no billing breakdown was available/);
+  assert.doesNotMatch(md, /free-tier|Costs feature disabled/);
+});
+
+test('renderReport: Speed Insights gap only renders after the metric is collected', () => {
+  const md = renderReport({
+    recommendations: [],
+    gated: [],
+    signals: {
+      ...baseSignals,
+      metrics: {
+        ...baseSignals.metrics,
+        cwvCount: { rows: [] },
+      },
+    },
+  });
+
+  assert.match(md, /No Speed Insights measurements/);
+});
+
+test('renderReport: failed Speed Insights query is not rendered as no measurements', () => {
+  const md = renderReport({
+    recommendations: [],
+    gated: [],
+    signals: {
+      ...baseSignals,
+      metrics: {
+        ...baseSignals.metrics,
+        cwvCount: { ok: false, code: 'FORBIDDEN', rows: [] },
+      },
+    },
+  });
+
+  assert.match(md, /Speed Insights metrics were not usable \(`FORBIDDEN`\)/);
+  assert.doesNotMatch(md, /No Speed Insights measurements/);
 });
 
 test('renderReport: canonicalizes o11y-derived cost routes', () => {

--- a/packages/vercel-optimize-tests/test/vercel-redaction.test.mjs
+++ b/packages/vercel-optimize-tests/test/vercel-redaction.test.mjs
@@ -15,18 +15,18 @@ test('redactSensitiveText: removes auth tokens from CLI-visible text', () => {
     'Authorization: Bearer abcdefghijklmnopqrstuvwxyz.1234567890',
     '{"token":"secret-json-token-abcdef123456"}',
     'x-vercel-id: sfo1::w45r5-1778646511413-d7c8c3cb26cb',
-    'project prj_1234567890abcdef team team_1234567890abcdef',
+    'project prj_1234567890abcdef team team_1234567890abcdef user usr_1234567890abcdef',
   ].join('\n');
 
   const redacted = redactSensitiveText(raw);
 
   assert.doesNotMatch(redacted, /vercel_secret|abcdefghijklmnopqrstuvwxyz|secret-json-token/);
-  assert.doesNotMatch(redacted, /w45r5-1778646511413|prj_1234567890abcdef|team_1234567890abcdef/);
+  assert.doesNotMatch(redacted, /w45r5-1778646511413|prj_1234567890abcdef|team_1234567890abcdef|usr_1234567890abcdef/);
   assert.match(redacted, /VERCEL_TOKEN=\[REDACTED\]/);
   assert.match(redacted, /--token \[REDACTED\]/);
   assert.match(redacted, /Authorization: \[REDACTED\]/);
   assert.match(redacted, /x-vercel-id: \[REDACTED\]/);
-  assert.match(redacted, /project prj_\[REDACTED\] team team_\[REDACTED\]/);
+  assert.match(redacted, /project prj_\[REDACTED\] team team_\[REDACTED\] user usr_\[REDACTED\]/);
   assert.match(redacted, /"token":"\[REDACTED\]"/);
 });
 

--- a/skills/vercel-optimize/AGENTS.md
+++ b/skills/vercel-optimize/AGENTS.md
@@ -11,7 +11,7 @@ Do not use it for projects that are not deployed on Vercel, greenfield projects 
 - Node.js 20+
 - Vercel CLI with `vercel metrics`, `vercel usage`, `vercel contract`, and `vercel api` support; v53+ is this skill's compatibility floor
 - Authenticated Vercel CLI session
-- Linked Vercel project directory (`vercel link`) for route metrics. `VERCEL_PROJECT_ID` can help resolve project config, but it does not replace directory linkage for `vercel metrics`.
+- Linked Vercel project directory (`vercel link`) for route metrics. `VERCEL_PROJECT_ID` can help resolve project config, but it does not replace directory linkage for `vercel metrics`. Team projects must resolve to a CLI-safe scope so `vercel metrics`, `vercel usage`, and `vercel contract` all run against the same team.
 - Observability Plus for per-route metric analysis
 
 ## Procedure

--- a/skills/vercel-optimize/AGENTS.md
+++ b/skills/vercel-optimize/AGENTS.md
@@ -11,7 +11,7 @@ Do not use it for projects that are not deployed on Vercel, greenfield projects 
 - Node.js 20+
 - Vercel CLI with `vercel metrics`, `vercel usage`, `vercel contract`, and `vercel api` support; v53+ is this skill's compatibility floor
 - Authenticated Vercel CLI session
-- Linked Vercel project directory (`vercel link`) for route metrics. `VERCEL_PROJECT_ID` can help resolve project config, but it does not replace directory linkage for `vercel metrics`. Team projects must resolve to a CLI-safe scope so `vercel metrics`, `vercel usage`, and `vercel contract` all run against the same team.
+- Linked Vercel project directory (`vercel link`) for route metrics. `VERCEL_PROJECT_ID` can help resolve project config, but it does not replace directory linkage for `vercel metrics`. The project must resolve to a CLI-safe team or personal scope so `vercel metrics`, `vercel usage`, and `vercel contract` all run against the same account.
 - Observability Plus for per-route metric analysis
 
 ## Procedure

--- a/skills/vercel-optimize/README.md
+++ b/skills/vercel-optimize/README.md
@@ -21,7 +21,7 @@ Manual install: copy `skills/vercel-optimize` into `.agents/skills/vercel-optimi
 - Node.js 20+
 - Vercel CLI with `vercel metrics`, `vercel usage`, `vercel contract`, and `vercel api` support (`npm i -g vercel@latest`). The skill enforces v53+ as its compatibility floor.
 - Authenticated Vercel CLI session (`vercel login`)
-- Linked Vercel project directory (`vercel link`) for route metrics. `VERCEL_PROJECT_ID` can resolve project config, but it does not replace directory linkage for `vercel metrics`.
+- Linked Vercel project directory (`vercel link`) for route metrics. `VERCEL_PROJECT_ID` can resolve project config, but it does not replace directory linkage for `vercel metrics`. Team projects must resolve to a CLI-safe scope so `vercel metrics`, `vercel usage`, and `vercel contract` all run against the same team.
 - Observability Plus for metric-backed route ranking
 - Code-backed recommendation coverage is strongest for Next.js and SvelteKit, supported for Nuxt route mapping with generic checks, and limited for Astro. Hono, Remix, and unknown frameworks pause up front.
 

--- a/skills/vercel-optimize/README.md
+++ b/skills/vercel-optimize/README.md
@@ -21,7 +21,7 @@ Manual install: copy `skills/vercel-optimize` into `.agents/skills/vercel-optimi
 - Node.js 20+
 - Vercel CLI with `vercel metrics`, `vercel usage`, `vercel contract`, and `vercel api` support (`npm i -g vercel@latest`). The skill enforces v53+ as its compatibility floor.
 - Authenticated Vercel CLI session (`vercel login`)
-- Linked Vercel project directory (`vercel link`) for route metrics. `VERCEL_PROJECT_ID` can resolve project config, but it does not replace directory linkage for `vercel metrics`. Team projects must resolve to a CLI-safe scope so `vercel metrics`, `vercel usage`, and `vercel contract` all run against the same team.
+- Linked Vercel project directory (`vercel link`) for route metrics. `VERCEL_PROJECT_ID` can resolve project config, but it does not replace directory linkage for `vercel metrics`. The project must resolve to a CLI-safe team or personal scope so `vercel metrics`, `vercel usage`, and `vercel contract` all run against the same account.
 - Observability Plus for metric-backed route ranking
 - Code-backed recommendation coverage is strongest for Next.js and SvelteKit, supported for Nuxt route mapping with generic checks, and limited for Astro. Hono, Remix, and unknown frameworks pause up front.
 

--- a/skills/vercel-optimize/SKILL.md
+++ b/skills/vercel-optimize/SKILL.md
@@ -21,7 +21,7 @@ Core doctrine: read [references/doctrine.md](references/doctrine.md) if any rule
 
 - Vercel CLI v53+ with `vercel metrics`, `vercel usage`, `vercel contract`, and `vercel api`.
 - Authenticated CLI session: `vercel login`.
-- Linked app directory: `vercel link`. `VERCEL_PROJECT_ID` can help resolve project config, but `vercel metrics` still requires directory linkage.
+- Linked app directory: `vercel link`. `VERCEL_PROJECT_ID` can help resolve project config, but `vercel metrics` still requires directory linkage. For team projects, the link or environment must include the project org/team so the collector can resolve a CLI-safe `--scope` and keep `vercel metrics`, `vercel usage`, and `vercel contract` on the same team.
 - Node.js 20+.
 - Observability Plus for route-level metric-backed recommendations.
 
@@ -73,6 +73,8 @@ node scripts/merge-signals.mjs "$RUN_DIR/vercel-signals.json" "$RUN_DIR/codebase
 ```
 
 Collection details, schemas, metric IDs, and degradation behavior live in [references/data-collection.md](references/data-collection.md). The metric registry is [lib/queries.mjs](lib/queries.mjs); keep all queries on the shared 14-day window.
+
+`collect-signals.mjs` resolves the linked project team to `commandScope.cliScope`; downstream scripts reuse that scope for every Vercel CLI command that accepts `--scope`. Do not run `vercel usage`, `vercel metrics`, or `vercel contract` manually without the same scope; unscoped usage can report the user's personal organization while route metrics come from the team project.
 
 ### 1.1 Stop on blockers
 
@@ -158,7 +160,7 @@ node scripts/reconcile-candidates.mjs "$RUN_DIR/investigation-evidence.json" \
   --out "$RUN_DIR/reconciled-investigation.json"
 ```
 
-`--cwd` must be the linked project directory so `vercel metrics` resolves the right project/team.
+`--cwd` must be the linked project directory so `deep-dive.mjs` can verify the same project link and reuse `signals.json.commandScope.cliScope` for any follow-up `vercel metrics` calls.
 
 Reconciliation deterministically converts disproven candidates into observations before any source investigation:
 

--- a/skills/vercel-optimize/SKILL.md
+++ b/skills/vercel-optimize/SKILL.md
@@ -21,7 +21,7 @@ Core doctrine: read [references/doctrine.md](references/doctrine.md) if any rule
 
 - Vercel CLI v53+ with `vercel metrics`, `vercel usage`, `vercel contract`, and `vercel api`.
 - Authenticated CLI session: `vercel login`.
-- Linked app directory: `vercel link`. `VERCEL_PROJECT_ID` can help resolve project config, but `vercel metrics` still requires directory linkage. For team projects, the link or environment must include the project org/team so the collector can resolve a CLI-safe `--scope` and keep `vercel metrics`, `vercel usage`, and `vercel contract` on the same team.
+- Linked app directory: `vercel link`. `VERCEL_PROJECT_ID` can help resolve project config, but `vercel metrics` still requires directory linkage. The link or environment must include the intended project org/team/user scope so the collector can resolve a CLI-safe `--scope` and keep `vercel metrics`, `vercel usage`, and `vercel contract` on the same account.
 - Node.js 20+.
 - Observability Plus for route-level metric-backed recommendations.
 
@@ -76,6 +76,8 @@ Collection details, schemas, metric IDs, and degradation behavior live in [refer
 
 `collect-signals.mjs` resolves the linked project team to `commandScope.cliScope`; downstream scripts reuse that scope for every Vercel CLI command that accepts `--scope`. Do not run `vercel usage`, `vercel metrics`, or `vercel contract` manually without the same scope; unscoped usage can report the user's personal organization while route metrics come from the team project.
 
+If project or scope resolution is ambiguous, stop and ask the user which Vercel project and team/personal scope they want audited. Do not infer the intended scope from the current `vercel whoami` team, and do not proceed with metrics, usage, or contract collection until the link or `VERCEL_PROJECT_ID` + `VERCEL_ORG_ID` identifies the intended account.
+
 ### 1.1 Stop on blockers
 
 Check blockers before gating:
@@ -87,6 +89,7 @@ jq '{frameworkSupportBlocker, observabilityPlus, observabilityPlusUsable, observ
 Required actions:
 
 - `frameworkSupportBlocker === "unsupported_framework"`: use the unsupported-framework prompt above.
+- `PROJECT_SCOPE_UNRESOLVED` or `SCOPE_UNRESOLVED`: stop and ask which Vercel team/personal scope owns the project. Rerun after `vercel link --yes --project <project-name-or-id> --team <team-slug>` or after setting both `VERCEL_PROJECT_ID` and `VERCEL_ORG_ID`.
 - `observabilityPlusBlocker === null`: continue.
 - `no_traffic`: tell the user route metrics are sparse; continue only if they accept limited output.
 - `payment_required` or `no_oplus_probe`: render [references/observability-plus.md](references/observability-plus.md) verbatim and ask.

--- a/skills/vercel-optimize/SKILL.md
+++ b/skills/vercel-optimize/SKILL.md
@@ -74,7 +74,7 @@ node scripts/merge-signals.mjs "$RUN_DIR/vercel-signals.json" "$RUN_DIR/codebase
 
 Collection details, schemas, metric IDs, and degradation behavior live in [references/data-collection.md](references/data-collection.md). The metric registry is [lib/queries.mjs](lib/queries.mjs); keep all queries on the shared 14-day window.
 
-`collect-signals.mjs` resolves the linked project team to `commandScope.cliScope`; downstream scripts reuse that scope for every Vercel CLI command that accepts `--scope`. Do not run `vercel usage`, `vercel metrics`, or `vercel contract` manually without the same scope; unscoped usage can report the user's personal organization while route metrics come from the team project.
+`collect-signals.mjs` resolves the linked project owner to `commandScope.cliScope`; downstream scripts reuse that scope for every Vercel CLI command that accepts `--scope`. Do not run `vercel usage`, `vercel metrics`, or `vercel contract` manually without the same scope; unscoped usage can report the user's personal organization while route metrics come from the team project.
 
 If project or scope resolution is ambiguous, stop and ask the user which Vercel project and team/personal scope they want audited. Do not infer the intended scope from the current `vercel whoami` team, and do not proceed with metrics, usage, or contract collection until the link or `VERCEL_PROJECT_ID` + `VERCEL_ORG_ID` identifies the intended account.
 
@@ -89,7 +89,7 @@ jq '{frameworkSupportBlocker, observabilityPlus, observabilityPlusUsable, observ
 Required actions:
 
 - `frameworkSupportBlocker === "unsupported_framework"`: use the unsupported-framework prompt above.
-- `PROJECT_SCOPE_UNRESOLVED` or `SCOPE_UNRESOLVED`: stop and ask which Vercel team/personal scope owns the project. Rerun after `vercel link --yes --project <project-name-or-id> --team <team-slug>` or after setting both `VERCEL_PROJECT_ID` and `VERCEL_ORG_ID`.
+- `PROJECT_SCOPE_UNRESOLVED` or `SCOPE_UNRESOLVED`: stop and ask which Vercel team/personal scope owns the project. For team projects, rerun after `vercel link --yes --project <project-name-or-id> --team <team-slug>`; for personal projects, rerun after linking under the intended user account or after setting both `VERCEL_PROJECT_ID` and `VERCEL_ORG_ID`.
 - `observabilityPlusBlocker === null`: continue.
 - `no_traffic`: tell the user route metrics are sparse; continue only if they accept limited output.
 - `payment_required` or `no_oplus_probe`: render [references/observability-plus.md](references/observability-plus.md) verbatim and ask.

--- a/skills/vercel-optimize/lib/render-report.mjs
+++ b/skills/vercel-optimize/lib/render-report.mjs
@@ -17,7 +17,6 @@ export function renderReport({ recommendations = [], gated = [], abstentions = [
   const projectName = opts.projectName ?? signals.project?.name ?? '<project>';
   const stack = signals.stack ?? signals.codebase?.stack ?? {};
   const usage = signals.usage ?? null;
-  const oplus = signals.observabilityPlus !== false;
   const plan = signals.plan ?? { plan: 'unknown', reason: '(not detected)' };
 
   // Sub-agents don't always propagate o11ySignal/aliasRoutes — look them up by candidateRef and canonicalize the displayed ref.
@@ -27,7 +26,7 @@ export function renderReport({ recommendations = [], gated = [], abstentions = [
   const lines = [];
   lines.push(`# Vercel Optimization Report — ${projectName}`);
   lines.push('');
-  lines.push(renderMetadataLine(stack, plan, usage, oplus));
+  lines.push(renderMetadataLine(stack, plan, usage, signals));
   const coverageLine = renderCoverageLine(candidates, recommendations, signals, {
     abstentions,
     heldBackCount: opts.heldBackCount,
@@ -307,7 +306,7 @@ function renderCoverageLine(candidates, recommendations, signals, opts = {}) {
   return `**Coverage**: ${parts.join('  ·  ')} · [details](#not-investigated-in-this-run)`;
 }
 
-function renderMetadataLine(stack, plan, usage, oplus) {
+function renderMetadataLine(stack, plan, usage, signals = {}) {
   const fw = `${stack.framework ?? 'unknown'}@${stack.frameworkVersion ?? '?'}`;
   const router = stack.hasAppRouter ? 'app-router' : stack.hasPagesRouter ? 'pages-router' : null;
   const orm = stack.orm && stack.orm !== 'none' ? stack.orm : null;
@@ -315,14 +314,43 @@ function renderMetadataLine(stack, plan, usage, oplus) {
   const period = usage?.period
     ? `${usage.period.from ?? '?'} → ${usage.period.to ?? '?'}`
     : '(unavailable)';
-  const oplusLabel = oplus
-    ? 'Observability Plus enabled — per-route metrics included'
-    : 'Not enabled — analysis based on billing + scanner findings';
+  const oplusLabel = observabilityLabel(signals, usage);
   // Plan-inference reason is debug detail — only surface when plan is uncertain.
   const planLabel = plan.plan === 'uncertain'
     ? `${plan.plan} (${plan.reason ?? 'no signal'})`
     : (plan.plan ?? 'unknown');
   return `**Stack**: ${stackParts}  ·  **Plan**: ${planLabel}  ·  **Period**: ${period}  ·  **Observability**: ${oplusLabel}`;
+}
+
+function observabilityLabel(signals, usage) {
+  if (signals.observabilityPlusUsable === true) {
+    return 'Observability Plus enabled — per-route metrics included';
+  }
+  if (signals.observabilityPlusUsable === false) {
+    if (usage) {
+      return 'Per-route metrics unavailable — analysis based on billing + scanner findings';
+    }
+    if (signals.usageError === 'NOT_COLLECTED_OBSERVABILITY_BLOCKED') {
+      return 'Per-route metrics unavailable — audit paused before metric-backed route ranking';
+    }
+    return 'Per-route metrics unavailable — limited analysis based on scanner findings';
+  }
+  if (signals.observabilityPlus === true) {
+    return 'Observability Plus enabled — per-route metrics included';
+  }
+  if (signals.usageError === 'NOT_COLLECTED_UNSUPPORTED_FRAMEWORK') {
+    return 'Not checked — audit paused at unsupported-framework preflight';
+  }
+  if (signals.usageError === 'NOT_COLLECTED_OBSERVABILITY_BLOCKED') {
+    return 'Per-route metrics unavailable — audit paused before metric-backed route ranking';
+  }
+  if (usage) {
+    return 'Not enabled — analysis based on billing + scanner findings';
+  }
+  if (signals.observabilityPlus === false) {
+    return 'Not enabled — limited analysis only';
+  }
+  return 'Not checked — limited analysis only';
 }
 
 function renderCostHeader(signals) {
@@ -374,14 +402,15 @@ function renderCostBreakdown(usage, signals) {
 
   // Fallback to o11y-derived ranking when usage payload missing.
   const gbHr = signals.metrics?.fnGbHrByRoute?.rows ?? [];
+  const usageGap = missingUsageSentence(signals);
   if (gbHr.length === 0) {
-    lines.push('_`vercel usage` was not available (free-tier or Costs feature disabled). Without per-route observability data either, we cannot rank cost drivers._');
+    lines.push(`_${usageGap} Without per-route function GB-hour data, this report cannot rank cost drivers._`);
     return lines;
   }
   const top = groupGbHoursByCanonicalRoute(gbHr)
     .sort((a, b) => (b.value ?? 0) - (a.value ?? 0))
     .slice(0, 10);
-  lines.push('_`vercel usage` unavailable; ranking by `function_duration_gbhr` instead. These do not translate to dollars directly, but they show which routes consume billable units._');
+  lines.push(`_${usageGap} Ranking by \`function_duration_gbhr\` instead. These do not translate to dollars directly, but they show which routes consume billable units._`);
   lines.push('');
   lines.push('| Route | GB-hr (sum, 14d) |');
   lines.push('|---|---|');
@@ -660,18 +689,109 @@ function renderConfigurationNotes(signals) {
 
 function renderDataGaps(signals) {
   const lines = [];
-  if (signals.observabilityPlus === false) lines.push('- Observability Plus not enabled — per-route latency / cache-hit / cold-start metrics unavailable.');
-  if (!signals.usage) lines.push('- `vercel usage` was unavailable — cost breakdown derived from observability where possible.');
-  const cwv = signals.metrics?.cwvCount?.rows?.[0]?.value ?? 0;
-  if (cwv === 0) lines.push('- No Speed Insights measurements — Core Web Vitals analysis dormant. Wire up Speed Insights to enable LCP/INP/CLS recommendations.');
-  const isrR = signals.metrics?.isrReadsByRoute?.rows ?? [];
-  if (isrR.length === 0) lines.push('- No ISR activity observed — either the project does not use ISR or no eligible routes had traffic in the window.');
-  const images = signals.metrics?.imageCount?.rows?.[0]?.value ?? 0;
-  if (images === 0) lines.push('- No image transformations observed — either `next/image` is not used or no images served in the window.');
-  const middleware = signals.metrics?.middlewareCount?.rows ?? [];
-  if (middleware.length === 0) lines.push('- No middleware invocations — either no `middleware.ts` is shipped or its matcher excludes all observed traffic.');
+  const observabilityGap = observabilityDataGap(signals);
+  if (observabilityGap) lines.push(observabilityGap);
+  if (!signals.usage) lines.push(`- ${missingUsageSentence(signals)}`);
+  const cwvMetric = metricState(signals, 'cwvCount');
+  if (cwvMetric.failed) {
+    lines.push(`- Speed Insights metrics were not usable (\`${cwvMetric.code}\`), so LCP/INP/CLS analysis was skipped.`);
+  } else if (cwvMetric.collected) {
+    const cwv = cwvMetric.rows?.[0]?.value ?? 0;
+    if (cwv === 0) lines.push('- No Speed Insights measurements — Core Web Vitals analysis dormant. Wire up Speed Insights to enable LCP/INP/CLS recommendations.');
+  }
+  const isrMetric = metricState(signals, 'isrReadsByRoute');
+  if (isrMetric.collected) {
+    const isrR = isrMetric.rows ?? [];
+    if (isrR.length === 0) lines.push('- No ISR activity observed — either the project does not use ISR or no eligible routes had traffic in the window.');
+  }
+  const imageMetric = metricState(signals, 'imageCount');
+  if (imageMetric.collected) {
+    const images = imageMetric.rows?.[0]?.value ?? 0;
+    if (images === 0) lines.push('- No image transformations observed — either `next/image` is not used or no images served in the window.');
+  }
+  const middlewareMetric = metricState(signals, 'middlewareCount');
+  if (middlewareMetric.collected) {
+    const middleware = middlewareMetric.rows ?? [];
+    if (middleware.length === 0) lines.push('- No middleware invocations — either no `middleware.ts` is shipped or its matcher excludes all observed traffic.');
+  }
   if (lines.length === 0) lines.push('_(no relevant gaps — every signal had data)_');
   return lines;
+}
+
+function observabilityDataGap(signals = {}) {
+  if (signals.usageError === 'NOT_COLLECTED_UNSUPPORTED_FRAMEWORK') {
+    return '- Observability Plus was not checked because the audit paused at the unsupported-framework preflight.';
+  }
+  if (signals.observabilityPlusUsable === false) {
+    const blocker = signals.observabilityPlusBlocker;
+    if (blocker === 'project_disabled') {
+      return '- Per-route metrics unavailable — Observability Plus is disabled for this project.';
+    }
+    if (blocker === 'forbidden' || blocker === 'project_not_found') {
+      return '- Per-route metrics unavailable — the authenticated Vercel scope cannot read this project.';
+    }
+    if (blocker === 'not_linked') {
+      return '- Per-route metrics unavailable — the app directory is not linked to the Vercel project.';
+    }
+    if (blocker === 'no_oplus_probe') {
+      return '- Per-route metrics unavailable — Observability Plus was not detected for this scope.';
+    }
+    if (blocker === 'payment_required') {
+      return '- Per-route metrics unavailable — Observability Plus metrics were not usable for this scope.';
+    }
+    if (blocker === 'daily_quota_exceeded') {
+      return '- Per-route metrics unavailable — the Observability Plus query quota is exhausted for today.';
+    }
+    if (blocker === 'no_traffic') {
+      return '- Per-route metrics sparse — no route-level traffic was returned in the metrics window.';
+    }
+    if (blocker === 'all_failed_other') {
+      return '- Per-route metrics unavailable — all Observability Plus metric queries failed.';
+    }
+    if (blocker) {
+      return `- Per-route metrics unavailable — Observability Plus metrics returned \`${blocker}\`.`;
+    }
+    return '- Per-route metrics unavailable — Observability Plus data was not usable for this run.';
+  }
+  if (signals.observabilityPlus === false) {
+    return '- Observability Plus not enabled — per-route latency / cache-hit / cold-start metrics unavailable.';
+  }
+  return null;
+}
+
+function missingUsageSentence(signals = {}) {
+  const code = signals.usageError;
+  if (code === 'NOT_COLLECTED_OBSERVABILITY_BLOCKED') {
+    return '`vercel usage` was not collected because the audit paused before billing collection on the Observability Plus blocker.';
+  }
+  if (code === 'NOT_COLLECTED_UNSUPPORTED_FRAMEWORK') {
+    return '`vercel usage` was not collected because the audit paused at the unsupported-framework preflight.';
+  }
+  if (code === 'USAGE_CONTEXT_MISMATCH') {
+    return '`vercel usage` returned data for a different team context, so the billing breakdown was not used.';
+  }
+  if (code === 'USAGE_UNAVAILABLE') {
+    return '`vercel usage` returned `USAGE_UNAVAILABLE`; no billing breakdown was available from the Vercel CLI.';
+  }
+  if (typeof code === 'string' && code.trim() !== '') {
+    return `\`vercel usage\` returned \`${code}\`; no billing breakdown was available from the Vercel CLI.`;
+  }
+  return '`vercel usage` did not return a billing payload.';
+}
+
+function metricState(signals, id) {
+  const metrics = signals.metrics ?? {};
+  if (!Object.prototype.hasOwnProperty.call(metrics, id)) {
+    return { collected: false, failed: false, rows: null, code: null };
+  }
+  const metric = metrics[id] ?? {};
+  const failed = metric.ok === false;
+  return {
+    collected: !failed,
+    failed,
+    rows: Array.isArray(metric.rows) ? metric.rows : [],
+    code: metric.code ?? 'UNKNOWN',
+  };
 }
 
 function sortRecs(recs) {

--- a/skills/vercel-optimize/lib/vercel.mjs
+++ b/skills/vercel-optimize/lib/vercel.mjs
@@ -40,6 +40,11 @@ export async function checkAuth() {
   }
 }
 
+export async function getCliIdentity() {
+  const r = await runVercelJson(['whoami', '--format', 'json']);
+  return r.ok ? r.data : null;
+}
+
 // Supports newer `.vercel/repo.json` (multi-project) + legacy `.vercel/project.json` (single-project).
 export async function readProjectJson(cwd = process.cwd()) {
   try {
@@ -80,6 +85,104 @@ export async function resolveProjectId(explicit, cwd = process.cwd()) {
     };
   }
   return await readProjectJson(cwd);
+}
+
+export async function resolveCommandScope(project = {}) {
+  const orgId = project?.orgId ?? null;
+  const identity = await getCliIdentity();
+  const currentTeam = identity?.team ?? null;
+
+  if (!orgId) {
+    return {
+      ok: true,
+      cliScope: currentTeam?.slug ?? null,
+      source: currentTeam?.slug ? 'whoami-current-team' : 'current-user',
+      required: false,
+      detail: currentTeam?.slug
+        ? 'Using the current CLI team as the command scope because the project link has no orgId.'
+        : 'Using the current CLI user scope because the project link has no orgId and no current team was reported.',
+    };
+  }
+
+  if (String(orgId).startsWith('team_')) {
+    if (currentTeam?.id === orgId && currentTeam?.slug) {
+      return {
+        ok: true,
+        cliScope: currentTeam.slug,
+        source: 'whoami-current-team',
+        required: true,
+        teamId: orgId,
+        detail: 'Resolved linked team ID to the current CLI team slug.',
+      };
+    }
+
+    const team = await getTeamInfo(orgId);
+    if (team.ok && team.slug) {
+      return {
+        ok: true,
+        cliScope: team.slug,
+        source: 'team-api',
+        required: true,
+        teamId: orgId,
+        detail: 'Resolved linked team ID to a Vercel CLI scope slug.',
+      };
+    }
+
+    return {
+      ok: false,
+      cliScope: null,
+      source: 'team-api',
+      required: true,
+      teamId: orgId,
+      error: team.error ?? 'TEAM_SCOPE_UNRESOLVED',
+      detail: 'Could not resolve the linked team ID to a Vercel CLI scope slug.',
+    };
+  }
+
+  if (String(orgId).startsWith('usr_')) {
+    const user = identity?.user ?? identity ?? {};
+    const userId = user.id ?? identity?.id ?? null;
+    const username = user.username ?? identity?.username ?? null;
+    if ((!userId || userId === orgId) && username) {
+      return {
+        ok: true,
+        cliScope: username,
+        source: 'whoami-user',
+        required: true,
+        userId: orgId,
+        detail: 'Resolved linked user ID to a Vercel CLI username scope.',
+      };
+    }
+    return {
+      ok: false,
+      cliScope: null,
+      source: 'whoami-user',
+      required: true,
+      userId: orgId,
+      error: 'USER_SCOPE_UNRESOLVED',
+      detail: 'Could not resolve the linked user ID to the authenticated Vercel username.',
+    };
+  }
+
+  return {
+    ok: true,
+    cliScope: orgId,
+    source: 'linked-org-scope',
+    required: true,
+    detail: 'Using the linked org value as the Vercel CLI scope.',
+  };
+}
+
+async function getTeamInfo(teamIdOrSlug) {
+  const r = await runVercelJson(['api', `/v2/teams/${encodeURIComponent(teamIdOrSlug)}`]);
+  if (!r.ok) return { ok: false, error: r.code ?? 'UNKNOWN' };
+  const team = r.data?.team ?? r.data ?? {};
+  return {
+    ok: true,
+    id: team.id ?? null,
+    slug: team.slug ?? null,
+    name: team.name ?? null,
+  };
 }
 
 // Some commands emit `{error: {...}}` on stdout AND exit non-zero — parse stdout first; embedded `error` is the most reliable signal.
@@ -400,8 +503,8 @@ export async function getAccountPlan(scope) {
 }
 
 async function getCurrentTeamId() {
-  const r = await runVercelJson(['whoami', '--format', 'json']);
-  return r.ok ? (r.data?.team?.id ?? null) : null;
+  const identity = await getCliIdentity();
+  return identity?.team?.id ?? null;
 }
 
 async function getBillingPlanFromPath(path, source) {
@@ -598,11 +701,12 @@ async function pathExists(p) {
   try { await access(p); return true; } catch { return false; }
 }
 
-// `--scope <teamId>` is buggy on several subcommands (silently falls back to currentTeam) — only pass slugs.
+// `--scope <teamId>` is buggy on several subcommands (silently falls back to
+// currentTeam). Resolve raw account IDs to slugs/usernames before scoped calls.
 function scopedArgs(args, scope) {
   if (!scope) return args;
-  if (typeof scope === 'string' && /^team_[A-Za-z0-9]+$/.test(scope)) {
-    return args;
+  if (typeof scope === 'string' && /^(team|usr)_/.test(scope)) {
+    throw new Error('RAW_ID_SCOPE_UNRESOLVED: resolve the linked org/user ID to a CLI scope slug before running Vercel commands.');
   }
   return [...args, '--scope', scope];
 }

--- a/skills/vercel-optimize/lib/vercel.mjs
+++ b/skills/vercel-optimize/lib/vercel.mjs
@@ -50,11 +50,18 @@ export async function readProjectJson(cwd = process.cwd()) {
   try {
     const raw = await readFile(join(cwd, '.vercel', 'repo.json'), 'utf-8');
     const parsed = JSON.parse(raw);
-    const first = parsed?.projects?.[0];
+    const projects = Array.isArray(parsed?.projects) ? parsed.projects.filter((p) => p?.id) : [];
+    if (projects.length > 1) {
+      throw new Error('AMBIGUOUS_PROJECT_LINK: `.vercel/repo.json` contains multiple projects. Run from the linked app directory, or pass the intended projectId together with VERCEL_ORG_ID.');
+    }
+    const first = projects[0];
     if (first?.id) {
       return { projectId: first.id, orgId: first.orgId ?? null, source: 'repo.json' };
     }
-  } catch { /* fall through */ }
+  } catch (err) {
+    if (err?.message?.startsWith('AMBIGUOUS_PROJECT_LINK:')) throw err;
+    /* fall through */
+  }
 
   // Legacy single-project format.
   try {
@@ -89,20 +96,20 @@ export async function resolveProjectId(explicit, cwd = process.cwd()) {
 
 export async function resolveCommandScope(project = {}) {
   const orgId = project?.orgId ?? null;
-  const identity = await getCliIdentity();
-  const currentTeam = identity?.team ?? null;
 
   if (!orgId) {
     return {
-      ok: true,
-      cliScope: currentTeam?.slug ?? null,
-      source: currentTeam?.slug ? 'whoami-current-team' : 'current-user',
-      required: false,
-      detail: currentTeam?.slug
-        ? 'Using the current CLI team as the command scope because the project link has no orgId.'
-        : 'Using the current CLI user scope because the project link has no orgId and no current team was reported.',
+      ok: false,
+      cliScope: null,
+      source: 'missing-org-scope',
+      required: true,
+      error: 'PROJECT_SCOPE_UNRESOLVED',
+      detail: 'The project was resolved without an org/team owner, so the collector cannot prove which Vercel scope to query.',
     };
   }
+
+  const identity = await getCliIdentity();
+  const currentTeam = identity?.team ?? null;
 
   if (String(orgId).startsWith('team_')) {
     if (currentTeam?.id === orgId && currentTeam?.slug) {
@@ -247,7 +254,7 @@ export function redactSensitiveText(value) {
     .replace(/\b(x-vercel-id:\s*)[^\r\n]+/gi, '$1[REDACTED]')
     .replace(/\b(VERCEL_TOKEN|TURBO_TOKEN|NPM_TOKEN|NODE_AUTH_TOKEN|GITHUB_TOKEN)=("[^"]+"|'[^']+'|[^\s"'`]+)/g, '$1=[REDACTED]')
     .replace(/(--token(?:=|\s+))("[^"]+"|'[^']+'|[^\s"'`]+)/gi, '$1[REDACTED]')
-    .replace(/\b(prj|team)_[A-Za-z0-9]{8,}\b/g, '$1_[REDACTED]')
+    .replace(/\b(prj|team|usr)_[A-Za-z0-9]{8,}\b/g, '$1_[REDACTED]')
     .replace(/("token"\s*:\s*")[^"]{8,}(")/gi, '$1[REDACTED]$2');
 }
 

--- a/skills/vercel-optimize/lib/vercel.mjs
+++ b/skills/vercel-optimize/lib/vercel.mjs
@@ -104,7 +104,7 @@ export async function resolveCommandScope(project = {}) {
       source: 'missing-org-scope',
       required: true,
       error: 'PROJECT_SCOPE_UNRESOLVED',
-      detail: 'The project was resolved without an org/team owner, so the collector cannot prove which Vercel scope to query.',
+      detail: 'The project was resolved without an owner account, so the collector cannot prove which Vercel scope to query.',
     };
   }
 
@@ -293,6 +293,15 @@ export async function checkObservabilityPlusConfiguration({ orgId, projectId } =
       detail: 'No team ID was available for the Observability Plus configuration preflight.',
     };
   }
+  if (String(orgId).startsWith('usr_')) {
+    return {
+      ok: false,
+      source: 'observability-configuration-api',
+      access: null,
+      blocker: 'unknown',
+      detail: 'The Observability Plus team configuration preflight is not available for a user-owned project; falling back to the scoped metrics probe.',
+    };
+  }
   const qs = `?teamId=${encodeURIComponent(orgId)}`;
   const r = await runVercelJson(['api', `/v1/observability/manage/configuration/projects${qs}`]);
   return classifyObservabilityPlusConfiguration(r, { projectId });
@@ -390,9 +399,12 @@ export async function queryMetric(metricId, opts = {}) {
   );
 }
 
-// `vercel api /v9/projects/<id>` 404s when project's team ≠ user's currentTeam — always pass `?teamId=<orgId>`.
+// Team-owned projects need `?teamId=<orgId>` to avoid current-team drift. User-
+// owned projects use the authenticated user context and should not pass teamId.
 export async function getProjectConfig(projectId, orgId) {
-  const qs = orgId ? `?teamId=${encodeURIComponent(orgId)}` : '';
+  const qs = orgId && !String(orgId).startsWith('usr_')
+    ? `?teamId=${encodeURIComponent(orgId)}`
+    : '';
   const r = await runVercelJson(['api', `/v9/projects/${projectId}${qs}`]);
   return r.ok ? r.data : { error: r.code, stderr: r.stderr };
 }

--- a/skills/vercel-optimize/references/data-collection.md
+++ b/skills/vercel-optimize/references/data-collection.md
@@ -26,6 +26,13 @@ The merged `signals.json` has this top-level shape:
   "projectId": "prj_xxx",
   "orgId": "team_xxx",
   "projectIdSource": "repo.json" | "project.json" | "arg" | "env",
+  "commandScope": {
+    "ok": true,
+    "cliScope": "team-slug-or-username",
+    "source": "team-api" | "whoami-current-team" | "whoami-user" | "linked-org-scope" | "current-user",
+    "required": true,
+    "detail": "..."
+  },
   "frameworkSupport": {
     "ok": true,
     "status": "supported" | "limited" | "unsupported",
@@ -55,6 +62,8 @@ The merged `signals.json` has this top-level shape:
 
 All metric queries use the same `timeWindow` constant (`14d`) — defined as `TIME_WINDOW` in [lib/queries.mjs](../lib/queries.mjs) and covered by the repo test suite. Mixing windows silently produces incompatible rollups; never pin a per-query `since`.
 
+All Vercel CLI commands that accept scope must use `commandScope.cliScope` (`--scope <team-slug-or-username>`). Linked project files often contain a raw `team_...` ID, but several CLI subcommands silently fall back to the current team when `--scope` receives that ID. `collect-signals.mjs` resolves raw team IDs to slugs before running `vercel metrics`, `vercel usage`, or `vercel contract`; `deep-dive.mjs` reuses the same scope for follow-up metric queries. If the slug cannot be resolved, stop instead of running scoped commands unscoped or with a raw team ID.
+
 Downstream consumers reference `signals.<field>` paths verbatim. Bumping `schemaVersion` is required when any consumed path is renamed or removed.
 
 ## Per-signal source matrix
@@ -65,11 +74,12 @@ Downstream consumers reference `signals.<field>` paths verbatim. Bumping `schema
 | CLI version | `vercel --version` | Everything | Exit with "upgrade to v53+" — v53 is the skill's compatibility floor |
 | Project ID + Org ID | `.vercel/repo.json` (newer) or `.vercel/project.json` (legacy) → `VERCEL_PROJECT_ID` + `VERCEL_ORG_ID` → argv | Everything | Exit with "run `vercel link` or pass projectId" |
 | Framework support | local `package.json` via `detectStack()` + `classifyFrameworkSupport()` | Code-backed route recommendations | Stop before metric fan-out on unsupported frameworks unless the user chooses `--continue-unsupported-framework` |
+| CLI command scope | `vercel whoami --format json`, then `vercel api /v2/teams/:orgId` when a linked `team_...` ID must be converted to a slug | Keeps `vercel metrics`, `vercel usage`, and `vercel contract` on the linked project's team instead of the user's current/personal scope | `SCOPE_UNRESOLVED`; stop and ask the user to `vercel switch <team>` or re-link with `vercel link --yes --project <project> --team <team-slug>` |
 | Observability Plus configuration | Vercel CLI/API probe plus one metric access check | All `metrics.*` signals | Stop early when the team lacks Observability Plus or this project is disabled |
 | Observability Plus metrics access | One canary `vercel metrics vercel.request.count --since 14d --limit 1`, then full fan-out only if it succeeds | All `metrics.*` signals | Set `observabilityPlusUsable=false` with blocker detail; emit a minimal blocker document before slower project config / usage collection unless `--continue-without-observability` is passed |
 | Project config | `vercel api /v9/projects/:id?teamId=<orgId>` | Fluid Compute, BotID, Speed Insights, security flags | `{error: "..."}` placeholder; gates that need it skip |
-| Plan tier | `vercel api /v2/teams/:orgId` (or `/v2/user` for user-owned projects) → `billing.plan`, then `vercel contract --format json --scope <orgId>` fallback → `inferPlan()` | Cost-context framing only | `plan="uncertain"`; cost magnitudes still computed from `usage.services[].billedCost` |
-| Billing usage | `vercel usage --format json --from <14d> --to <today>` with best-effort project grouping when supported by the installed CLI | Cost magnitude framing, billing-driven candidates | `null` + `usageError` set when queried and unavailable; `NOT_COLLECTED_*` when a preflight stop happened before billing collection |
+| Plan tier | `vercel api /v2/teams/:orgId` (or `/v2/user` for user-owned projects) → `billing.plan`, then scoped `vercel contract --format json` fallback → `inferPlan()` | Cost-context framing only | `plan="uncertain"`; cost magnitudes still computed from `usage.services[].billedCost` |
+| Billing usage | Scoped `vercel usage --format json --from <14d> --to <today>` with best-effort project grouping when supported by the installed CLI | Cost magnitude framing, billing-driven candidates | `null` + `usageError` set when queried and unavailable; `NOT_COLLECTED_*` when a preflight stop happened before billing collection |
 | Stack | local `package.json` + dir scan | Version-aware citation filtering, scanner gating | "unknown" framework → all framework-specific citations filtered |
 | `metrics.fnDurationP95ByRoute` | `vercel metrics vercel.function_invocation.function_duration_ms -a p95 --group-by route --since 14d` | `slow_route`, `platform_fluid_compute` gates | `{ok:false}`; gate emits no candidates |
 | `metrics.requestsByRouteCache` | `vercel metrics vercel.request.count --group-by route --group-by cache_result --since 14d` | `uncached_route`, traffic-total computation | `{ok:false}` |
@@ -104,6 +114,7 @@ Downstream consumers reference `signals.<field>` paths verbatim. Bumping `schema
 | Code | Meaning | Skill behavior |
 |---|---|---|
 | `unsupported_framework` | Detected framework cannot reliably map Vercel route metrics back to source files | Stop before metric fan-out; ask whether to continue with a limited platform/scanner audit |
+| `SCOPE_UNRESOLVED` | The linked project belongs to a specific team/user, but the collector could not resolve a CLI-safe `--scope` value | Stop before `vercel metrics`, `vercel usage`, or `vercel contract`; ask the user to switch/re-link with the correct team |
 | `no_oplus_probe` | Observability Plus not enabled on team | Stop before full metric fan-out; ask whether to enable Observability Plus or run scanner-only |
 | `project_disabled` | Observability Plus enabled for team but disabled for project | Stop before full metric fan-out; ask the user to enable Observability Plus for this project or continue scanner-only |
 | `daily_quota_exceeded` | Observability Plus query quota is exhausted for the day | Stop before full metric fan-out; tell the user to retry after the next UTC midnight reset or ask whether to continue scanner-only |

--- a/skills/vercel-optimize/references/data-collection.md
+++ b/skills/vercel-optimize/references/data-collection.md
@@ -29,7 +29,7 @@ The merged `signals.json` has this top-level shape:
   "commandScope": {
     "ok": true,
     "cliScope": "team-slug-or-username",
-    "source": "team-api" | "whoami-current-team" | "whoami-user" | "linked-org-scope" | "current-user",
+    "source": "team-api" | "whoami-current-team" | "whoami-user" | "linked-org-scope" | "missing-org-scope",
     "required": true,
     "detail": "..."
   },
@@ -62,7 +62,7 @@ The merged `signals.json` has this top-level shape:
 
 All metric queries use the same `timeWindow` constant (`14d`) — defined as `TIME_WINDOW` in [lib/queries.mjs](../lib/queries.mjs) and covered by the repo test suite. Mixing windows silently produces incompatible rollups; never pin a per-query `since`.
 
-All Vercel CLI commands that accept scope must use `commandScope.cliScope` (`--scope <team-slug-or-username>`). Linked project files often contain a raw `team_...` ID, but several CLI subcommands silently fall back to the current team when `--scope` receives that ID. `collect-signals.mjs` resolves raw team IDs to slugs before running `vercel metrics`, `vercel usage`, or `vercel contract`; `deep-dive.mjs` reuses the same scope for follow-up metric queries. If the slug cannot be resolved, stop instead of running scoped commands unscoped or with a raw team ID.
+All Vercel CLI commands that accept scope must use `commandScope.cliScope` (`--scope <team-slug-or-username>`). Linked project files often contain a raw `team_...` ID, but several CLI subcommands silently fall back to the current team when `--scope` receives that ID. `collect-signals.mjs` resolves raw team IDs to slugs before running `vercel metrics`, `vercel usage`, or `vercel contract`; `deep-dive.mjs` reuses the same scope for follow-up metric queries. If the project link lacks an org/team owner or the CLI-safe scope cannot be resolved, stop and ask the user which Vercel project and team/personal scope they want audited. Do not infer scope from the current `vercel whoami` team.
 
 Downstream consumers reference `signals.<field>` paths verbatim. Bumping `schemaVersion` is required when any consumed path is renamed or removed.
 
@@ -72,9 +72,9 @@ Downstream consumers reference `signals.<field>` paths verbatim. Bumping `schema
 |---|---|---|---|
 | Auth | `vercel whoami` | Everything | Exit with "run `vercel login`" |
 | CLI version | `vercel --version` | Everything | Exit with "upgrade to v53+" — v53 is the skill's compatibility floor |
-| Project ID + Org ID | `.vercel/repo.json` (newer) or `.vercel/project.json` (legacy) → `VERCEL_PROJECT_ID` + `VERCEL_ORG_ID` → argv | Everything | Exit with "run `vercel link` or pass projectId" |
+| Project ID + Org ID | `.vercel/repo.json` (newer) or `.vercel/project.json` (legacy) → `VERCEL_PROJECT_ID` + `VERCEL_ORG_ID` → argv | Everything | Exit with "run `vercel link` or pass projectId". Multi-project `repo.json` or project ID without org/team scope is ambiguous; ask the user to clarify the intended project/account |
 | Framework support | local `package.json` via `detectStack()` + `classifyFrameworkSupport()` | Code-backed route recommendations | Stop before metric fan-out on unsupported frameworks unless the user chooses `--continue-unsupported-framework` |
-| CLI command scope | `vercel whoami --format json`, then `vercel api /v2/teams/:orgId` when a linked `team_...` ID must be converted to a slug | Keeps `vercel metrics`, `vercel usage`, and `vercel contract` on the linked project's team instead of the user's current/personal scope | `SCOPE_UNRESOLVED`; stop and ask the user to `vercel switch <team>` or re-link with `vercel link --yes --project <project> --team <team-slug>` |
+| CLI command scope | `vercel whoami --format json`, then `vercel api /v2/teams/:orgId` when a linked `team_...` ID must be converted to a slug | Keeps `vercel metrics`, `vercel usage`, and `vercel contract` on the linked project's account instead of the user's current/personal scope | `PROJECT_SCOPE_UNRESOLVED` or `SCOPE_UNRESOLVED`; stop and ask the user to clarify the intended project/account, then `vercel switch <team>` or re-link with `vercel link --yes --project <project> --team <team-slug>` |
 | Observability Plus configuration | Vercel CLI/API probe plus one metric access check | All `metrics.*` signals | Stop early when the team lacks Observability Plus or this project is disabled |
 | Observability Plus metrics access | One canary `vercel metrics vercel.request.count --since 14d --limit 1`, then full fan-out only if it succeeds | All `metrics.*` signals | Set `observabilityPlusUsable=false` with blocker detail; emit a minimal blocker document before slower project config / usage collection unless `--continue-without-observability` is passed |
 | Project config | `vercel api /v9/projects/:id?teamId=<orgId>` | Fluid Compute, BotID, Speed Insights, security flags | `{error: "..."}` placeholder; gates that need it skip |
@@ -114,6 +114,7 @@ Downstream consumers reference `signals.<field>` paths verbatim. Bumping `schema
 | Code | Meaning | Skill behavior |
 |---|---|---|
 | `unsupported_framework` | Detected framework cannot reliably map Vercel route metrics back to source files | Stop before metric fan-out; ask whether to continue with a limited platform/scanner audit |
+| `PROJECT_SCOPE_UNRESOLVED` | The project was found without an org/team owner, or `.vercel/repo.json` contains multiple linked projects | Stop before `vercel metrics`, `vercel usage`, or `vercel contract`; ask the user which Vercel project and team/personal scope to audit |
 | `SCOPE_UNRESOLVED` | The linked project belongs to a specific team/user, but the collector could not resolve a CLI-safe `--scope` value | Stop before `vercel metrics`, `vercel usage`, or `vercel contract`; ask the user to switch/re-link with the correct team |
 | `no_oplus_probe` | Observability Plus not enabled on team | Stop before full metric fan-out; ask whether to enable Observability Plus or run scanner-only |
 | `project_disabled` | Observability Plus enabled for team but disabled for project | Stop before full metric fan-out; ask the user to enable Observability Plus for this project or continue scanner-only |

--- a/skills/vercel-optimize/references/data-collection.md
+++ b/skills/vercel-optimize/references/data-collection.md
@@ -45,7 +45,7 @@ The merged `signals.json` has this top-level shape:
   "project": { /* /v9/projects/:id response, scoped to orgId via ?teamId */ },
   "contract": { "context": "...", "commitments": [], "totalCommitments": 0 },
   "usage": { /* vercel usage --format json --breakdown daily, or null */ },
-  "usageError": null | "USAGE_UNAVAILABLE" | "EXIT_<n>",
+  "usageError": null | "USAGE_UNAVAILABLE" | "USAGE_CONTEXT_MISMATCH" | "NOT_COLLECTED_OBSERVABILITY_BLOCKED" | "NOT_COLLECTED_UNSUPPORTED_FRAMEWORK" | "EXIT_<n>" | "UNKNOWN",
   "stack": { /* framework + version + router + ORM + monorepo */ },
   "codebase": { /* scan-codebase output: stack + routes + findings */ },
   "metrics": { /* per-metric query results (only when observabilityPlus=true) */ },
@@ -69,7 +69,7 @@ Downstream consumers reference `signals.<field>` paths verbatim. Bumping `schema
 | Observability Plus metrics access | One canary `vercel metrics vercel.request.count --since 14d --limit 1`, then full fan-out only if it succeeds | All `metrics.*` signals | Set `observabilityPlusUsable=false` with blocker detail; emit a minimal blocker document before slower project config / usage collection unless `--continue-without-observability` is passed |
 | Project config | `vercel api /v9/projects/:id?teamId=<orgId>` | Fluid Compute, BotID, Speed Insights, security flags | `{error: "..."}` placeholder; gates that need it skip |
 | Plan tier | `vercel contract --format json --scope <orgId>` → `inferPlan()` | Cost-context framing only | `plan="uncertain"`; cost magnitudes still computed from `usage.services[].billedCost` |
-| Billing usage | `vercel usage --format json --from <14d> --to <today>` with best-effort project grouping when supported by the installed CLI | Cost magnitude framing, billing-driven candidates | `null` + `usageError` set; cost magnitudes degrade to "small" by default |
+| Billing usage | `vercel usage --format json --from <14d> --to <today>` with best-effort project grouping when supported by the installed CLI | Cost magnitude framing, billing-driven candidates | `null` + `usageError` set when queried and unavailable; `NOT_COLLECTED_*` when a preflight stop happened before billing collection |
 | Stack | local `package.json` + dir scan | Version-aware citation filtering, scanner gating | "unknown" framework → all framework-specific citations filtered |
 | `metrics.fnDurationP95ByRoute` | `vercel metrics vercel.function_invocation.function_duration_ms -a p95 --group-by route --since 14d` | `slow_route`, `platform_fluid_compute` gates | `{ok:false}`; gate emits no candidates |
 | `metrics.requestsByRouteCache` | `vercel metrics vercel.request.count --group-by route --group-by cache_result --since 14d` | `uncached_route`, traffic-total computation | `{ok:false}` |
@@ -92,7 +92,7 @@ Downstream consumers reference `signals.<field>` paths verbatim. Bumping `schema
 
 **ISR read:write ratio caveat.** `isrReadsByRoute` exposes the **origin-tier** read count only. CDN-tier reads (regional cache hits that never reach the ISR origin) are not separately surfaced today and can dominate total read volume. Before flagging "writes > reads" as inverted, the gate and report must (a) acknowledge CDN-tier reads aren't included, (b) corroborate with `requestsByRouteCache` `cache_result=HIT` share before alarming. A high origin-write rate alone does not imply pathological over-revalidation if the CDN is absorbing the steady-state read traffic.
 | `metrics.imageCount`, `imageByHost`, `imageSourceBytes` | `vercel metrics vercel.image_transformation.*` | Image-optimization narrative | `{ok:false}` |
-| `metrics.cwvLcpByRoute`, `cwvInpByRoute`, `cwvClsByRoute`, `cwvTtfbByRoute`, `cwvCount`, `cwvCountByRoute` | `vercel metrics vercel.speed_insights_metric.*` (`p75` for vitals, `sum` for counts) `--since 14d` | `cwv_poor` gate | Empty when Speed Insights not enabled on the project — gate stays dormant |
+| `metrics.cwvLcpByRoute`, `cwvInpByRoute`, `cwvClsByRoute`, `cwvTtfbByRoute`, `cwvCount`, `cwvCountByRoute` | `vercel metrics vercel.speed_insights_metric.*` (`p75` for vitals, `sum` for counts) `--since 14d` | `cwv_poor` gate | Empty when no Speed Insights measurements are returned for the 14-day window — gate stays dormant; do not infer disabled vs no traffic unless another signal proves it |
 | `metrics.firewallByAction` | `vercel metrics vercel.firewall_action.count -a sum --group-by waf_action --since 14d` | Bot-protection narrative; shows existing managed rule activity | `{ok:false}` |
 | `metrics.botIdChecks` | `vercel metrics vercel.bot_id_check.count -a sum --since 14d` | Confirms whether BotID is actively running | `{ok:false}` |
 | `metrics.externalApiCount`, `externalApiBytes` | `vercel metrics vercel.external_api_request.*` grouped by `origin_hostname` | External-dependency cost narrative | `{ok:false}` |
@@ -107,7 +107,7 @@ Downstream consumers reference `signals.<field>` paths verbatim. Bumping `schema
 | `no_oplus_probe` | Observability Plus not enabled on team | Stop before full metric fan-out; ask whether to enable Observability Plus or run scanner-only |
 | `project_disabled` | Observability Plus enabled for team but disabled for project | Stop before full metric fan-out; ask the user to enable Observability Plus for this project or continue scanner-only |
 | `daily_quota_exceeded` | Observability Plus query quota is exhausted for the day | Stop before full metric fan-out; tell the user to retry after the next UTC midnight reset or ask whether to continue scanner-only |
-| `USAGE_UNAVAILABLE` | `vercel usage` 404 — team has no Costs feature enabled | `usage=null`; cost-tier gates emit lower-priority candidates; billing section of the report shows "unavailable" |
+| `USAGE_UNAVAILABLE` | `vercel usage` returned no Costs payload after billing usage was actually queried | `usage=null`; cost-tier gates emit lower-priority candidates; billing section of the report shows the exact usage error |
 | `PROJECT_NOT_FOUND` | `vercel api /v9/projects/<id>` 404 (typically wrong scope) | `project={error}`; platform gates that depend on project config skip; report flags the data gap |
 | `invalid_filter_dimension` / `invalid_dimension` | Metric query used a dimension the metric doesn't support | Metric returns `{ok:false, code, allowedValues}`; consumer can introspect and adjust |
 | `NOT_LINKED` | The app directory is not linked in the way `vercel metrics` requires | Run `vercel link --yes --project <project-name-or-id> --cwd <app-dir>`; add `--team <team-id-or-slug>` when known. Passing only `VERCEL_PROJECT_ID` is not enough for route metrics if cwd is unlinked |
@@ -188,7 +188,7 @@ Calling without `?teamId=` returns 404 when the project belongs to a team other 
 
 ### `vercel usage --format json`
 
-May return `Error: Costs not found (404)` on teams without the Costs feature. Treat as `USAGE_UNAVAILABLE` and degrade — the skill still produces a useful report from metrics + scanner.
+May return `Error: Costs not found (404)`. Treat that queried error as `USAGE_UNAVAILABLE` and degrade — the skill can still produce a useful report from metrics + scanner. Do not use this explanation when `usageError` is `NOT_COLLECTED_OBSERVABILITY_BLOCKED` or another `NOT_COLLECTED_*` value; those mean the audit stopped before `vercel usage` ran.
 
 ## Why we avoid stderr grep
 

--- a/skills/vercel-optimize/references/data-collection.md
+++ b/skills/vercel-optimize/references/data-collection.md
@@ -49,7 +49,7 @@ The merged `signals.json` has this top-level shape:
   "observabilityPlusBlocker": null | "no_oplus_probe" | "project_disabled" | "payment_required" | "forbidden" | "daily_quota_exceeded" | "project_not_found" | "not_linked" | "all_failed_other" | "no_traffic",
   "observabilityPlusBlockerDetail": "...",
   "plan": { "plan": "hobby" | "pro" | "enterprise" | "uncertain", "reason": "..." },
-  "project": { /* /v9/projects/:id response, scoped to orgId via ?teamId */ },
+  "project": { /* /v9/projects/:id response; team-owned projects include ?teamId */ },
   "contract": { "context": "...", "commitments": [], "totalCommitments": 0 },
   "usage": { /* vercel usage --format json --breakdown daily, or null */ },
   "usageError": null | "USAGE_UNAVAILABLE" | "USAGE_CONTEXT_MISMATCH" | "NOT_COLLECTED_OBSERVABILITY_BLOCKED" | "NOT_COLLECTED_UNSUPPORTED_FRAMEWORK" | "EXIT_<n>" | "UNKNOWN",
@@ -62,7 +62,7 @@ The merged `signals.json` has this top-level shape:
 
 All metric queries use the same `timeWindow` constant (`14d`) — defined as `TIME_WINDOW` in [lib/queries.mjs](../lib/queries.mjs) and covered by the repo test suite. Mixing windows silently produces incompatible rollups; never pin a per-query `since`.
 
-All Vercel CLI commands that accept scope must use `commandScope.cliScope` (`--scope <team-slug-or-username>`). Linked project files often contain a raw `team_...` ID, but several CLI subcommands silently fall back to the current team when `--scope` receives that ID. `collect-signals.mjs` resolves raw team IDs to slugs before running `vercel metrics`, `vercel usage`, or `vercel contract`; `deep-dive.mjs` reuses the same scope for follow-up metric queries. If the project link lacks an org/team owner or the CLI-safe scope cannot be resolved, stop and ask the user which Vercel project and team/personal scope they want audited. Do not infer scope from the current `vercel whoami` team.
+All Vercel CLI commands that accept scope must use `commandScope.cliScope` (`--scope <team-slug-or-username>`). Linked project files often contain raw `team_...` or `usr_...` IDs, but several CLI subcommands silently fall back to the current team when `--scope` receives a raw account ID. `collect-signals.mjs` resolves raw team IDs to slugs and raw user IDs to usernames before running `vercel metrics`, `vercel usage`, or `vercel contract`; `deep-dive.mjs` reuses the same scope for follow-up metric queries. If the project link lacks an owner account or the CLI-safe scope cannot be resolved, stop and ask the user which Vercel project and team/personal scope they want audited. Do not infer scope from the current `vercel whoami` team.
 
 Downstream consumers reference `signals.<field>` paths verbatim. Bumping `schemaVersion` is required when any consumed path is renamed or removed.
 
@@ -72,12 +72,12 @@ Downstream consumers reference `signals.<field>` paths verbatim. Bumping `schema
 |---|---|---|---|
 | Auth | `vercel whoami` | Everything | Exit with "run `vercel login`" |
 | CLI version | `vercel --version` | Everything | Exit with "upgrade to v53+" — v53 is the skill's compatibility floor |
-| Project ID + Org ID | `.vercel/repo.json` (newer) or `.vercel/project.json` (legacy) → `VERCEL_PROJECT_ID` + `VERCEL_ORG_ID` → argv | Everything | Exit with "run `vercel link` or pass projectId". Multi-project `repo.json` or project ID without org/team scope is ambiguous; ask the user to clarify the intended project/account |
+| Project ID + Org ID | `.vercel/repo.json` (newer) or `.vercel/project.json` (legacy) → `VERCEL_PROJECT_ID` + `VERCEL_ORG_ID` → argv | Everything | Exit with "run `vercel link` or pass projectId". Multi-project `repo.json` or project ID without owner account scope is ambiguous; ask the user to clarify the intended project/account |
 | Framework support | local `package.json` via `detectStack()` + `classifyFrameworkSupport()` | Code-backed route recommendations | Stop before metric fan-out on unsupported frameworks unless the user chooses `--continue-unsupported-framework` |
-| CLI command scope | `vercel whoami --format json`, then `vercel api /v2/teams/:orgId` when a linked `team_...` ID must be converted to a slug | Keeps `vercel metrics`, `vercel usage`, and `vercel contract` on the linked project's account instead of the user's current/personal scope | `PROJECT_SCOPE_UNRESOLVED` or `SCOPE_UNRESOLVED`; stop and ask the user to clarify the intended project/account, then `vercel switch <team>` or re-link with `vercel link --yes --project <project> --team <team-slug>` |
-| Observability Plus configuration | Vercel CLI/API probe plus one metric access check | All `metrics.*` signals | Stop early when the team lacks Observability Plus or this project is disabled |
+| CLI command scope | `vercel whoami --format json`, then `vercel api /v2/teams/:orgId` when a linked `team_...` ID must be converted to a slug | Keeps `vercel metrics`, `vercel usage`, and `vercel contract` on the linked project's account instead of the user's current/personal scope | `PROJECT_SCOPE_UNRESOLVED` or `SCOPE_UNRESOLVED`; stop and ask the user to clarify the intended project/account, then re-link under the intended team or personal account |
+| Observability Plus configuration | Vercel CLI/API probe plus one metric access check; user-owned projects skip the team configuration endpoint and rely on the scoped metrics probe | All `metrics.*` signals | Stop early when the account lacks Observability Plus or this project is disabled |
 | Observability Plus metrics access | One canary `vercel metrics vercel.request.count --since 14d --limit 1`, then full fan-out only if it succeeds | All `metrics.*` signals | Set `observabilityPlusUsable=false` with blocker detail; emit a minimal blocker document before slower project config / usage collection unless `--continue-without-observability` is passed |
-| Project config | `vercel api /v9/projects/:id?teamId=<orgId>` | Fluid Compute, BotID, Speed Insights, security flags | `{error: "..."}` placeholder; gates that need it skip |
+| Project config | `vercel api /v9/projects/:id?teamId=<orgId>` for team-owned projects; omit `teamId` for `usr_...` user-owned projects | Fluid Compute, BotID, Speed Insights, security flags | `{error: "..."}` placeholder; gates that need it skip |
 | Plan tier | `vercel api /v2/teams/:orgId` (or `/v2/user` for user-owned projects) → `billing.plan`, then scoped `vercel contract --format json` fallback → `inferPlan()` | Cost-context framing only | `plan="uncertain"`; cost magnitudes still computed from `usage.services[].billedCost` |
 | Billing usage | Scoped `vercel usage --format json --from <14d> --to <today>` with best-effort project grouping when supported by the installed CLI | Cost magnitude framing, billing-driven candidates | `null` + `usageError` set when queried and unavailable; `NOT_COLLECTED_*` when a preflight stop happened before billing collection |
 | Stack | local `package.json` + dir scan | Version-aware citation filtering, scanner gating | "unknown" framework → all framework-specific citations filtered |
@@ -114,7 +114,7 @@ Downstream consumers reference `signals.<field>` paths verbatim. Bumping `schema
 | Code | Meaning | Skill behavior |
 |---|---|---|
 | `unsupported_framework` | Detected framework cannot reliably map Vercel route metrics back to source files | Stop before metric fan-out; ask whether to continue with a limited platform/scanner audit |
-| `PROJECT_SCOPE_UNRESOLVED` | The project was found without an org/team owner, or `.vercel/repo.json` contains multiple linked projects | Stop before `vercel metrics`, `vercel usage`, or `vercel contract`; ask the user which Vercel project and team/personal scope to audit |
+| `PROJECT_SCOPE_UNRESOLVED` | The project was found without an owner account, or `.vercel/repo.json` contains multiple linked projects | Stop before `vercel metrics`, `vercel usage`, or `vercel contract`; ask the user which Vercel project and team/personal scope to audit |
 | `SCOPE_UNRESOLVED` | The linked project belongs to a specific team/user, but the collector could not resolve a CLI-safe `--scope` value | Stop before `vercel metrics`, `vercel usage`, or `vercel contract`; ask the user to switch/re-link with the correct team |
 | `no_oplus_probe` | Observability Plus not enabled on team | Stop before full metric fan-out; ask whether to enable Observability Plus or run scanner-only |
 | `project_disabled` | Observability Plus enabled for team but disabled for project | Stop before full metric fan-out; ask the user to enable Observability Plus for this project or continue scanner-only |
@@ -176,7 +176,7 @@ Array of `{id, description}` entries — NOT an object. Many metric IDs in earli
 
 Status filtering uses `http_status` (not `status`). Both `http_status eq '500'` and `http_status ge 500` work.
 
-### `vercel api /v9/projects/<id>?teamId=<orgId>`
+### `vercel api /v9/projects/<id>` / `?teamId=<orgId>`
 
 Top-level keys relevant to the skill (real, verified):
 - `framework` (string, e.g. `"nextjs"`)
@@ -188,7 +188,7 @@ Top-level keys relevant to the skill (real, verified):
 - `webAnalytics` (`{id}`) — installed but `features.webAnalytics` says enabled state
 - `nodeVersion` (e.g. `"22.x"`)
 
-Calling without `?teamId=` returns 404 when the project belongs to a team other than the user's `currentTeam`.
+Calling without `?teamId=` returns 404 when the project belongs to a team other than the user's `currentTeam`. For user-owned projects (`orgId` starts with `usr_`), omit `teamId` and let the CLI use the authenticated user context.
 
 ### `vercel contract --format json`
 

--- a/skills/vercel-optimize/references/scoring.md
+++ b/skills/vercel-optimize/references/scoring.md
@@ -98,7 +98,7 @@ The agent renders this as the final output of Step 4. The shape is fixed; the co
 **Stack**: {framework}@{frameworkVersion} | {router} | {orm}
 **Plan**: {plan.plan} ({plan.reason})
 **Period**: {usage.period.from} → {usage.period.to}
-**Observability**: {observabilityPlus ? "Observability Plus enabled — per-route metrics included" : "Not enabled — analysis based on billing + scanner findings"}
+**Observability**: {observability status}
 
 ## Cost breakdown
 
@@ -108,7 +108,15 @@ The agent renders this as the final output of Step 4. The shape is fixed; the co
 
 Total billed: {usage.totals.billedCost} (we render the precise current cost — we just don't project future precise savings)
 
-If `vercel usage` is unavailable (free-tier teams, Costs feature disabled), the cost breakdown is replaced by an observability-derived cost ranking from `metrics.fnGbHrByRoute` + `metrics.fnCpuMsByRoute` + `metrics.fdtByRoute`. These don't translate directly to dollars — they show *which routes consume the billable units* so the user knows what to attack first.
+If `vercel usage` was queried and unavailable, the cost breakdown is replaced by an observability-derived cost ranking from `metrics.fnGbHrByRoute` + `metrics.fnCpuMsByRoute` + `metrics.fdtByRoute` when those metrics exist. These don't translate directly to dollars — they show *which routes consume the billable units* so the user knows what to attack first. If `usageError` is `NOT_COLLECTED_OBSERVABILITY_BLOCKED` or another `NOT_COLLECTED_*` value, say usage was not collected; do not describe it as a billing-plan or Costs-feature finding.
+
+Render Observability status from the actual collection state:
+- `Observability Plus enabled — per-route metrics included` when `observabilityPlusUsable=true`.
+- `Per-route metrics unavailable — audit paused before metric-backed route ranking` when an Observability Plus blocker stopped the run before billing/scanner collection.
+- `Per-route metrics unavailable — analysis based on billing + scanner findings` when the user accepted a limited audit and billing/scanner signals were collected.
+- `Per-route metrics unavailable — limited analysis based on scanner findings` when the user accepted a limited audit but billing usage was queried and unavailable.
+- `Not checked — audit paused at unsupported-framework preflight` when framework support stopped the run before the Observability Plus check.
+- `Not enabled — analysis based on billing + scanner findings` only for legacy/limited reports where Observability Plus is known false and billing/scanner signals exist.
 
 ## Highest-impact recommendations
 
@@ -164,9 +172,9 @@ This section earns the user's trust. For every metric signal we considered but d
 (what we couldn't measure — Observability Plus disabled means no per-route latency, etc.)
 ```
 
-Common data gaps to call out when the underlying metric returned empty rows:
+Common data gaps to call out when the underlying metric returned empty rows. If the metric query failed (`ok=false`), say the metric was not usable with the code; do not convert failed queries into "no measurements" or "not used" claims.
 
-- **Core Web Vitals empty.** Speed Insights not wired up on this project (or no client traffic in the last 14 days). The `cwv_poor` gate stayed dormant; no claims about LCP/INP/CLS are made.
+- **Core Web Vitals empty.** The Speed Insights metric returned no measurements for the 14-day window. The `cwv_poor` gate stayed dormant; no claims about LCP/INP/CLS are made.
 - **ISR empty.** Project doesn't use Incremental Static Regeneration. The `isr_overrevalidation` gate stayed dormant.
 - **Middleware empty.** No `middleware.ts` (or matcher excludes all observed traffic). The `middleware_heavy` gate stayed dormant.
 - **Image transformations empty.** No `next/image` usage or no images served in the window.

--- a/skills/vercel-optimize/scripts/collect-signals.mjs
+++ b/skills/vercel-optimize/scripts/collect-signals.mjs
@@ -7,6 +7,7 @@ import {
   checkCliVersion,
   checkAuth,
   resolveProjectId,
+  resolveCommandScope,
   hasObservabilityPlus,
   checkObservabilityPlusConfiguration,
   getMetricsSchema,
@@ -74,8 +75,6 @@ async function main() {
   }
   log(`project link resolved (source=${project.source}; teamScope=${project.orgId ? 'yes' : 'no'})`);
 
-  const scope = project.orgId || undefined;
-
   log('checking framework support…');
   const stack = await detectStack();
   const frameworkSupport = classifyFrameworkSupport(stack);
@@ -89,6 +88,7 @@ async function main() {
       projectId: project.projectId,
       orgId: project.orgId,
       projectIdSource: project.source,
+      commandScope: null,
       frameworkSupport,
       frameworkSupportBlocker: frameworkSupport.blocker,
       frameworkSupportDetail: frameworkSupport.detail,
@@ -117,6 +117,14 @@ async function main() {
   if (!frameworkSupport.ok && continueUnsupportedFramework) {
     log('continuing after unsupported framework blocker because --continue-unsupported-framework was set');
   }
+
+  log('resolving Vercel CLI command scope…');
+  const commandScope = await resolveCommandScope(project);
+  if (!commandScope.ok) {
+    throw new Error(`SCOPE_UNRESOLVED: ${commandScope.detail} Run \`vercel switch <team>\` or re-link with \`vercel link --yes --project <project-name-or-id> --team <team-slug>\`.`);
+  }
+  const scope = commandScope.cliScope || undefined;
+  log(`command scope resolved (source=${commandScope.source}; scoped=${scope ? 'yes' : 'no'})`);
 
   log('checking Observability Plus configuration…');
   const observabilityPlusConfig = await checkObservabilityPlusConfiguration({
@@ -186,6 +194,7 @@ async function main() {
       projectId: project.projectId,
       orgId: project.orgId,
       projectIdSource: project.source,
+      commandScope,
       observabilityPlus: oplus,
       observabilityPlusPreflight: observabilityPlusConfig,
       observabilityPlusUsable: oplusDiag.usable,
@@ -218,7 +227,7 @@ async function main() {
   log('pulling project config + account plan + contract + usage in parallel…');
   const [projectCfg, accountPlan, contract, usageResult] = await Promise.all([
     getProjectConfig(project.projectId, project.orgId),
-    getAccountPlan(scope),
+    getAccountPlan(project.orgId || scope),
     getContract(scope),
     getUsage({ days: 14, scope }),
   ]);
@@ -300,6 +309,7 @@ async function main() {
     projectId: project.projectId,
     orgId: project.orgId,
     projectIdSource: project.source,
+    commandScope,
     observabilityPlus: oplus,
     observabilityPlusPreflight: observabilityPlusConfig,
     observabilityPlusUsable: oplusDiag.usable,

--- a/skills/vercel-optimize/scripts/collect-signals.mjs
+++ b/skills/vercel-optimize/scripts/collect-signals.mjs
@@ -75,6 +75,10 @@ async function main() {
   }
   log(`project link resolved (source=${project.source}; teamScope=${project.orgId ? 'yes' : 'no'})`);
 
+  if (!project.orgId) {
+    throw new Error('PROJECT_SCOPE_UNRESOLVED: the project was resolved without an org/team owner. Ask the user which Vercel team or personal scope owns the project, then rerun from a linked app directory or set VERCEL_PROJECT_ID with VERCEL_ORG_ID for that scope.');
+  }
+
   log('checking framework support…');
   const stack = await detectStack();
   const frameworkSupport = classifyFrameworkSupport(stack);

--- a/skills/vercel-optimize/scripts/collect-signals.mjs
+++ b/skills/vercel-optimize/scripts/collect-signals.mjs
@@ -76,7 +76,7 @@ async function main() {
   log(`project link resolved (source=${project.source}; teamScope=${project.orgId ? 'yes' : 'no'})`);
 
   if (!project.orgId) {
-    throw new Error('PROJECT_SCOPE_UNRESOLVED: the project was resolved without an org/team owner. Ask the user which Vercel team or personal scope owns the project, then rerun from a linked app directory or set VERCEL_PROJECT_ID with VERCEL_ORG_ID for that scope.');
+    throw new Error('PROJECT_SCOPE_UNRESOLVED: the project was resolved without an owner account. Ask the user which Vercel team or personal scope owns the project, then rerun from a linked app directory or set VERCEL_PROJECT_ID with VERCEL_ORG_ID for that scope.');
   }
 
   log('checking framework support…');

--- a/skills/vercel-optimize/scripts/deep-dive.mjs
+++ b/skills/vercel-optimize/scripts/deep-dive.mjs
@@ -4,7 +4,7 @@
 // Byte-stable apart from totalWallMs; each CLI query is isolated.
 
 import { readFile } from 'node:fs/promises';
-import { queryMetric, readProjectJson } from '../lib/vercel.mjs';
+import { queryMetric, readProjectJson, resolveCommandScope } from '../lib/vercel.mjs';
 import { specsForCandidate, mergeIntoEvidence, SCANNER_KINDS, TIME_WINDOW } from '../lib/deep-dive.mjs';
 
 const SCHEMA_VERSION = '1.0';
@@ -57,7 +57,20 @@ async function main() {
   }
   log(`cwd link OK (source ${link.source})`);
 
-  const scope = merged.orgId || undefined;
+  const commandScope = await resolveDeepDiveCommandScope(merged, link);
+  if (!commandScope.ok) {
+    console.error(`[deep-dive] FATAL: could not resolve a CLI-safe Vercel scope (${commandScope.detail ?? commandScope.error ?? 'unknown'}).`);
+    console.error('         Re-run collect-signals.mjs with the current skill, run `vercel switch <team>`, or re-link with `vercel link --yes --project <project> --team <team-slug>`.');
+    process.exit(2);
+  }
+  if (typeof commandScope.cliScope === 'string' && /^(team|usr)_/.test(commandScope.cliScope)) {
+    console.error('[deep-dive] FATAL: commandScope.cliScope is a raw account ID, not a CLI-safe scope.');
+    console.error('         Re-run collect-signals.mjs with the current skill so deep-dive queries use the same team as the broad pass.');
+    process.exit(2);
+  }
+  const scope = commandScope.cliScope || undefined;
+  log(`command scope resolved (source=${commandScope.source}; scoped=${scope ? 'yes' : 'no'})`);
+
   const toLaunch = Array.isArray(gate.toLaunch) ? gate.toLaunch : [];
   const platform = Array.isArray(gate.platform) ? gate.platform : [];
 
@@ -208,6 +221,19 @@ async function main() {
   };
 
   process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+}
+
+async function resolveDeepDiveCommandScope(merged, link) {
+  const linkedOrgId = merged.orgId ?? link.orgId ?? null;
+  if (merged.commandScope?.ok && (merged.commandScope.cliScope || !linkedOrgId)) {
+    return merged.commandScope;
+  }
+  if (merged.commandScope && merged.commandScope.ok === false) return merged.commandScope;
+
+  return await resolveCommandScope({
+    projectId: merged.projectId ?? link.projectId ?? null,
+    orgId: merged.orgId ?? link.orgId ?? null,
+  });
 }
 
 // Reduce CLI response to {value} or {rows:[{value,...dims}]}. The per-metric

--- a/skills/vercel-optimize/scripts/deep-dive.mjs
+++ b/skills/vercel-optimize/scripts/deep-dive.mjs
@@ -55,6 +55,11 @@ async function main() {
     console.error('         Re-run with --cwd <dir-linked-to-the-collected-project>.');
     process.exit(2);
   }
+  if (merged.orgId && link.orgId && link.orgId !== merged.orgId) {
+    console.error('[deep-dive] FATAL: cwd .vercel/ links the project to a different Vercel scope than signals.json.');
+    console.error('         Re-run with --cwd <dir-linked-to-the-collected-project>, or rerun collect-signals.mjs from the intended app directory.');
+    process.exit(2);
+  }
   log(`cwd link OK (source ${link.source})`);
 
   const commandScope = await resolveDeepDiveCommandScope(merged, link);

--- a/skills/vercel-optimize/scripts/deep-dive.mjs
+++ b/skills/vercel-optimize/scripts/deep-dive.mjs
@@ -73,6 +73,12 @@ async function main() {
     console.error('         Re-run collect-signals.mjs with the current skill so deep-dive queries use the same team as the broad pass.');
     process.exit(2);
   }
+  const commandAccountId = commandScope.teamId ?? commandScope.userId ?? null;
+  if (commandAccountId && link.orgId && link.orgId !== commandAccountId) {
+    console.error('[deep-dive] FATAL: cwd .vercel/ links the project to a different Vercel scope than commandScope.');
+    console.error('         Re-run with --cwd <dir-linked-to-the-collected-project>, or rerun collect-signals.mjs from the intended app directory.');
+    process.exit(2);
+  }
   const scope = commandScope.cliScope || undefined;
   log(`command scope resolved (source=${commandScope.source}; scoped=${scope ? 'yes' : 'no'})`);
 


### PR DESCRIPTION
## Summary
- distinguish Observability Plus blockers from actual `vercel usage` failures in report copy
- resolve linked team/user IDs to CLI-safe `--scope` values before running `vercel metrics`, `vercel usage`, or `vercel contract`
- support user-owned projects by using the username scope while avoiding team-only Observability configuration and project `teamId` query params
- stop when project/scope resolution is ambiguous instead of inferring from the current `vercel whoami` team
- stop on multi-project `.vercel/repo.json` and deep-dive cwd/scope mismatches so agents ask the user to clarify the intended project/account
- make deep-dive metric queries reuse the same `commandScope.cliScope` instead of raw `orgId`, and fail rather than falling back to the wrong scope
- avoid claiming Speed Insights, ISR, image, or middleware gaps when those metrics were never collected or failed
- update scoring/data-collection guidance and add renderer, collector, deep-dive, and redaction regressions for blocker, unsupported framework, limited audit, usage unavailable, Speed Insights, team-scope, and user-scope states

## Verification
- `node --test packages/vercel-optimize-tests/test/collect-framework-preflight.test.mjs packages/vercel-optimize-tests/test/deep-dive.test.mjs packages/vercel-optimize-tests/test/vercel-redaction.test.mjs`
- `node --test packages/vercel-optimize-tests/test/infer-plan.test.mjs packages/vercel-optimize-tests/test/render-report.test.mjs packages/vercel-optimize-tests/test/observability-preflight.test.mjs`
- `node --test packages/vercel-optimize-tests/test/*.test.mjs`
- `git diff --check`