### PR TITLE
Sync writing-guidelines from wd2

### DIFF
--- a/skills/writing-guidelines/SKILL.md
+++ b/skills/writing-guidelines/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: writing-guidelines
-description: Review docs/prose for Writing Guidelines compliance. Use when asked to "review my docs", "check writing style", "audit prose", "review docs voice and tone", or "check this page against the writing handbook".
+description: Review docs/prose for Writing Guidelines compliance. Use when asked
+  to "review my docs", "check writing style", "audit prose", "review docs voice
+  and tone", or "check this page against the writing handbook".
 metadata:
   author: vercel
-  version: "1.0.0"
+  version: 1.0.1
   argument-hint: <file-or-pattern>
 ---
 
@@ -37,3 +39,4 @@ When a user provides a file or pattern argument:
 4. Output findings using the format specified in the guidelines
 
 If no files specified, ask the user which files to review.
+DRIFT EDIT


### PR DESCRIPTION
This pull request was created by Forward Nexus from the wd2 project.

Items synchronized from the consumer project:
- writing-guidelines (skill, version 1.0.0 -> 1.0.1)

Forward Nexus preserved hidden link metadata in frontmatter and added or bumped a top-level version field when needed.