### PR TITLE
fix: publish skills.sh JSON schema and point $schema at it

### DIFF
--- a/schemas/skills.sh.schema.json
+++ b/schemas/skills.sh.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/vercel-labs/agent-skills/main/schemas/skills.sh.schema.json",
+  "title": "skills.sh catalog",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["groupings"],
+  "properties": {
+    "notGrouped": {
+      "type": "string",
+      "enum": ["top", "bottom"],
+      "description": "Where ungrouped skills appear relative to groupings."
+    },
+    "groupings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["title", "skills"],
+        "properties": {
+          "title": { "type": "string", "minLength": 1 },
+          "description": { "type": "string" },
+          "skills": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "minItems": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://skills.sh/schemas/skills.sh.schema.json",
+  "$schema": "https://raw.githubusercontent.com/vercel-labs/agent-skills/main/schemas/skills.sh.schema.json",
   "notGrouped": "bottom",
   "groupings": [
     {


### PR DESCRIPTION
## Summary
- Add `schemas/skills.sh.schema.json` describing the `skills.sh.json` catalog shape.
- Point `$schema` at the raw GitHub URL (the skills.sh-hosted path currently returns 404).

Fixes #270

## Test plan
- [ ] `curl -sI https://raw.githubusercontent.com/vercel-labs/agent-skills/main/schemas/skills.sh.schema.json` returns 200 after merge
- [ ] Validate `skills.sh.json` against the new schema

Made with [Cursor](https://cursor.com)