### PR TITLE
Harden vercel-optimize Workflow guidance

### DIFF
--- a/packages/vercel-optimize-tests/test/citations.test.mjs
+++ b/packages/vercel-optimize-tests/test/citations.test.mjs
@@ -12,7 +12,7 @@ import {
 
 test('loadLibrary returns version + entries', async () => {
   const lib = await loadLibrary();
-  assert.equal(lib.version, '1.1.0');
+  assert.equal(lib.version, '1.1.1');
   assert.ok(lib.urls.length >= 30, 'expected >=30 URL entries');
   assert.ok(lib.ruleSkillRefs.length >= 10, 'expected >=10 rule refs');
 });

--- a/packages/vercel-optimize-tests/test/flags-gate.test.mjs
+++ b/packages/vercel-optimize-tests/test/flags-gate.test.mjs
@@ -6,7 +6,13 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
-import { applyHardGates, FLAGS_ENDPOINT, isFlagsEndpointCandidate } from '../../../skills/vercel-optimize/lib/gates/hard-gates.mjs';
+import {
+  applyHardGates,
+  FLAGS_ENDPOINT,
+  WORKFLOW_ENDPOINT_PREFIXES,
+  isFlagsEndpointCandidate,
+  isWorkflowRuntimeEndpointCandidate,
+} from '../../../skills/vercel-optimize/lib/gates/hard-gates.mjs';
 import { detectStack } from '../../../skills/vercel-optimize/lib/vercel.mjs';
 
 const exec = promisify(execFile);
@@ -30,6 +36,29 @@ test('applyHardGates: gates the Vercel Flags endpoint with package context', () 
   assert.equal(out.gated.length, 1);
   assert.match(out.gated[0].gatedReason, /Vercel Flags endpoint/);
   assert.match(out.gated[0].gatedReason, /@vercel\/flags/);
+});
+
+test('isWorkflowRuntimeEndpointCandidate: detects Vercel Workflow runtime endpoints', () => {
+  assert.deepEqual(WORKFLOW_ENDPOINT_PREFIXES, ['/.well-known/workflow', '/api/.well-known/workflow']);
+  assert.equal(isWorkflowRuntimeEndpointCandidate({ scope: 'route', route: '/.well-known/workflow/v1/step' }), true);
+  assert.equal(isWorkflowRuntimeEndpointCandidate({ scope: 'route', route: '/.well-known/workflow/v1/flow/' }), true);
+  assert.equal(isWorkflowRuntimeEndpointCandidate({ scope: 'route', route: '/api/.well-known/workflow/v1/step' }), true);
+  assert.equal(isWorkflowRuntimeEndpointCandidate({ scope: 'route', route: '/.well-known/vercel/flags' }), false);
+  assert.equal(isWorkflowRuntimeEndpointCandidate({ scope: 'route', route: '/api/projects/ai/chat/[id]/stream' }), false);
+  assert.equal(isWorkflowRuntimeEndpointCandidate({ scope: 'account' }), false);
+});
+
+test('applyHardGates: gates Vercel Workflow runtime endpoints with package context', () => {
+  const workflow = { kind: 'slow_route', scope: 'route', route: '/.well-known/workflow/v1/step', priority: 100 };
+  const other = { kind: 'slow_route', scope: 'route', route: '/api/orders', priority: 90 };
+  const out = applyHardGates([workflow, other], {
+    stack: { hasWorkflowPackage: true, workflowPackages: ['workflow', '@workflow/next'] },
+  });
+  assert.deepEqual(out.allowed, [other]);
+  assert.equal(out.gated.length, 1);
+  assert.match(out.gated[0].gatedReason, /Vercel Workflow runtime endpoint/);
+  assert.match(out.gated[0].gatedReason, /long-running step\/flow requests are expected/);
+  assert.match(out.gated[0].gatedReason, /@workflow\/next/);
 });
 
 test('gate-investigations: hard-gates /.well-known/vercel/flags before launch budget', async () => {
@@ -63,6 +92,45 @@ test('gate-investigations: hard-gates /.well-known/vercel/flags before launch bu
   }
 });
 
+test('gate-investigations: hard-gates Workflow runtime endpoints before launch budget', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'vo-workflow-gate-'));
+  try {
+    const signalsPath = join(root, 'signals.json');
+    await writeFile(signalsPath, JSON.stringify({
+      stack: { framework: 'next', hasWorkflowPackage: true, workflowPackages: ['workflow'] },
+      project: { defaultResourceConfig: { fluid: true } },
+      metrics: {
+        fnDurationP95ByRoute: {
+          ok: true,
+          rows: [
+            { route: '/.well-known/workflow/v1/step', value: 12000 },
+            { route: '/api/orders', value: 1800 },
+          ],
+        },
+        requestsByRouteCache: {
+          ok: true,
+          rows: [
+            { route: '/.well-known/workflow/v1/step', cache_result: 'MISS', value: 8000 },
+            { route: '/api/orders', cache_result: 'MISS', value: 3000 },
+          ],
+        },
+        requestsByRouteStatus: { ok: true, rows: [] },
+        fnStatusByRoute: { ok: true, rows: [] },
+      },
+      codebase: { findings: [] },
+    }), 'utf-8');
+    const { stdout } = await exec('node', [GATE_SCRIPT, signalsPath, '--max-candidates=all']);
+    const out = JSON.parse(stdout);
+    assert.ok(!out.toLaunch.some((c) => c.route === '/.well-known/workflow/v1/step'));
+    assert.ok(out.toLaunch.some((c) => c.route === '/api/orders'));
+    const gated = out.gated.find((c) => c.route === '/.well-known/workflow/v1/step');
+    assert.ok(gated, 'Workflow endpoint should appear in gated list');
+    assert.match(gated.gatedReason, /Vercel Workflow runtime endpoint/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test('detectStack: records @vercel/flags packages from package.json', async () => {
   const root = await mkdtemp(join(tmpdir(), 'vo-flags-stack-'));
   try {
@@ -80,6 +148,28 @@ test('detectStack: records @vercel/flags packages from package.json', async () =
     assert.equal(stack.framework, 'next');
     assert.equal(stack.hasVercelFlagsPackage, true);
     assert.deepEqual(stack.vercelFlagsPackages, ['@vercel/flags', '@vercel/flags/next']);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('detectStack: records Workflow SDK packages from package.json', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'vo-workflow-stack-'));
+  try {
+    await mkdir(join(root, 'app'), { recursive: true });
+    await writeFile(join(root, 'package.json'), JSON.stringify({
+      dependencies: {
+        next: '16.0.0',
+        workflow: '^4.2.0',
+      },
+      devDependencies: {
+        '@workflow/next': '4.2.0',
+      },
+    }), 'utf-8');
+    const stack = await detectStack(root);
+    assert.equal(stack.framework, 'next');
+    assert.equal(stack.hasWorkflowPackage, true);
+    assert.deepEqual(stack.workflowPackages, ['@workflow/next', 'workflow']);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/vercel-optimize-tests/test/investigation-brief.test.mjs
+++ b/packages/vercel-optimize-tests/test/investigation-brief.test.mjs
@@ -248,6 +248,17 @@ test('citationSubset: includes wildcard-version URLs (e.g. Vercel platform docs)
   assert.ok(fluid, 'Fluid Compute doc applies to any version + slow_route');
 });
 
+test('citationSubset: scopes Workflow docs to relevant candidate kinds', async () => {
+  const routeErrors = await citationSubset('route_errors', 'next', '15.4.0');
+  assert.ok(routeErrors.urls.some((e) => e.url === 'https://workflow-sdk.dev/docs/foundations/starting-workflows'));
+
+  const image = await citationSubset('image_optimization', 'next', '15.4.0');
+  assert.equal(
+    image.urls.some((e) => e.url === 'https://workflow-sdk.dev/docs/foundations/starting-workflows'),
+    false,
+  );
+});
+
 const stubCitations = {
   urls: [
     { url: 'https://vercel.com/docs/fluid-compute', topic: 'Fluid Compute', appliesTo: ['slow_route'], applicableFrameworks: ['*'] },
@@ -389,6 +400,7 @@ test('buildBrief: per-kind interpretation hints render for known kinds', () => {
   });
   assert.match(md, /How to read the evidence for this candidate kind/);
   assert.ok(md.includes(KIND_INTERPRETATION_HINTS.slow_route[0]));
+  assert.match(md, /streaming, SSE, resumable chat/);
 });
 
 test('buildBrief: cache candidates include cache-policy guidance', () => {

--- a/packages/vercel-optimize-tests/test/render-report.test.mjs
+++ b/packages/vercel-optimize-tests/test/render-report.test.mjs
@@ -220,6 +220,22 @@ test('renderReport: public gated reasons avoid raw budget internals', () => {
   assert.doesNotMatch(md, /=all/);
 });
 
+test('renderReport: public gated reasons avoid hard-gate internals', () => {
+  const md = renderReport({
+    recommendations: [],
+    gated: [
+      {
+        kind: 'slow_route',
+        route: '/.well-known/workflow/v1/step',
+        gatedReason: 'hardGated: Vercel Workflow runtime endpoint; long-running step/flow requests are expected orchestration, not an app-route optimization target',
+      },
+    ],
+    signals: baseSignals,
+  });
+  assert.match(md, /Vercel Workflow runtime endpoint; long-running step\/flow requests are expected orchestration/);
+  assert.doesNotMatch(md, /hardGated/);
+});
+
 test('renderReport: partitions recs by impactTier into High / Medium / Low', () => {
   const md = renderReport({
     recommendations: [

--- a/packages/vercel-optimize-tests/test/support-topics.test.mjs
+++ b/packages/vercel-optimize-tests/test/support-topics.test.mjs
@@ -143,6 +143,34 @@ test('supportTopicSubset: selects route-pattern topics only for matching routes'
   assert.ok(!normalTopics.some((t) => t.id === 'not-found-catchall-request-waste'));
 });
 
+test('supportTopicSubset: selects Workflow stream guardrails only for stream-shaped slow routes', async () => {
+  const streamTopics = await supportTopicSubset({
+    candidate: { kind: 'slow_route', route: '/api/projects/ai/chat/[id]/stream' },
+    signals: next15Signals,
+  });
+  assert.equal(streamTopics[0].id, 'workflow-resumable-stream-routes');
+
+  const normalTopics = await supportTopicSubset({
+    candidate: { kind: 'slow_route', route: '/api/projects' },
+    signals: next15Signals,
+  });
+  assert.ok(!normalTopics.some((t) => t.id === 'workflow-resumable-stream-routes'));
+});
+
+test('supportTopicSubset: keeps durable Workflow offload scoped to route errors', async () => {
+  const routeErrorTopics = await supportTopicSubset({
+    candidate: { kind: 'route_errors', route: '/api/import' },
+    signals: next15Signals,
+  });
+  assert.ok(routeErrorTopics.some((t) => t.id === 'route-error-durable-offload'));
+
+  const slowTopics = await supportTopicSubset({
+    candidate: { kind: 'slow_route', route: '/api/import' },
+    signals: next15Signals,
+  });
+  assert.ok(!slowTopics.some((t) => t.id === 'route-error-durable-offload'));
+});
+
 test('supportTopicSubset: selects high-impact framework topics for SvelteKit, Nuxt, and Astro', async () => {
   const svelteTopics = await supportTopicSubset({
     candidate: { kind: 'uncached_route', route: '/blog' },

--- a/skills/vercel-optimize/SKILL.md
+++ b/skills/vercel-optimize/SKILL.md
@@ -254,6 +254,9 @@ Every recommendation must:
 - Include at least one allowed citation that applies to the detected framework/version.
 - Use precise observed performance numbers.
 - Use cost magnitude phrases only; never customer-facing `$N` savings.
+- Do not recommend duration reductions for Vercel Workflow runtime endpoints (`/.well-known/workflow/v1/*`). These are generated orchestration routes for durable step/flow execution and should be hard-gated before investigation.
+- Workflow recommendations must name the boundary being changed. Valid examples: enqueue durable work and return a run ID instead of awaiting completion, fix stream replay/closure/locks, or reduce verified excess Workflow Steps/Storage. Do not infer cost savings from Workflow endpoint wall-clock duration.
+- For streaming, SSE, resumable chat, or other intentionally long-lived routes, do not frame wall-clock function duration as a problem by itself. Require evidence of avoidable pre-first-byte work, high active CPU, duplicate invocations, or post-response work that can move out of the user-visible path.
 - Name a specific cache policy when recommending caching.
 - Keep unsafe responses dynamic unless evidence proves they are safe to cache: auth-sensitive paths, errors, fallback responses, missing content, invalid requests, geolocation/device-varying output, and unversioned dynamic URLs.
 

--- a/skills/vercel-optimize/lib/gates/hard-gates.mjs
+++ b/skills/vercel-optimize/lib/gates/hard-gates.mjs
@@ -7,6 +7,10 @@ export const VERCEL_FLAGS_PACKAGES = [
   '@vercel/flags/sveltekit',
   '@vercel/flags/nuxt',
 ];
+export const WORKFLOW_ENDPOINT_PREFIXES = [
+  '/.well-known/workflow',
+  '/api/.well-known/workflow',
+];
 
 export function applyHardGates(candidates, signals = {}) {
   const allowed = [];
@@ -16,6 +20,13 @@ export function applyHardGates(candidates, signals = {}) {
       gated.push({
         ...candidate,
         gatedReason: flagsEndpointReason(signals),
+      });
+      continue;
+    }
+    if (isWorkflowRuntimeEndpointCandidate(candidate)) {
+      gated.push({
+        ...candidate,
+        gatedReason: workflowEndpointReason(signals),
       });
       continue;
     }
@@ -30,6 +41,15 @@ export function isFlagsEndpointCandidate(candidate) {
   return route === FLAGS_ENDPOINT;
 }
 
+export function isWorkflowRuntimeEndpointCandidate(candidate) {
+  if (!candidate || candidate.scope === 'account') return false;
+  const route = normalizeRoute(candidate.route);
+  if (!route) return false;
+  return WORKFLOW_ENDPOINT_PREFIXES.some((prefix) => (
+    route === prefix || route.startsWith(`${prefix}/`)
+  ));
+}
+
 function normalizeRoute(route) {
   if (typeof route !== 'string') return null;
   const normalized = canonicalizeRoute(route).replace(/\/+$/, '');
@@ -42,4 +62,12 @@ function flagsEndpointReason(signals) {
     return `hardGated: ${FLAGS_ENDPOINT} is the Vercel Flags endpoint (${packages.join(', ')} detected), not an optimization target`;
   }
   return `hardGated: ${FLAGS_ENDPOINT} is the Vercel Flags endpoint, not an optimization target`;
+}
+
+function workflowEndpointReason(signals) {
+  const packages = signals.stack?.workflowPackages;
+  if (Array.isArray(packages) && packages.length > 0) {
+    return `hardGated: Vercel Workflow runtime endpoint (${packages.join(', ')} detected); long-running step/flow requests are expected orchestration, not an app-route optimization target`;
+  }
+  return 'hardGated: Vercel Workflow runtime endpoint; long-running step/flow requests are expected orchestration, not an app-route optimization target';
 }

--- a/skills/vercel-optimize/lib/gates/index.mjs
+++ b/skills/vercel-optimize/lib/gates/index.mjs
@@ -42,4 +42,4 @@ export const DEFAULT_MAX_CODE_CANDIDATES = 6;
 export const MAX_CODE_CANDIDATES = DEFAULT_MAX_CODE_CANDIDATES;
 
 // Bump on any threshold change so report + iteration baselines can detect gate-logic drift.
-export const GATE_VERSION = '1.7.0';
+export const GATE_VERSION = '1.8.0';

--- a/skills/vercel-optimize/lib/gates/slow-route.mjs
+++ b/skills/vercel-optimize/lib/gates/slow-route.mjs
@@ -12,12 +12,12 @@ const ERROR_RATE_DISQUALIFY_THRESHOLD = 0.5;
 
 export const metadata = {
   id: 'slow_route',
-  threshold: '(p95 > 500 AND inv >= 1400) OR (p95 > 1500 AND inv >= 250); disqualified when 5xx rate > 50%',
+  threshold: '(p95 > 500 AND inv >= 1400) OR (p95 > 1500 AND inv >= 250); disqualified when 5xx rate > 50%; Vercel Workflow runtime endpoints are hard-gated',
   billingDimension: 'function-duration',
   scope: 'route',
   sourceCitation: 'vercel-optimize gate threshold',
   description:
-    'Routes with p95 function duration above 500ms at meaningful traffic (>=1,400 invocations in window), OR catastrophically slow routes (>1500ms p95 at any volume >=250). High duration drives both function-duration cost and user-perceived latency. Investigate sequential awaits, slow external APIs, missing caching, N+1 patterns. Routes with >50% 5xx rate are disqualified — those are reliability problems, not performance tuning targets, and surface via route_errors instead.',
+    'Routes with p95 function duration above 500ms at meaningful traffic (>=1,400 invocations in window), OR catastrophically slow routes (>1500ms p95 at any volume >=250). High duration drives both function-duration cost and user-perceived latency. Investigate sequential awaits, slow external APIs, missing caching, N+1 patterns. Routes with >50% 5xx rate are disqualified — those are reliability problems, not performance tuning targets, and surface via route_errors instead. Vercel Workflow runtime endpoints (`/.well-known/workflow/v1/*`) are hard-gated before launch because long-running step/flow requests are expected orchestration, not app-route bottlenecks.',
 };
 
 export function gate(signals) {

--- a/skills/vercel-optimize/lib/investigation-brief.mjs
+++ b/skills/vercel-optimize/lib/investigation-brief.mjs
@@ -272,6 +272,7 @@ export const KIND_INTERPRETATION_HINTS = {
   slow_route: [
     'Compare `cpu.p95` vs `latency.p95`. If cpu << latency, the bottleneck is wall-clock / external IO / awaits — look for sequential awaits, slow DB queries, slow external APIs. If cpu ≈ latency, look for in-process compute (rendering, JSON serialization, crypto).',
     'Compare `ttfb.p95` vs `latency.p95`. If ttfb ≈ latency, response generation finishes near the end — streaming or `after()` may shift perceived latency.',
+    'For streaming, SSE, resumable chat, or other intentionally long-lived routes, do not treat high wall-clock duration alone as a bug. Recommend a change only when evidence shows avoidable pre-first-byte work, high active CPU, duplicate invocations, or post-response work that can move out of the user-visible path.',
     'Inspect `perDeployment`: a 2x step between deployments points to a regression introduced in the newer deployment. Frame the rec as "regression introduced in <deployment_id>" rather than a generic perf claim.',
     'Inspect `startTypeSplit.cold` share. >5% cold means cold starts contribute meaningfully — Fluid Compute or warmer keep-alive is on the table.',
     'Inspect `statusDistribution`. A non-trivial 3xx/4xx slice may be inflating p95 because redirects/auth bounces still count as invocations.',

--- a/skills/vercel-optimize/lib/render-report.mjs
+++ b/skills/vercel-optimize/lib/render-report.mjs
@@ -540,6 +540,7 @@ function splitInvestigationOutcomes(abstentions) {
 
 function publicGatedReason(reason) {
   return formatPublicText(String(reason))
+    .replace(/\bhardGated:\s*/gi, '')
     .replace(/skippedByBudget\s*\(max-candidates=([^);]+)(?:;[^)]*)?\)/i, 'left for a larger run (max candidates: $1)')
     .replace(/skippedByBudget\b/gi, 'left for a larger run')
     .replace(/\s*;\s*raise with --max-candidates N or =all/gi, '')

--- a/skills/vercel-optimize/lib/vercel.mjs
+++ b/skills/vercel-optimize/lib/vercel.mjs
@@ -553,6 +553,9 @@ export async function detectStack(cwd = process.cwd()) {
     '@vercel/flags/sveltekit',
     '@vercel/flags/nuxt',
   ].filter((name) => deps[name]);
+  const workflowPackages = Object.keys(deps)
+    .filter((name) => name === 'workflow' || name.startsWith('@workflow/'))
+    .sort();
 
   const isMonorepo =
     !!pkg.workspaces ||
@@ -571,6 +574,8 @@ export async function detectStack(cwd = process.cwd()) {
     rootDirectory: null,
     hasVercelFlagsPackage: vercelFlagsPackages.length > 0,
     vercelFlagsPackages,
+    hasWorkflowPackage: workflowPackages.length > 0,
+    workflowPackages,
   };
 }
 
@@ -580,6 +585,7 @@ function baselineStack() {
     hasAppRouter: false, hasPagesRouter: false, cacheComponents: null, typescript: false,
     orm: 'none', isMonorepo: false, rootDirectory: null,
     hasVercelFlagsPackage: false, vercelFlagsPackages: [],
+    hasWorkflowPackage: false, workflowPackages: [],
   };
 }
 

--- a/skills/vercel-optimize/references/candidates.md
+++ b/skills/vercel-optimize/references/candidates.md
@@ -6,7 +6,7 @@
 
 The deterministic threshold expressions that turn observability signals into investigation candidates. Pure JS, no LLM. Thresholds live in `lib/gates/*.mjs`.
 
-Total gates: 15. Budget cap: `MAX_CODE_CANDIDATES = 6`. Gate version: `1.7.0`.
+Total gates: 15. Budget cap: `MAX_CODE_CANDIDATES = 6`. Gate version: `1.8.0`.
 
 ## Gates
 
@@ -144,12 +144,12 @@ Configured kinds emitted from scanner output. Each requires a minimum match coun
 
 ### `slow_route`
 
-- **Threshold**: `(p95 > 500 AND inv >= 1400) OR (p95 > 1500 AND inv >= 250); disqualified when 5xx rate > 50%`
+- **Threshold**: `(p95 > 500 AND inv >= 1400) OR (p95 > 1500 AND inv >= 250); disqualified when 5xx rate > 50%; Vercel Workflow runtime endpoints are hard-gated`
 - **Billing dimension**: function-duration
 - **Scope**: route
 - **Source citation**: `vercel-optimize gate threshold`
 
-Routes with p95 function duration above 500ms at meaningful traffic (>=1,400 invocations in window), OR catastrophically slow routes (>1500ms p95 at any volume >=250). High duration drives both function-duration cost and user-perceived latency. Investigate sequential awaits, slow external APIs, missing caching, N+1 patterns. Routes with >50% 5xx rate are disqualified — those are reliability problems, not performance tuning targets, and surface via route_errors instead.
+Routes with p95 function duration above 500ms at meaningful traffic (>=1,400 invocations in window), OR catastrophically slow routes (>1500ms p95 at any volume >=250). High duration drives both function-duration cost and user-perceived latency. Investigate sequential awaits, slow external APIs, missing caching, N+1 patterns. Routes with >50% 5xx rate are disqualified — those are reliability problems, not performance tuning targets, and surface via route_errors instead. Vercel Workflow runtime endpoints (`/.well-known/workflow/v1/*`) are hard-gated before launch because long-running step/flow requests are expected orchestration, not app-route bottlenecks.
 
 ---
 

--- a/skills/vercel-optimize/references/docs-library.json
+++ b/skills/vercel-optimize/references/docs-library.json
@@ -1,7 +1,7 @@
 {
   "$schema": "Curated documentation allow-list for the vercel-optimize skill. Entries are version-aware via applicableFrameworks (semver). The recommender prompt receives only the subset valid for the user's stack. Citations outside this allow-list are stripped by the unknown-citation sanitizer.",
-  "version": "1.1.0",
-  "lastVerified": "2026-05-19",
+  "version": "1.1.1",
+  "lastVerified": "2026-05-21",
   "schemaVersion": "1.0",
   "applicableFrameworksSyntax": "Semver-style. '*' = any framework. 'next@*' = any Next.js. 'next@14' = Next 14.x. 'next@>=15.0.0' = Next 15+. Multiple via '||': 'next@14 || next@>=15.0.0'.",
   "urls": [
@@ -253,8 +253,32 @@
     },
     {
       "url": "https://vercel.com/docs/workflow",
-      "topic": "Vercel Workflow — beta durable workflows for multi-step logic that can pause and resume over time",
-      "appliesTo": ["route_errors"],
+      "topic": "Vercel Workflow — beta durable workflows, observability, Workflow Steps/Storage pricing, and compute billing caveats",
+      "appliesTo": ["route_errors", "slow_route"],
+      "applicableFrameworks": ["*"]
+    },
+    {
+      "url": "https://workflow-sdk.dev/docs/foundations/starting-workflows",
+      "topic": "Workflow SDK starting workflows — start() returns after enqueueing, returnValue waits for completion, streams/status can be read later",
+      "appliesTo": ["route_errors", "slow_route"],
+      "applicableFrameworks": ["*"]
+    },
+    {
+      "url": "https://workflow-sdk.dev/docs/foundations/workflows-and-steps",
+      "topic": "Workflow SDK workflows and steps — workflow orchestration, step execution, persisted results, retries, sleep, and suspension",
+      "appliesTo": ["route_errors", "slow_route"],
+      "applicableFrameworks": ["*"]
+    },
+    {
+      "url": "https://workflow-sdk.dev/docs/foundations/streaming",
+      "topic": "Workflow SDK streaming — durable streams, getReadable startIndex, getWritable, lock release, stream close, and retry caveats",
+      "appliesTo": ["slow_route"],
+      "applicableFrameworks": ["*"]
+    },
+    {
+      "url": "https://workflow-sdk.dev/docs/ai/resumable-streams",
+      "topic": "Workflow SDK resumable streams — reconnecting AI chat streams with run IDs, stream startIndex, and tail-index headers",
+      "appliesTo": ["slow_route"],
       "applicableFrameworks": ["*"]
     },
     {

--- a/skills/vercel-optimize/references/doctrine.md
+++ b/skills/vercel-optimize/references/doctrine.md
@@ -89,6 +89,8 @@ A good run produces:
 - Recommendations from grepping the repo for known anti-patterns, without checking traffic.
 - "Enable Fluid Compute" without a cold-start signal.
 - "Add caching to /api/users" when the route has cookies() and is auth-gated.
+- "Reduce the duration of `/.well-known/workflow/v1/step`" because a Workflow step is long-running. Workflow runtime endpoints are generated orchestration routes; high wall-clock duration there is expected unless a separate reliability/error signal points elsewhere.
+- "Fix `/api/chat/[id]/stream` because it has high duration" without proving the stream does avoidable pre-first-byte work, high active CPU, duplicate invocations, or movable post-response work.
 - "Save $340/mo by doing X" — invented precision.
 - Citations to URLs that don't exist or that describe Next.js features the user's version doesn't have.
 - Long lists of recs the user can't act on; every rec needs an evidence chain.

--- a/skills/vercel-optimize/references/support-topics/route-error-durable-offload.md
+++ b/skills/vercel-optimize/references/support-topics/route-error-durable-offload.md
@@ -4,19 +4,19 @@ title: Durable offload for timeout-heavy routes
 status: active
 candidateKinds: ["route_errors"]
 frameworks: ["*"]
-priority: 82
-citations: ["https://vercel.com/docs/workflow", "https://vercel.com/docs/queues", "https://vercel.com/docs/functions/limitations"]
+priority: 84
+citations: ["https://vercel.com/docs/workflow", "https://workflow-sdk.dev/docs/foundations/starting-workflows", "https://workflow-sdk.dev/docs/foundations/workflows-and-steps", "https://vercel.com/docs/queues", "https://vercel.com/docs/functions/limitations"]
 maxBriefChars: 850
 ---
 
 ## Investigation Brief
-Timeout-heavy routes often need a job boundary, not a higher limit. Workflow is beta; mention it only when durable multi-step work is truly what the route is doing.
+Timeout-heavy routes often need a job boundary, not a higher limit. Workflow fits durable multi-step work that can continue after the response; return a run ID instead of waiting on `returnValue`.
 
 ## Evidence To Check
-Use `errorStatusPattern`, `errorCodes`, and source control flow. Look for long-running fan-out, polling, batch work, AI jobs, uploads, or multi-step side effects inside a request handler.
+Use `errorStatusPattern`, `errorCodes`, and source flow. Look for fan-out, polling, batch work, AI jobs, uploads, sleeps, approval, multi-step side effects. If Workflow is already used, check whether the route waits or streams progress.
 
 ## Do Not Recommend When
-Do not offload synchronous user-facing reads or writes that must complete before responding. Do not recommend beta primitives without naming the tradeoff.
+Do not offload work that must finish before responding. Do not claim savings from offload alone: Workflow Steps/Storage bill separately, and invoked functions still use compute billing.
 
 ## Verification
-Name the timeout/error class, the long-running operation, and the queue or workflow boundary that preserves user-visible semantics.
+Name the timeout/error class, long-running operation, post-enqueue response contract, and queue or workflow boundary that preserves semantics.

--- a/skills/vercel-optimize/references/support-topics/workflow-resumable-stream-routes.md
+++ b/skills/vercel-optimize/references/support-topics/workflow-resumable-stream-routes.md
@@ -1,0 +1,23 @@
+---
+id: workflow-resumable-stream-routes
+title: Workflow resumable stream routes
+status: active
+candidateKinds: ["slow_route"]
+frameworks: ["*"]
+routePatterns: ["(^|/)api/.*/stream/?$", "(^|/)chat/.*/stream/?$", "\\[id\\].*/stream"]
+priority: 98
+citations: ["https://workflow-sdk.dev/docs/ai/resumable-streams", "https://workflow-sdk.dev/docs/foundations/streaming", "https://vercel.com/docs/workflow"]
+maxBriefChars: 850
+---
+
+## Investigation Brief
+Stream-shaped routes may be Workflow SDK reconnection endpoints. Long wall-clock duration can be the live client connection.
+
+## Evidence To Check
+Look for `WorkflowChatTransport`, `getRun`, `run.getReadable`, `startIndex`, `x-workflow-run-id`, `x-workflow-stream-tail-index`, `getWritable`, or `createUIMessageStreamResponse`. Compare CPU, TTFB, wall-clock. Check full replay, missing tail-index, unreleased locks, or unclosed streams.
+
+## Do Not Recommend When
+Do not cache stream endpoints or remove resumability. Do not call high duration a bug when CPU is low, TTFB is healthy, and the route only holds a client connection.
+
+## Verification
+Name whether the route starts or reconnects a run, then cite the exact waste: replay, missing tail-index, lock leak, unclosed stream, high CPU, or avoidable pre-first-byte work.


### PR DESCRIPTION
## Summary
- hard-gate generated Vercel Workflow runtime endpoints before slow-route investigation
- add Workflow SDK stream/offload guardrails and scoped citations for investigation briefs
- keep Workflow cost guidance conservative unless Workflow Steps/Storage usage is actually measured

## Validation
- npm --prefix packages/vercel-optimize-tests test
- npm --prefix packages/vercel-optimize-tests run check-docs
- npm --prefix packages/vercel-optimize-tests run check-citations
- git diff --check