### PR TITLE
Add web-qa-testing skill

### DIFF
--- a/skills.sh.json
+++ b/skills.sh.json
@@ -27,6 +27,13 @@
       "skills": [
         "web-design-guidelines"
       ]
+    },
+    {
+      "title": "Testing",
+      "description": "Skills for testing and QA of web applications.",
+      "skills": [
+        "web-qa-testing"
+      ]
     }
   ]
 }

--- a/skills/web-qa-testing/SKILL.md
+++ b/skills/web-qa-testing/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: web-qa-testing
+description: QA a running web app by driving it in a real browser with agent-browser — exercise real flows and verify real behavior, not source code. Use when the user wants to test a feature, reproduce or verify a bug, walk a user flow end to end, check the states that are easy to forget (empty, loading, error, unauthorized, offline), do a regression pass, or produce a QA test plan and execution report. Triggers: "test this feature", "QA this", "reproduce this bug", "verify the fix", "does this flow work", "write a test plan", "check the error state".
+license: MIT
+metadata:
+  author: vercel
+  version: "1.0.0"
+---
+
+# Web QA Testing
+
+Test a web application the way a QA engineer does: by **using the product** in a
+real browser and verifying what it actually does. This skill drives
+[`agent-browser`](https://github.com/vercel-labs/agent-browser) to exercise real
+flows, observe real output, and produce a structured report.
+
+This is **black-box behavioral testing**. It does not read or judge the app's
+source code — it has no knowledge of the codebase's conventions, framework, or
+file layout, and it does not need any. It tests behavior through the browser, so
+it works on any web app regardless of stack.
+
+## Core Principle: Observe, Don't Assume
+
+A test result must come from something the browser actually showed.
+
+- **A PASS requires browser-verified evidence.** Reading code, or reasoning that
+  something "should" work, never justifies a PASS. Navigate to it, do it, read
+  the result.
+- **Assert exact values**, not vibes. Use `get text` / `eval` to read the real
+  string, status, or count and compare it to what was expected.
+- **After a mutation, reload and re-check.** A success message is not proof the
+  change persisted. Reload the page and confirm the new state survives.
+
+## When to Use This Skill
+
+- **Feature / use-case testing** — does this flow work end to end?
+- **Bug reproduction** — turn a vague report into deterministic repro steps.
+- **Fix verification** — confirm a fixed bug no longer reproduces.
+- **Regression** — re-walk a known-good flow after a change.
+- **State coverage** — the states that ship broken: empty, loading, error,
+  unauthorized, offline.
+
+## Workflow
+
+Follow these steps in order. Do not start clicking before you have mapped the
+journey.
+
+### 1. Map the user journey
+
+Before touching the browser, write down the flow: where the user starts, what
+they do, what the system should do at each step, where they end up, and **what
+should happen when any step fails**. The failure branches are the test cases
+most people skip.
+
+### 2. Pre-flight
+
+Confirm the app is reachable and set up auth/data through a stable path (an API,
+a seed command, or stored credentials) rather than clicking through the UI to
+get there — UI setup is slow and couples every test to the login screen.
+
+```bash
+agent-browser close --all                 # start from a clean session
+agent-browser open https://localhost:3000 # or the app's URL
+agent-browser get title                    # confirm the app loaded, not an error page
+```
+
+### 3. Walk the flow
+
+The core loop for every step: act, wait for the result, read what happened,
+capture it.
+
+```bash
+agent-browser snapshot                       # accessibility tree with @refs — read before acting
+agent-browser find label "Email" fill "test@app.test"
+agent-browser find label "Password" fill "Pass123!"
+agent-browser find role button click --name "Sign in"
+agent-browser wait --url "**/dashboard"      # wait for the expected result, not a fixed delay
+agent-browser get text "h1"                  # assert the exact landing state
+agent-browser screenshot                     # capture significant states
+```
+
+Prefer **semantic locators** (`find role`, `find text`, `find label`,
+`find testid`) over CSS/ID selectors. Semantic locators survive refactors and
+match how a user perceives the page; brittle selectors turn a passing test into
+a false failure on the next styling change.
+
+### 4. Test the states everyone forgets
+
+On every feature, cover these — not just the happy path. Each has an
+`agent-browser` recipe in [references/state-recipes.md](references/state-recipes.md).
+
+| State | What to verify | How |
+|-------|----------------|-----|
+| **Happy path** | Flow completes, correct end state | Walk it, assert final text/URL |
+| **Empty** | No-data view is intentional, not a crash | Use an empty account/filter; read body text |
+| **Loading** | A spinner appears and then *resolves* | Screenshot immediately after navigate |
+| **Error** | A failed request shows a real message | `network route ... --body` an error, reload |
+| **Unauthorized** | Protected view blocks/ redirects | Hit it with no/expired auth |
+| **Offline / network failure** | App degrades, doesn't hang | `set offline on`, retry the action |
+
+A spinner that never disappears, an empty list that renders blank, or a failed
+request that shows nothing are all user-facing bugs — and all invisible if you
+only test the happy path.
+
+### 5. Verify persistence
+
+After any create/update/delete, reload and confirm the change is still there.
+
+```bash
+agent-browser find role button click --name "Save"
+agent-browser wait --text "Saved"
+agent-browser reload
+agent-browser wait --load networkidle
+agent-browser get text "..."                 # the change must still be present
+```
+
+### 6. Report
+
+Produce a test plan (before) and an execution report (after) using the
+templates and result framework in
+[references/report-format.md](references/report-format.md).
+
+## Result Framework
+
+Every test case resolves to exactly one:
+
+- **PASS** — verified working in the browser.
+- **FAIL** — verified broken; file a bug with repro steps and severity.
+- **SKIP** — not run, with a stated reason (e.g. loading state too fast to capture).
+- **BLOCKED** — couldn't run because an earlier bug prevents reaching it.
+
+Bug severity: **P1** silent failure / data loss / crash · **P2** degraded UX /
+broken-but-recoverable · **P3** cosmetic / minor.
+
+## Bug Reproduction & Verification
+
+To reproduce a reported bug, reduce it to the **shortest deterministic sequence**
+of `agent-browser` commands that shows the wrong behavior, with the exact
+observed-vs-expected difference. To verify a fix, run that same sequence and
+confirm the expected behavior now appears — and add the case to the regression
+set so it can't silently come back.
+
+## Decision Heuristics
+
+- **Unsure what to test?** What does the user see in each state — empty, loading,
+  error, success? That is the minimum surface.
+- **A selector keeps breaking on refactors?** Switch to a semantic locator.
+- **A loading state is too fast to capture?** It is not isolated — flag the
+  component, don't silently PASS.
+- **Something looks right but you're not certain?** `get text` the exact value
+  and assert it.
+- **A mutation seems to work?** Reload and check again before calling it PASS.
+- **Tempted to PASS from reading behavior, not seeing it?** Don't. Go observe it.
+
+## Reference Files
+
+- [references/state-recipes.md](references/state-recipes.md) — copy-paste
+  `agent-browser` recipes for each state (empty, loading, error, unauthorized,
+  offline, modals, responsive).
+- [references/report-format.md](references/report-format.md) — test plan and
+  execution report templates, result framework, bug format.
+
+## Installation
+
+```bash
+npx skills add vercel-labs/agent-skills --skill web-qa-testing
+```
+
+This skill requires [`agent-browser`](https://github.com/vercel-labs/agent-browser):
+
+```bash
+npm install -g agent-browser
+agent-browser install
+```

--- a/skills/web-qa-testing/references/report-format.md
+++ b/skills/web-qa-testing/references/report-format.md
@@ -1,0 +1,106 @@
+# Report Format
+
+A QA engagement produces two artifacts: a **test plan** written before testing,
+and an **execution report** written after. Both are designed so a reader who
+sees only the document knows exactly what was and was not covered.
+
+## Result framework
+
+Every test case resolves to exactly one result:
+
+| Result | Meaning |
+|--------|---------|
+| **PASS** | Verified working in the browser, with evidence. |
+| **FAIL** | Verified broken. File a bug with repro + severity. |
+| **SKIP** | Not run. State the reason. |
+| **BLOCKED** | Could not run; an earlier bug blocks reaching it. Name the blocker. |
+
+A PASS is never awarded from reading code or reasoning about intent — only from
+observed browser behavior.
+
+## Bug severity
+
+| Severity | Use for |
+|----------|---------|
+| **P1** | Silent failure, data loss, crash, security/auth hole. Blocks sign-off. |
+| **P2** | Degraded UX, broken-but-recoverable, missing error handling. |
+| **P3** | Cosmetic or minor. Does not block sign-off. |
+
+## Test plan template
+
+Written *before* execution. Maps the journey and enumerates cases — including
+the negative ones.
+
+```markdown
+# Test Plan — <Feature>
+
+**Prepared:** YYYY-MM-DD
+**App URL:** <url>
+**Auth:** <how to authenticate / seed user>
+**Out of scope:** <what this plan deliberately does not cover, and why>
+
+## Journey
+<entry → actions → expected system response → exit, and the failure branches>
+
+## Cases
+
+| ID | Test | Expected | How to verify |
+|----|------|----------|---------------|
+| F-01 | Feature renders | "<heading>" visible | `get text "h1"` |
+| F-02 | Happy path completes | Lands on <state> | walk flow, assert URL/text |
+| F-03 | Empty state | Intentional empty view | empty account; read body |
+| F-04 | Loading state | Spinner appears then resolves | screenshot on navigate |
+| F-05 | Error state | Visible error message | `network route --body`, reload |
+| F-06 | Unauthorized | Blocked / redirected | clear cookies, open route |
+| F-07 | Offline | Degrades, stays usable | `set offline on`, retry |
+| F-08 | Persistence | Change survives reload | mutate, reload, re-read |
+```
+
+## Execution report template
+
+Written *after* execution. Records results and every bug found.
+
+```markdown
+# QA Execution Report — <Feature>
+
+**Date:** YYYY-MM-DD
+**App URL:** <url>
+**Screenshots:** <path or attachment note>
+
+## Summary
+
+| Passed | Failed | Blocked | Skipped |
+|--------|--------|---------|---------|
+| 0 | 0 | 0 | 0 |
+
+## Results
+
+| ID | Result | Notes |
+|----|--------|-------|
+| F-01 | PASS | Heading "<...>" visible |
+| F-03 | FAIL | BUG-01 — empty list renders blank, no message |
+| F-04 | SKIP | Loading state resolved too fast to capture |
+| F-06 | BLOCKED | Blocked by BUG-01 |
+
+## Bugs
+
+### BUG-01 — <title> (P1)
+
+**Repro:**
+1. `agent-browser open <url>`
+2. <exact commands>
+
+**Observed:** <what the browser showed>
+**Expected:** <what should have happened>
+
+## Out of scope / risks
+
+<What was not tested and why; what could still break.>
+```
+
+## Why "out of scope" is mandatory
+
+An explicit out-of-scope section is what separates "I tested the feature" from
+"I tested these eight cases and deliberately left these two." Without it, a
+reader assumes full coverage and is surprised by the gap. State exclusions and
+the reason for each.

--- a/skills/web-qa-testing/references/state-recipes.md
+++ b/skills/web-qa-testing/references/state-recipes.md
@@ -1,0 +1,127 @@
+# State Recipes
+
+Copy-paste `agent-browser` recipes for the states a feature must handle. Replace
+URLs, selectors, and expected text with the app's real values. Every recipe ends
+by reading or screenshotting the result — the result is the test, not the action.
+
+## Happy path
+
+```bash
+agent-browser open https://localhost:3000/feature
+agent-browser wait --load networkidle
+agent-browser snapshot                         # read the page before acting
+agent-browser find role button click --name "Create"
+agent-browser wait --text "Created"
+agent-browser get text "[role=status]"         # assert the exact confirmation
+agent-browser screenshot                        # success-state.png
+```
+
+## Empty state
+
+Reach a genuinely empty view — a fresh account, or a filter that matches
+nothing. Verify it is an intentional empty state, not a blank page or a crash.
+
+```bash
+agent-browser open https://localhost:3000/items?filter=none-match
+agent-browser wait --load networkidle
+agent-browser get text "body"                  # expect an empty-state message, not ""
+agent-browser is visible "text=No items yet"   # or the app's real empty copy
+agent-browser screenshot
+```
+
+## Loading state
+
+Capture the page in the instant before data arrives. If the loading UI is too
+fast to catch, that is worth noting — but a spinner that *never* resolves is a
+bug.
+
+```bash
+agent-browser open https://localhost:3000/slow-feature
+agent-browser screenshot                        # immediately: should show skeleton/spinner
+agent-browser wait --text "Expected content"    # then it must resolve
+agent-browser screenshot                        # resolved state
+# Confirm the spinner is gone, not stuck:
+agent-browser wait "[aria-busy=true]" --state hidden
+```
+
+## Error state
+
+Mock a failed response with `network route`, then trigger the request. Confirm
+the app shows a real error message rather than a blank screen, a stuck spinner,
+or a thrown exception.
+
+```bash
+agent-browser network route "**/api/**" --body '{"error":"Service unavailable"}'
+# (use --abort instead to simulate a hard request failure)
+agent-browser reload
+agent-browser wait --load networkidle
+agent-browser get text "body"                  # expect a visible error message
+agent-browser screenshot                        # error-state.png
+agent-browser network unroute                   # always clean up the route
+```
+
+## Unauthorized
+
+Hit a protected view without valid auth and confirm it blocks or redirects —
+it must not render protected content or crash.
+
+```bash
+agent-browser cookies clear                     # drop the session
+agent-browser open https://localhost:3000/account/settings
+agent-browser wait --load networkidle
+agent-browser get url                           # expect redirect to /login (or a 403 view)
+agent-browser screenshot
+```
+
+## Offline / network failure
+
+Toggle offline and retry an action. The app should surface a failure and stay
+usable — not hang forever.
+
+```bash
+agent-browser set offline on
+agent-browser find role button click --name "Refresh"
+agent-browser wait --text "offline"            # or the app's real failure copy
+agent-browser screenshot
+agent-browser set offline off                   # restore connectivity
+```
+
+## Modal / dialog interaction
+
+Open a dialog, confirm it appears, act inside it, confirm it closes and the
+underlying action took effect.
+
+```bash
+agent-browser find role button click --name "Delete"
+agent-browser wait --text "Are you sure"
+agent-browser is visible "[role=dialog]"        # dialog is open
+agent-browser find role button click --name "Confirm"
+agent-browser wait "[role=dialog]" --state hidden  # dialog closed
+agent-browser get text "[role=status]"          # the action's result is visible
+```
+
+## Responsive / device
+
+Re-run a flow at a mobile viewport (or an emulated device) to catch layout and
+touch-target breakage that only appears on small screens.
+
+```bash
+agent-browser set device "iPhone 14"
+# or: agent-browser set viewport 375 812
+agent-browser open https://localhost:3000/feature
+agent-browser wait --load networkidle
+agent-browser screenshot --full                 # full-page mobile capture
+agent-browser is visible "text=Expected element"
+```
+
+## Form validation
+
+Submit invalid input and confirm the field-level error is shown — empty,
+wrong-type, and boundary values, not just a valid submission.
+
+```bash
+agent-browser find label "Email" fill "not-an-email"
+agent-browser find role button click --name "Submit"
+agent-browser get text "[aria-invalid=true] ~ *, [role=alert]"  # expect a validation message
+agent-browser screenshot
+```


### PR DESCRIPTION
## Summary

Adds `web-qa-testing` — a skill for QA-testing a running web app by driving it
in a real browser with [`agent-browser`](https://github.com/vercel-labs/agent-browser).

It's black-box behavioral testing: the agent exercises real user flows and
verifies what the app actually does, rather than reading or judging source code.
Because it tests through the browser, it works on any web app regardless of
stack.

This appears to be the first skill in the repo to use `agent-browser`, so it
also serves as a worked example of pairing the two tools.

## What it covers

- Mapping a user journey before testing, then walking it with `agent-browser`
- The states that ship broken when only the happy path is tested: **empty,
  loading, error, unauthorized, offline**
- Bug reproduction (→ deterministic repro steps) and fix verification
- A PASS/FAIL/SKIP/BLOCKED result framework with bug severity
- Test plan + execution report templates

## Structure
- skills/web-qa-testing/
- SKILL.md                      # entry point (174 lines)
- references/state-recipes.md   # agent-browser recipe per state
- references/report-format.md   # test plan + report templates

`SKILL.md` stays small; detailed recipes and templates live in `references/`
(progressive disclosure). Registered under a new "Testing" group in
`skills.sh.json`.

## Verification
- `skills.sh.json` is valid JSON; SKILL.md frontmatter has `name`,
  `description`, `license`, `metadata`
- SKILL.md is 174 lines (< 500); reference links resolve one level deep
- All documented `agent-browser` commands were dry-run against a live page on
  agent-browser 0.27.1 (`open`, `snapshot`, `find text/role/label`, `get`,
  `set offline`, `wait --state hidden`)