### PR TITLE
fix(composition-patterns): ComposerContext example + impact alignment

### DIFF
--- a/skills/composition-patterns/AGENTS.md
+++ b/skills/composition-patterns/AGENTS.md
@@ -678,7 +678,7 @@ function ForwardMessageDialog() {
 }
 
 function ForwardButton() {
-  const { actions } = use(Composer.Context)
+  const { actions } = use(ComposerContext)
   return <Button onPress={actions.submit}>Forward</Button>
 }
 ```

--- a/skills/composition-patterns/AGENTS.md
+++ b/skills/composition-patterns/AGENTS.md
@@ -44,7 +44,7 @@ proliferation and enable flexible composition.
 
 ### 1.1 Avoid Boolean Prop Proliferation
 
-**Impact: CRITICAL (prevents unmaintainable component variants)**
+**Impact: HIGH (prevents unmaintainable component variants)**
 
 Don't add boolean props like `isThread`, `isEditing`, `isDMThread` to customize
 

--- a/skills/composition-patterns/rules/architecture-avoid-boolean-props.md
+++ b/skills/composition-patterns/rules/architecture-avoid-boolean-props.md
@@ -1,6 +1,6 @@
 ---
 title: Avoid Boolean Prop Proliferation
-impact: CRITICAL
+impact: HIGH
 impactDescription: prevents unmaintainable component variants
 tags: composition, props, architecture
 ---

--- a/skills/composition-patterns/rules/state-lift-state.md
+++ b/skills/composition-patterns/rules/state-lift-state.md
@@ -111,7 +111,7 @@ function ForwardMessageDialog() {
 }
 
 function ForwardButton() {
-  const { actions } = use(Composer.Context)
+  const { actions } = use(ComposerContext)
   return <Button onPress={actions.submit}>Forward</Button>
 }
 ```


### PR DESCRIPTION
## Summary
- Fixes incorrect `use(Composer.Context)` to `use(ComposerContext)` in `state-lift-state.md` and mirrored `AGENTS.md` (issue #286 item 1)
- Aligns `architecture-avoid-boolean-props.md` impact CRITICAL to HIGH to match `SKILL.md` / `_sections.md` (issue #286 item 2)

Does not touch the react-best-practices items in #286 (items 3-5); those overlap with open PR #295.

Closes #286

## Test plan
- [x] Confirmed no remaining Composer.Context under skills/composition-patterns/
- [x] Spot-checked other composition-patterns examples already use ComposerContext
- [ ] Reviewer: confirm HIGH is the intended architecture-section impact
