### PR TITLE
Fix client-only dynamic import examples

### DIFF
--- a/packages/react-best-practices-build/test-cases.json
+++ b/packages/react-best-practices-build/test-cases.json
@@ -227,7 +227,7 @@
     "ruleId": "",
     "ruleTitle": "Defer Non-Critical Third-Party Libraries",
     "type": "good",
-    "code": "import dynamic from 'next/dynamic'\n\nconst Analytics = dynamic(\n  () => import('@vercel/analytics/react').then(m => m.Analytics),\n  { ssr: false }\n)\n\nexport default function RootLayout({ children }) {\n  return (\n    <html>\n      <body>\n        {children}\n        <Analytics />\n      </body>\n    </html>\n  )\n}",
+    "code": "// components/analytics-provider.tsx\n'use client'\n\nimport dynamic from 'next/dynamic'\n\nconst Analytics = dynamic(\n  () => import('@vercel/analytics/react').then(m => m.Analytics),\n  { ssr: false }\n)\n\nexport function AnalyticsProvider() {\n  return <Analytics />\n}\n\n// app/layout.tsx\nimport { AnalyticsProvider } from '@/components/analytics-provider'\n\nexport default function RootLayout({ children }) {\n  return (\n    <html>\n      <body>\n        {children}\n        <AnalyticsProvider />\n      </body>\n    </html>\n  )\n}",
     "language": "tsx",
     "description": "loads after hydration"
   },
@@ -243,7 +243,7 @@
     "ruleId": "",
     "ruleTitle": "Dynamic Imports for Heavy Components",
     "type": "good",
-    "code": "import dynamic from 'next/dynamic'\n\nconst MonacoEditor = dynamic(\n  () => import('./monaco-editor').then(m => m.MonacoEditor),\n  { ssr: false }\n)\n\nfunction CodePanel({ code }: { code: string }) {\n  return <MonacoEditor value={code} />\n}",
+    "code": "'use client'\n\nimport dynamic from 'next/dynamic'\n\nconst MonacoEditor = dynamic(\n  () => import('./monaco-editor').then(m => m.MonacoEditor),\n  { ssr: false }\n)\n\nfunction CodePanel({ code }: { code: string }) {\n  return <MonacoEditor value={code} />\n}",
     "language": "tsx",
     "description": "Monaco loads on demand"
   },

--- a/skills/react-best-practices/AGENTS.md
+++ b/skills/react-best-practices/AGENTS.md
@@ -529,6 +529,9 @@ export default function RootLayout({ children }) {
 **Correct: loads after hydration**
 
 ```tsx
+// components/analytics-provider.tsx
+'use client'
+
 import dynamic from 'next/dynamic'
 
 const Analytics = dynamic(
@@ -536,12 +539,19 @@ const Analytics = dynamic(
   { ssr: false }
 )
 
+export function AnalyticsProvider() {
+  return <Analytics />
+}
+
+// app/layout.tsx
+import { AnalyticsProvider } from '@/components/analytics-provider'
+
 export default function RootLayout({ children }) {
   return (
     <html>
       <body>
         {children}
-        <Analytics />
+        <AnalyticsProvider />
       </body>
     </html>
   )
@@ -567,6 +577,8 @@ function CodePanel({ code }: { code: string }) {
 **Correct: Monaco loads on demand**
 
 ```tsx
+'use client'
+
 import dynamic from 'next/dynamic'
 
 const MonacoEditor = dynamic(

--- a/skills/react-best-practices/rules/bundle-defer-third-party.md
+++ b/skills/react-best-practices/rules/bundle-defer-third-party.md
@@ -29,6 +29,9 @@ export default function RootLayout({ children }) {
 **Correct (loads after hydration):**
 
 ```tsx
+// components/analytics-provider.tsx
+'use client'
+
 import dynamic from 'next/dynamic'
 
 const Analytics = dynamic(
@@ -36,12 +39,19 @@ const Analytics = dynamic(
   { ssr: false }
 )
 
+export function AnalyticsProvider() {
+  return <Analytics />
+}
+
+// app/layout.tsx
+import { AnalyticsProvider } from '@/components/analytics-provider'
+
 export default function RootLayout({ children }) {
   return (
     <html>
       <body>
         {children}
-        <Analytics />
+        <AnalyticsProvider />
       </body>
     </html>
   )

--- a/skills/react-best-practices/rules/bundle-dynamic-imports.md
+++ b/skills/react-best-practices/rules/bundle-dynamic-imports.md
@@ -22,6 +22,8 @@ function CodePanel({ code }: { code: string }) {
 **Correct (Monaco loads on demand):**
 
 ```tsx
+'use client'
+
 import dynamic from 'next/dynamic'
 
 const MonacoEditor = dynamic(


### PR DESCRIPTION
## Summary
- Moves the Analytics `ssr: false` dynamic import example behind a Client Component boundary.
- Adds `use client` to the Monaco dynamic import example.
- Regenerates `skills/react-best-practices/AGENTS.md` and extracted test cases.

## Why
This addresses #216, where React best-practices examples used `ssr: false` dynamic imports in contexts that looked like Server Components.

## Validation
- `pnpm validate`
- `pnpm build`
- `git diff --check`