### PR TITLE
docs(vercel-optimize): add quick-try link

### DIFF
--- a/skills/vercel-optimize/README.md
+++ b/skills/vercel-optimize/README.md
@@ -16,6 +16,12 @@ npx skills add vercel-labs/agent-skills --skill vercel-optimize
 
 Manual install: copy `skills/vercel-optimize` into `.agents/skills/vercel-optimize` and reference `SKILL.md` from your project `AGENTS.md`.
 
+## Quick Try
+
+Want to evaluate the workflow before installing locally? Try the skill in an OpenClaw/Hermes-style agent:
+
+[Try Vercel Optimize in Telegram or WhatsApp](https://app.clawmama.run/skills/ehd4qx/hermes?utm_source=github&utm_medium=readme&utm_campaign=skill_outreach_vercel_labs_agent_skills)
+
 ## Requirements
 
 - Node.js 20+
@@ -39,31 +45,31 @@ The agent should collect metrics first. If it starts by reading source files or 
 
 ## Roadmap
 
-| Attribute | Status |
-|---|---|
-| Route-level Vercel Function invocations, duration, TTFB, and cold starts | Supported |
-| Vercel Function CPU, memory, and GB-hours | Supported |
-| Request volume, cache hit rate, HTTP status, and method distribution | Supported |
-| Fast Data Transfer and bot traffic patterns | Supported |
-| ISR reads, writes, and over-revalidation | Supported |
-| Routing Middleware volume and duration | Supported |
-| External API latency, volume, and transfer bytes | Supported |
-| Core Web Vitals from Speed Insights | Supported |
-| Image Optimization usage, source hosts, and source bytes | Supported |
-| Build Minutes fan-out | Supported |
-| Usage spikes by billing service | Supported |
-| Bot Protection and BotID configuration | Supported |
-| Fluid Compute configuration and compute signals | Supported |
-| Region pinning and project configuration mismatches | Supported |
-| Observability Events cost attribution | Supported |
-| Route-to-file recommendations for Next.js and SvelteKit | Supported |
-| Nuxt route mapping with generic/platform checks | Supported |
-| Generic route mapping and platform checks for Astro | Supported |
-| Hono route-to-file mapping | Planned |
-| Remix route-to-file mapping | Planned |
-| AI Gateway usage and cost optimization | Planned |
-| Sandbox usage and cost optimization | Planned |
-| Blob, Edge Config, Runtime Cache, Workflows, Queues, Flags, and Microfrontends billing dimensions | Planned |
+| Attribute                                                                                         | Status    |
+| ------------------------------------------------------------------------------------------------- | --------- |
+| Route-level Vercel Function invocations, duration, TTFB, and cold starts                          | Supported |
+| Vercel Function CPU, memory, and GB-hours                                                         | Supported |
+| Request volume, cache hit rate, HTTP status, and method distribution                              | Supported |
+| Fast Data Transfer and bot traffic patterns                                                       | Supported |
+| ISR reads, writes, and over-revalidation                                                          | Supported |
+| Routing Middleware volume and duration                                                            | Supported |
+| External API latency, volume, and transfer bytes                                                  | Supported |
+| Core Web Vitals from Speed Insights                                                               | Supported |
+| Image Optimization usage, source hosts, and source bytes                                          | Supported |
+| Build Minutes fan-out                                                                             | Supported |
+| Usage spikes by billing service                                                                   | Supported |
+| Bot Protection and BotID configuration                                                            | Supported |
+| Fluid Compute configuration and compute signals                                                   | Supported |
+| Region pinning and project configuration mismatches                                               | Supported |
+| Observability Events cost attribution                                                             | Supported |
+| Route-to-file recommendations for Next.js and SvelteKit                                           | Supported |
+| Nuxt route mapping with generic/platform checks                                                   | Supported |
+| Generic route mapping and platform checks for Astro                                               | Supported |
+| Hono route-to-file mapping                                                                        | Planned   |
+| Remix route-to-file mapping                                                                       | Planned   |
+| AI Gateway usage and cost optimization                                                            | Planned   |
+| Sandbox usage and cost optimization                                                               | Planned   |
+| Blob, Edge Config, Runtime Cache, Workflows, Queues, Flags, and Microfrontends billing dimensions | Planned   |
 
 ## What You Get
 


### PR DESCRIPTION
Add a Quick Try section to the vercel-optimize README with a link to try the skill via OpenClaw/Hermes-style agent in Telegram or WhatsApp. Closes #301.