### PR TITLE
Add writing-guidelines skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,33 @@ Review UI code for compliance with web interface best practices. Audits your cod
 - Touch & Interaction (touch-action, tap-highlight)
 - Locale & i18n (Intl.DateTimeFormat, Intl.NumberFormat)
 
+### writing-guidelines
+
+Review docs and prose for compliance with the Vercel writing handbook. Audits your pages for 80+ rules covering voice, structure, content types, code samples, typography, and AI workflow.
+
+**Use when:**
+
+- "Review my docs"
+- "Check writing style"
+- "Audit prose"
+- "Review docs voice and tone"
+- "Check this page against the writing handbook"
+
+**Categories covered:**
+
+- Planning (content plan, content type, user-shaped titles)
+- Voice & tone (active voice, direct address, banned words like `easy`/`simple`/`quick`)
+- Tone by content type (tutorial, how-to, reference, conceptual, troubleshooting)
+- Headings & structure (sentence case, descriptive subheadings, TL;DR opens)
+- Lists (when to use, bold/description format)
+- Code (language tags, TypeScript first, `<Steps/>`, 80-col / 25-line limits)
+- Placeholders, units, & numbers (`snake_case` text, count-up numbers, `64 KB`/`200 ms`)
+- Typography (no em dashes as punctuation, curly quotes, ellipsis character, non-breaking spaces)
+- Source formatting (no hard-wrap, no `---` rules, blank line discipline)
+- Pricing & money pages (tables, uncompromising detail)
+- AI workflow (accountability, enterprise models, plan first, disclose AI use)
+- Review (PR description discipline, author accountability)
+
 ### react-native-guidelines
 
 React Native best practices optimized for AI agents. Contains 16 rules across 7 sections covering performance, architecture, and platform-specific patterns.

--- a/skills/writing-guidelines/SKILL.md
+++ b/skills/writing-guidelines/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: writing-guidelines
+description: Review docs/prose for Writing Guidelines compliance. Use when asked to "review my docs", "check writing style", "audit prose", "review docs voice and tone", or "check this page against the writing handbook".
+metadata:
+  author: vercel
+  version: "1.0.0"
+  argument-hint: <file-or-pattern>
+---
+
+# Writing Guidelines
+
+Review files for compliance with Writing Guidelines.
+
+## How It Works
+
+1. Fetch the latest guidelines from the source URL below
+2. Read the specified files (or prompt user for files/pattern)
+3. Check against all rules in the fetched guidelines
+4. Output findings in the terse `file:line` format
+
+## Guidelines Source
+
+Fetch fresh guidelines before each review:
+
+```
+https://raw.githubusercontent.com/vercel-labs/writing-guidelines/main/command.md
+```
+
+Use WebFetch to retrieve the latest rules. The fetched content contains all the rules and output format instructions.
+
+## Usage
+
+When a user provides a file or pattern argument:
+1. Fetch guidelines from the source URL above
+2. Read the specified files
+3. Apply all rules from the fetched guidelines
+4. Output findings using the format specified in the guidelines
+
+If no files specified, ask the user which files to review.


### PR DESCRIPTION
## Summary

Adds a new `writing-guidelines` skill that mirrors the existing `web-design-guidelines` pattern: a thin `SKILL.md` that fetches rules from a dedicated source repo ([vercel-labs/writing-guidelines](https://github.com/vercel-labs/writing-guidelines)) on each invocation.

The skill reviews docs and prose for compliance with the Vercel writing handbook. It covers planning, voice and tone, structure, code samples, typography, and the AI workflow.

## Use when

- "Review my docs"
- "Check writing style"
- "Audit prose"
- "Review docs voice and tone"
- "Check this page against the writing handbook"

## Categories covered

- Planning (content plan, content type, user-shaped titles)
- Voice & tone (active voice, direct address, banned words: \`easy\`/\`simple\`/\`quick\`)
- Tone by content type (tutorial, how-to, reference, conceptual, troubleshooting)
- Headings & structure (sentence case, descriptive subheadings, TL;DR opens)
- Lists (when to use, bold/description format)
- Code (language tags, TypeScript first, \`<Steps/>\`, 80-col / 25-line limits)
- Placeholders, units, & numbers (\`snake_case\` text, count-up numbers, \`64 KB\` / \`200 ms\`)
- Typography (no em dashes, curly quotes, ellipsis, non-breaking spaces)
- Source formatting (no hard-wrap, no \`---\` rules, blank line discipline)
- Pricing & money pages (tables, uncompromising detail)
- AI workflow (accountability, enterprise models, plan first, disclose AI use)
- Review (PR description discipline, author accountability)

## Source repo

[vercel-labs/writing-guidelines](https://github.com/vercel-labs/writing-guidelines) hosts:

- \`README.md\`: human-readable canonical guidelines (long form)
- \`command.md\`: terse review prompt fetched by this skill
- \`AGENTS.md\`: MUST/SHOULD/NEVER reference for projects to include in their own \`AGENTS.md\`

## Test plan

- [ ] Verify \`https://raw.githubusercontent.com/vercel-labs/writing-guidelines/main/command.md\` resolves
- [ ] Run the skill against a sample MDX docs page and confirm findings emit in \`file:line\` format
- [ ] Confirm output matches the format example in \`command.md\`