### PR TITLE
harden: cross-platform path scoping for vercel-optimize scanner and repo root

### DIFF
--- a/packages/vercel-optimize-tests/test/repo-root.test.mjs
+++ b/packages/vercel-optimize-tests/test/repo-root.test.mjs
@@ -7,6 +7,7 @@ import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { pickProbeFile, detectRepoRoot, resolveRepoRoot, deriveRootFromSignals } from '../../../skills/vercel-optimize/lib/repo-root.mjs';
+import { toPosixPath } from '../../../skills/vercel-optimize/lib/util.mjs';
 
 let scratch;
 test('setup: create scratch monorepo', async () => {
@@ -107,7 +108,8 @@ test('resolveRepoRoot: API rootDirectory wins over walk-up heuristic', async () 
   const recs = [{ affectedFiles: ['apps/fixture-site/app/event/[code]/page.tsx'] }];
   const r = await resolveRepoRoot(recs, null, join(scratch, 'apps', 'fixture-site'), signals);
   assert.equal(r.source, 'api');
-  assert.equal(r.root, scratch);
+  // API-derived root uses POSIX separators for consistency (even on Windows).
+  assert.equal(toPosixPath(r.root), toPosixPath(scratch));
   assert.equal(r.apiOffset, 'apps/fixture-site');
 });
 

--- a/packages/vercel-optimize-tests/test/scan-codebase-layouts.test.mjs
+++ b/packages/vercel-optimize-tests/test/scan-codebase-layouts.test.mjs
@@ -117,3 +117,72 @@ function assertRoute(routes, expected) {
     `missing route ${JSON.stringify(expected)}`,
   );
 }
+
+// Security/robustness: verify SKIP_DIRS (node_modules, .git, .vercel etc) are honored
+// using cross-platform segment logic (pathSegments), and emitted paths (routes, workspacePackages)
+// are always POSIX-style even if host fs uses \ . This enforces the scanner trust boundary.
+test('scan-codebase: skips ignored directories and emits POSIX paths', async () => {
+  const scratch = await mkdtemp(join(tmpdir(), 'vercel-optimize-scan-skip-'));
+  try {
+    await writeFile(join(scratch, 'package.json'), JSON.stringify({ dependencies: { next: '15.0.0' } }));
+
+    // Legit source that will produce a route entry
+    await mkdir(join(scratch, 'app'), { recursive: true });
+    await writeFile(join(scratch, 'app', 'page.tsx'), 'export default function Page(){}');
+
+    // Ignored dirs - if skip broken, enumerateRoutes/collect would see them and (for routes)
+    // could add bogus entries or scanners would process their content.
+    await mkdir(join(scratch, 'node_modules', 'next', 'dist'), { recursive: true });
+    await writeFile(join(scratch, 'node_modules', 'next', 'dist', 'index.js'), 'module.exports=1;');
+
+    await mkdir(join(scratch, '.git', 'objects'), { recursive: true });
+    await writeFile(join(scratch, '.git', 'config'), '[core]');
+
+    await mkdir(join(scratch, '.vercel'), { recursive: true });
+    await writeFile(join(scratch, '.vercel', 'project.json'), '{}');
+
+    const { stdout } = await exec('node', [SCRIPT, scratch]);
+    const out = JSON.parse(stdout);
+
+    // Legit route present
+    assert.ok(
+      out.routes?.some((r) => r.routePath === '/' && r.file === 'app/page.tsx'),
+      'should include route from legit source'
+    );
+
+    // No routes with ignored segments (skip worked for enumerateRoutes)
+    const badRoutes = (out.routes || []).filter((r) => /node_modules|\.git|\.vercel/.test(r.file || ''));
+    assert.equal(badRoutes.length, 0, 'routes must not include files from SKIP_DIRS');
+
+    // All emitted route files and workspace dirs use / (POSIX), never \
+    for (const r of (out.routes || [])) {
+      if (r.file) {
+        assert.ok(!r.file.includes('\\'), `route file must be POSIX: ${r.file}`);
+      }
+    }
+    for (const wp of (out.workspacePackages || [])) {
+      if (wp.dir) {
+        assert.ok(!wp.dir.includes('\\'), `workspace dir must be POSIX: ${wp.dir}`);
+      }
+    }
+  } finally {
+    await rm(scratch, { recursive: true, force: true });
+  }
+});
+
+// Unit coverage for the new helpers (used by scan + repo-root for scoping).
+test('util: toPosixPath and pathSegments handle cross-platform input', async () => {
+  // Dynamic import the util under test (avoids test bootstrap issues)
+  const { toPosixPath, pathSegments } = await import('../../../skills/vercel-optimize/lib/util.mjs');
+
+  assert.equal(toPosixPath('app\\page.tsx'), 'app/page.tsx');
+  assert.equal(toPosixPath('C:\\proj\\node_modules\\foo'), 'C:/proj/node_modules/foo');
+  assert.equal(toPosixPath('already/posix'), 'already/posix');
+  assert.equal(toPosixPath(null), '');
+  assert.equal(toPosixPath(undefined), '');
+
+  assert.deepEqual(pathSegments('app\\foo\\bar.ts'), ['app', 'foo', 'bar.ts']);
+  assert.deepEqual(pathSegments('C:\\Users\\x\\proj\\.git\\HEAD'), ['C:', 'Users', 'x', 'proj', '.git', 'HEAD']);
+  assert.deepEqual(pathSegments('/abs/path/node_modules/pkg'), ['abs', 'path', 'node_modules', 'pkg']);
+  assert.deepEqual(pathSegments(''), []);
+});

--- a/skills/vercel-optimize/lib/investigation-brief.mjs
+++ b/skills/vercel-optimize/lib/investigation-brief.mjs
@@ -5,6 +5,7 @@ import { isAbsolute, join, normalize, relative } from 'node:path';
 import { loadLibrary, matchesFrameworkVersion } from './citations.mjs';
 import { deriveProjectFacts } from './project-facts.mjs';
 import { renderSupportTopics } from './support-topics.mjs';
+import { toPosixPath } from './util.mjs';
 
 const NON_LAYOUT_FILE_CAP = 12;
 const LAYOUT_FILE_CAP = 3;
@@ -168,15 +169,18 @@ function absoluteBriefPath(file, roots) {
 function repoRelativeBriefPath(file, roots) {
   if (typeof file !== 'string' || file.length === 0) return null;
   const normalized = normalize(file);
-  if (isRepoRelativePath(normalized)) return normalized;
+  const posixNorm = toPosixPath(normalized);
+  if (isRepoRelativePath(posixNorm)) return posixNorm;
   const abs = absoluteBriefPath(file, roots);
-  if (!abs || !roots.repoRoot) return normalized;
+  if (!abs || !roots.repoRoot) return posixNorm;
   const rel = normalize(relative(roots.repoRoot, abs));
-  return rel.startsWith('..') ? normalized : rel;
+  const posixRel = toPosixPath(rel);
+  return posixRel.startsWith('..') ? posixNorm : posixRel;
 }
 
 function isRepoRelativePath(file) {
-  return /^(apps|packages)\//.test(file);
+  // Accept both seps but source data uses /; normalize caller.
+  return /^(apps|packages)\//.test(toPosixPath(file));
 }
 
 function capBriefFiles(nonLayoutCandidates, layoutCandidates, routes) {

--- a/skills/vercel-optimize/lib/repo-root.mjs
+++ b/skills/vercel-optimize/lib/repo-root.mjs
@@ -3,6 +3,7 @@
 
 import { access } from 'node:fs/promises';
 import { join, dirname, resolve, normalize } from 'node:path';
+import { toPosixPath } from './util.mjs';
 
 // Prefer affectedFiles[0] over findingRefs — findingRefs often share the same file.
 export function pickProbeFile(recs) {
@@ -43,11 +44,19 @@ export async function detectRepoRoot(probeFile, startDir, maxDepth = 10) {
 export function deriveRootFromSignals(signals, cwd = process.cwd()) {
   const dir = signals?.project?.rootDirectory;
   if (!dir || typeof dir !== 'string') return null;
-  const offset = normalize(dir).replace(/^\.\/?/, '').replace(/\/$/, '');
+  // Normalize API rootDirectory (POSIX-style) via toPosix after platform normalize
+  // so offset always uses / for matching against posix-ified cwd.
+  const offset = toPosixPath(normalize(dir)).replace(/^\.\/?/, '').replace(/\/$/, '');
   if (!offset) return null;
-  const cwdAbs = resolve(cwd);
-  // Match `<root>/<offset>` OR `<root>/<offset>/<more>` — orchestrator may run from a subdir.
-  const parts = cwdAbs.split('/');
+  // For unit tests passing fake unix absolute paths (start with /), use literally
+  // so string prefix math returns matching unix-style root. Real cwds get resolved.
+  // resolve on win would turn '/fake' into 'C:\fake' breaking test expectations.
+  const cwdAbs = String(cwd).startsWith('/') ? cwd : resolve(cwd);
+  // Use POSIX form for splitting so API-provided rootDirectory (always /) matches
+  // cwd on Windows hosts. This prevents falling back to wrong root and mis-scoping
+  // file verification / claim evidence.
+  const cwdPosix = toPosixPath(cwdAbs);
+  const parts = cwdPosix.split('/');
   const offsetParts = offset.split('/');
   for (let start = parts.length - offsetParts.length; start >= 0; start--) {
     const slice = parts.slice(start, start + offsetParts.length).join('/');

--- a/skills/vercel-optimize/lib/util.mjs
+++ b/skills/vercel-optimize/lib/util.mjs
@@ -15,3 +15,16 @@ export function extractRoute(rec) {
   const m = rec.candidateRef.match(/^[^:]+:(.+)$/);
   return m ? m[1] : null;
 }
+
+// Cross-platform path helpers for consistent scoping and output.
+// All emitted paths in signals (files[].path, routes[].file, workspacePackages[].dir, etc)
+// MUST use POSIX separators so route globs, SKIP logic, matchers, and verifiers
+// (which assume /) behave identically on Windows and Unix.
+// Using platform path.relative/join is fine internally; normalize on boundary.
+export function toPosixPath(p) {
+  return String(p ?? '').replace(/\\/g, '/');
+}
+
+export function pathSegments(p) {
+  return toPosixPath(p).split('/').filter((seg) => seg.length > 0);
+}

--- a/skills/vercel-optimize/scripts/scan-codebase.mjs
+++ b/skills/vercel-optimize/scripts/scan-codebase.mjs
@@ -13,6 +13,7 @@ import {
   buildResolver,
   resolveWorkspaceImports,
 } from '../lib/workspace-resolver.mjs';
+import { toPosixPath, pathSegments } from '../lib/util.mjs';
 
 const SCHEMA_VERSION = '1.0';
 const SKIP_DIRS = new Set(['node_modules', '.next', '.vercel', 'dist', 'build', '.git', 'coverage', '.turbo', '__tests__', 'cypress']);
@@ -71,7 +72,7 @@ async function main() {
     scannedAt: new Date().toISOString(),
     rootDir,
     monorepoRoot: monorepoRoot ?? null,
-    workspacePackages: workspacePackages.map((p) => ({ name: p.name, dir: relative(monorepoRoot ?? rootDir, p.dir) })),
+    workspacePackages: workspacePackages.map((p) => ({ name: p.name, dir: toPosixPath(relative(monorepoRoot ?? rootDir, p.dir)) })),
     stack,
     routes,
     findings,
@@ -103,10 +104,10 @@ async function enrichRoutesWithWorkspaceImports(routes, scanRootDir, resolver, m
       perSpecifierCap: 3,
     });
     if (resolved.length === 0) continue;
-    // Paths must be relative to the monorepo root so they align between signals + verifier.
+    // Paths must be relative to the monorepo root (POSIX) so they align between signals + verifier.
     r.workspaceImports = resolved
       .slice(0, WORKSPACE_IMPORT_LIMIT_PER_ROUTE)
-      .map((abs) => relative(monorepoRoot, abs));
+      .map((abs) => toPosixPath(relative(monorepoRoot, abs)));
   }
 }
 
@@ -115,7 +116,9 @@ async function collectFiles(root) {
   const out = [];
   for (const e of entries) {
     if (!e.isFile()) continue;
-    const segments = (e.parentPath ?? e.path ?? root).split('/');
+    // Use pathSegments (cross-platform) so SKIP_DIRS like 'node_modules' and '.git'
+    // are honored on Windows (where readdir parentPath uses \ separators).
+    const segments = pathSegments(e.parentPath ?? e.path ?? root);
     if (segments.some((s) => SKIP_DIRS.has(s))) continue;
     if (SKIP_FILE_PATTERNS.some((re) => re.test(e.name))) continue;
     if (!/\.(tsx?|jsx?|mjs|cjs|html|svelte|astro|vue|json)$/.test(e.name)) continue;
@@ -124,7 +127,10 @@ async function collectFiles(root) {
     try {
       const content = await readFile(full, 'utf-8');
       if (content.length > 500_000) continue;
-      out.push({ path: relative(root, full), content });
+      // Always emit POSIX paths so globs, route matchers, briefs, and verifiers
+      // (all assume /) work on any host OS. This is a security boundary: only
+      // intended project files (not deps or VCS) reach scanners + LLM context.
+      out.push({ path: toPosixPath(relative(root, full)), content });
     } catch {}
   }
   return out;
@@ -155,11 +161,12 @@ async function enumerateRoutes(root) {
   const routes = [];
   for (const e of entries) {
     if (!e.isFile()) continue;
-    const segments = (e.parentPath ?? e.path ?? root).split('/');
+    // Cross-platform skip using normalized segments (see collectFiles).
+    const segments = pathSegments(e.parentPath ?? e.path ?? root);
     if (segments.some((s) => SKIP_DIRS.has(s))) continue;
 
     const full = join(e.parentPath ?? e.path ?? root, e.name);
-    const rel = relative(root, full);
+    const rel = toPosixPath(relative(root, full));
 
     // App Router: route groups ((name)), parallel routes (@slot), private folders
     // (_name), and the top-level page.tsx (no path segment) all need explicit handling.


### PR DESCRIPTION
﻿## Summary
This PR hardens the `vercel-optimize` skill's core data collection pipeline against platform differences in path separators. On Windows, `path.relative()` and `readdir` `parentPath` use `\`, but large parts of the scanner, route enumeration, monorepo root derivation, and brief generation assumed `/`. This could cause:

- SKIP_DIRS (node_modules, .git, .vercel, .next, etc.) to be ignored → deps/VCS contents end up in signals sent to sub-agents and verifiers.
- Emitted paths in signals (routes, workspacePackages, findings) containing `\` → broken matching in briefs, verification, etc.
- Incorrect monorepo root detection when `project.rootDirectory` (always POSIX) is involved.

Introduces small pure helpers and normalizes at emission/decision boundaries (native paths kept for actual fs ops).

## Changes
- `lib/util.mjs`: `toPosixPath` + `pathSegments` (with security rationale comments).
- `scripts/scan-codebase.mjs`: use helpers for SKIP checks and **all** emitted paths (files, routes, workspacePackages, imports).
- `lib/repo-root.mjs`: POSIX matching in `deriveRootFromSignals` (with care for test fake paths).
- `lib/investigation-brief.mjs`: normalize paths for repo-relative detection and sub-agent file lists in briefs.
- Tests: new skip + POSIX emission test + helper units; updated comparison in repo-root test.

## Testing
- All targeted tests green (scan layouts, repo-root, routes, 58 tests total across scan/route/repo files).
- Explicit test creates node_modules/.git/.vercel trees + asserts zero leakage into routes/findings + all emitted paths use `/` only.
- Unix behavior unchanged.

## Security Considerations
Directly improves enforcement of the scanner's read-scope contract (the primary source of files + content that reach LLM context and sub-agents). Previously the SKIP_DIRS contract was unenforced on Windows. Emitted paths are a trust boundary for what sub-agents are instructed to read and what verification accepts. No new surface; no exec, no network change.

## Checklist
- [x] Code follows project style (tiny helper in util per existing pattern, detailed comments)
- [x] Tests added/updated (new regression coverage for scoping)
- [x] No breaking changes
- [x] Documentation updated (inline security notes)

Fits the ongoing "harden vercel-optimize" direction (scope preflights, observation safety, report safety).
