### PR TITLE
Add feishu-document-api and hermes-memory-maintenance skills (Productivity & Automation)

### DIFF
--- a/skills.sh.json
+++ b/skills.sh.json
@@ -27,6 +27,14 @@
       "skills": [
         "web-design-guidelines"
       ]
+    },
+    {
+      "title": "Productivity & Automation",
+      "description": "Skills for document automation and agent memory maintenance — Feishu/Lark document API workflows and AI agent memory optimization.",
+      "skills": [
+        "feishu-document-api",
+        "hermes-memory-maintenance"
+      ]
     }
   ]
 }

--- a/skills/feishu-document-api/SKILL.md
+++ b/skills/feishu-document-api/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: feishu-document-api
+description: Create, write, and manage Feishu (Lark) documents programmatically via the Open API. Automates document creation, block-level content writing, ownership transfer, and in-place content sync for Feishu/Lark enterprise workspaces.
+license: MIT
+metadata:
+  author: hermes-agent
+  version: "2.5.0"
+---
+
+# Feishu Document API
+
+Use when the user asks to create, write to, or manipulate Feishu (Lark) documents via the Open API. Best for automating document creation, syncing content to Feishu, and building document-based workflows.
+
+## How It Works
+
+Feishu documents are block-based — every element (text, heading, bullet, table, code block) is a typed block. The API reads and writes at the block level.
+
+### 1. Get Tenant Access Token
+
+```
+POST /open-apis/auth/v3/tenant_access_token/internal
+Body: {"app_id": "${FEISHU_APP_ID}", "app_secret": "${FEISHU_APP_SECRET}"}
+```
+Response → `tenant_access_token` (expires in 2h, always fetch fresh)
+
+### 2. Create Document
+
+```
+POST /open-apis/docx/v1/documents
+Body: {"title": "Document Title"}
+```
+Returns `document_id` — used as both doc identifier and root block ID.
+
+### 3. Add Content Blocks
+
+```
+POST /open-apis/docx/v1/documents/{doc_id}/blocks/{doc_id}/children
+Body: {"children": [block_objects], "index": N}
+```
+
+**Block type reference:**
+
+| Type | Key | Purpose |
+|------|-----|---------|
+| 1 | `page` | Root block (the document itself) |
+| 2 | `text` | Normal paragraph |
+| 3-7 | `heading1-5` | Section headings |
+| 12 | `bullet` | Unordered list item |
+| 13 | `ordered` | Numbered list |
+| 14 | `code` | Code/monospace block |
+| 15 | `quote` | Block quote |
+| 31 | `table` | Native table (skeleton only) |
+| 32 | `table_cell` | Auto-created cell within a table |
+
+**Critical constraints:**
+- **50 blocks max per POST** — chunk larger batches
+- **No mixed block types in one batch** — all blocks in a POST must share the same `block_type`
+- **No heading blocks (3-7) at the document root** via API — use bold text (type 2) as workaround
+- **Empty text blocks rejected** — use `" "` (single space) as content
+
+### 4. Transfer Document Ownership
+
+When sharing fails, transfer ownership instead:
+```
+POST /open-apis/drive/v1/permissions/{doc_id}/members/transfer_owner?type=docx
+Body: {"member_type": "openid", "member_id": "<user_open_id>"}
+```
+⚠️ Transfer BEFORE revealing the URL to avoid permission leaks.
+
+## Prerequisites
+
+- Feishu app with `docx:document` scope enabled
+- `FEISHU_APP_ID` and `FEISHU_APP_SECRET` credentials
+- The app must be published after adding scopes
+- For sharing: `docs:permission.member:create` scope needed
+
+## Usage
+
+When a user asks to create a Feishu document:
+
+1. Authenticate with tenant credentials
+2. Create the document with the requested title
+3. Write content blocks (chunked by type, max 50 per POST)
+4. Transfer ownership to the intended user
+5. Verify success before sharing the URL
+
+For existing documents, read raw content via:
+```
+GET /open-apis/docx/v1/documents/{doc_id}/raw_content
+```
+
+For in-place updates: batch-delete old blocks, then POST new content.
+
+## Full Documentation
+
+For complete details including table creation (block_type 31), async content syncing workflows, and all verified pitfalls, see the [source repository](https://github.com/duruonanni/hermes-skill-kit/blob/main/feishu-document-api/SKILL.md).

--- a/skills/hermes-memory-maintenance/SKILL.md
+++ b/skills/hermes-memory-maintenance/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: hermes-memory-maintenance
+description: Maintain and optimize AI agent memory files. Audits for redundancy, consolidation, capacity limits, contradiction detection, and hallucination prevention through structured memory design — for agents with persistent file-based memory systems.
+license: MIT
+metadata:
+  author: hermes-agent
+  version: "1.4.0"
+---
+
+# Hermes Memory Maintenance
+
+Maintains agent memory files by auditing content quality, consolidating entries, managing capacity, and preventing hallucination through structured memory design.
+
+## When to Use
+
+- Memory utilization exceeds 80% and needs consolidation
+- User reports the agent "forgot" previously saved information — memory may be silently truncating at capacity limits
+- Rapid accumulation of fine-grained entries where many could be merged
+- Stable procedural knowledge currently in memory that should be archived to skills
+- After heavy configuration or setup activity (3+ tool installations, 5+ preference settings)
+
+## Architecture
+
+Agent memory systems often use flat file storage with delimiter-separated entries (e.g., `§`-separated markdown files). Two files are common:
+
+1. **Memory file** — Environment facts, installed tools, configs, procedures
+2. **User file** — User identity, preferences, communication style, workflow expectations
+
+Both are typically injected into every session's system prompt with configurable character limits.
+
+### Three-Layer Defense Against Injection
+
+| Layer | Role |
+|-------|------|
+| **Write Filter** | Scans every write for threat patterns (injection, exfiltration, promptware) |
+| **Load Filter** | Secondary scan at snapshot build time |
+| **Snapshot Isolation** | Frozen snapshot prevents mid-session injection |
+
+## Maintenance Workflow
+
+### Step 1: Audit Current State
+
+Check file sizes and configured limits:
+```bash
+wc -c memory_file.md user_file.md
+```
+
+Score each entry for quality (0-4 scale):
+| Score | Criteria |
+|-------|----------|
+| +1 | Length > 80 chars (sufficient detail) |
+| +1 | Structured/labelled format |
+| +1 | Contains actionable directive |
+| +1 | Contains verifiable facts |
+
+- **3-4** 🟢 High quality
+- **2** 🟡 Adequate
+- **0-1** 🔴 Consolidate or remove
+
+### Step 2: Identify Problems
+
+| Signal | Action |
+|--------|--------|
+| Cross-file redundancy (same fact in both files) | Merge into one file only |
+| Intra-file redundancy (same topic repeated) | Merge into one comprehensive entry |
+| Overly fine-grained rules (9 rules that could be 5) | Consolidate related entries |
+| Stable procedural knowledge | Archive to a skill (loaded on-demand) |
+| Outdated ephemera (temporary configs, old pricing) | Delete entirely |
+| Content drift (facts in wrong file) | Move to correct file |
+
+### Step 3: Consolidate
+
+Use the memory tool for entry-level edits (add/replace/remove) to avoid file desync issues. For major restructures:
+
+1. Backup the files
+2. Delete the drift file
+3. Re-add entries one at a time
+4. Verify roundtrip integrity
+
+### Step 4: Archive Stable Knowledge to Skills
+
+Move stable procedural knowledge out of memory into a skill:
+
+| Memory entry type | To skill? | Keep in memory? |
+|-------------------|-----------|-----------------|
+| Numbered procedure steps | ✅ Yes | ❌ No |
+| Multi-pitfall workflow | ✅ Yes | ❌ No |
+| Quick fact (< 100 chars) | ❌ No | ✅ Yes |
+| User identity/preferences | ❌ No | ✅ Yes |
+| Session progress or state | ❌ No | ❌ Use session search |
+
+## Stale Entry Detection
+
+| Content type | TTL |
+|-------------|-----|
+| Behavioral rules | 90 days |
+| Environment config | 30 days |
+| User identity | 180 days |
+| Error archive | 365 days |
+
+## Contradiction Detection
+
+Scan for:
+- Duplicate user/platform IDs
+- Duplicate topic headers
+- Conflicting behavioral directives
+
+## Full Documentation
+
+For complete details including multi-user section-based structure, external evaluation pattern, concurrent write safety, and all verified pitfalls, see the [source repository](https://github.com/duruonanni/hermes-skill-kit/blob/main/hermes-memory-maintenance/SKILL.md).


### PR DESCRIPTION
## Summary

Add two community-contributed skills to extend the collection beyond web development into **document automation** and **agent memory management**.

### feishu-document-api
Create, write, and manage Feishu (Lark) documents programmatically via the Open API. Covers auth, block-type reference, content creation, ownership transfer, and in-place content sync.

### hermes-memory-maintenance
Maintain and optimize AI agent memory files — audits for redundancy, consolidation, capacity limits, contradiction detection, and hallucination prevention through structured memory design.

## Changes

- `skills.sh.json`: Added "Productivity & Automation" group with both skills
- `skills/feishu-document-api/SKILL.md`: New skill (2.5.0)
- `skills/hermes-memory-maintenance/SKILL.md`: New skill (1.4.0)

Both skills follow the agentskills.io format and are already published and verified in the [duruonanni/hermes-skill-kit](https://github.com/duruonanni/hermes-skill-kit) repository.