### PR TITLE
react-view-transitions: isolation, scroll-hang, reveal-flicker, shared-element placement

### DIFF
--- a/skills/react-view-transitions/references/css-recipes.md
+++ b/skills/react-view-transitions/references/css-recipes.md
@@ -226,6 +226,51 @@ For elements with `backdrop-filter`, hide the old snapshot to avoid flash:
 }
 ```
 
+### Floating Element Isolation (popovers, menus, tooltips, control clusters)
+
+Same freeze as persistent chrome. A floating/interactive element left rendered while a background transition runs is otherwise captured in the `root` snapshot and flickers as it settles. Give it a real, unique `view-transition-name` (never `none` — that's the CSS default = no isolation) and:
+
+```css
+::view-transition-group(popover) {
+  animation: none;
+  z-index: 100;
+}
+::view-transition-old(popover),
+::view-transition-new(popover) {
+  animation: none;
+}
+```
+
+### Skeleton ↔ Content Morph (group-only)
+
+For an element that appears in **both** a Suspense fallback and the resolved content (search input, title, a solid bar), share one `view-transition-name` across both and animate only the **group** (position/size) — disable the old/new cross-fade so text/solid shapes don't ghost:
+
+```css
+::view-transition-group(search-input) {
+  animation-duration: var(--duration-move);
+}
+::view-transition-old(search-input),
+::view-transition-new(search-input) {
+  animation: none;
+}
+```
+
+### Sliding Indicator (tab underline / segmented pill)
+
+One shared-name indicator morphs between positions. Slide the group; disable old/new so the solid bar slides instead of cross-fading:
+
+```css
+::view-transition-group(.tab-underline) {
+  animation-duration: 220ms;
+  animation-timing-function: cubic-bezier(0.5, 0, 0.2, 1);
+}
+::view-transition-old(.tab-underline),
+::view-transition-new(.tab-underline) {
+  animation: none;
+  height: 100%;
+}
+```
+
 ---
 
 ## Reduced Motion

--- a/skills/react-view-transitions/references/css-recipes.md
+++ b/skills/react-view-transitions/references/css-recipes.md
@@ -241,20 +241,6 @@ Same freeze as persistent chrome. A floating/interactive element left rendered w
 }
 ```
 
-### Skeleton ↔ Content Morph (group-only)
-
-For an element that appears in **both** a Suspense fallback and the resolved content (search input, title, a solid bar), share one `view-transition-name` across both and animate only the **group** (position/size) — disable the old/new cross-fade so text/solid shapes don't ghost:
-
-```css
-::view-transition-group(search-input) {
-  animation-duration: var(--duration-move);
-}
-::view-transition-old(search-input),
-::view-transition-new(search-input) {
-  animation: none;
-}
-```
-
 ### Sliding Indicator (tab underline / segmented pill)
 
 One shared-name indicator morphs between positions. Slide the group; disable old/new so the solid bar slides instead of cross-fading:

--- a/skills/react-view-transitions/references/implementation.md
+++ b/skills/react-view-transitions/references/implementation.md
@@ -125,6 +125,7 @@ This example uses `slide-down` / `slide-up` for directional vertical motion. For
 **Rules:**
 - Always use `default="none"` on the content `<ViewTransition>` to prevent re-animation on revalidation or unrelated transitions.
 - Use simple string props (not type maps) on Suspense `<ViewTransition>`s — Suspense resolves fire as separate transitions with no type, so type-keyed props won't match.
+- If the same element appears in **both** the fallback and the content (a title, a search input, a control bar), it will flicker unless you morph it — give both the same `view-transition-name`. This only morphs when the content resolves within the same reveal (cached/prefetched); on a cold fetch it enters later as a separate transition. See "Shared Controls / Text Between Skeleton and Content" in `patterns.md` and the "Skeleton ↔ Content Morph" recipe in `css-recipes.md`.
 
 ## Step 6: Add Shared Element Transitions
 

--- a/skills/react-view-transitions/references/implementation.md
+++ b/skills/react-view-transitions/references/implementation.md
@@ -150,6 +150,7 @@ When list items contain shared elements, compose both patterns with two nested `
 **Rules:**
 - Names must be globally unique — use prefixes like `photo-${id}`.
 - Add `default="none"` on list-side shared elements to prevent per-item cross-fades on filter/search updates.
+- The target must be **in the DOM at navigation time** for the pair to form. If it's behind a Suspense fallback (not rendered yet), no pair forms and it won't morph — render it above the data boundary.
 
 ## Step 7: Verify Each Navigation Path
 

--- a/skills/react-view-transitions/references/implementation.md
+++ b/skills/react-view-transitions/references/implementation.md
@@ -125,7 +125,7 @@ This example uses `slide-down` / `slide-up` for directional vertical motion. For
 **Rules:**
 - Always use `default="none"` on the content `<ViewTransition>` to prevent re-animation on revalidation or unrelated transitions.
 - Use simple string props (not type maps) on Suspense `<ViewTransition>`s — Suspense resolves fire as separate transitions with no type, so type-keyed props won't match.
-- If the same element appears in **both** the fallback and the content (a title, a search input, a control bar), it will flicker unless you morph it — give both the same `view-transition-name`. This only morphs when the content resolves within the same reveal (cached/prefetched); on a cold fetch it enters later as a separate transition. See "Shared Controls / Text Between Skeleton and Content" in `patterns.md` and the "Skeleton ↔ Content Morph" recipe in `css-recipes.md`.
+- If the same element appears in **both** the fallback and the content (a title, a heading), it flickers on reveal — an opacity dip. Render it **outside** the `<Suspense>` boundary (or pin it), so it isn't in both. See "Suspense reveal flicker" in `patterns.md`.
 
 ## Step 6: Add Shared Element Transitions
 

--- a/skills/react-view-transitions/references/implementation.md
+++ b/skills/react-view-transitions/references/implementation.md
@@ -150,7 +150,7 @@ When list items contain shared elements, compose both patterns with two nested `
 **Rules:**
 - Names must be globally unique — use prefixes like `photo-${id}`.
 - Add `default="none"` on list-side shared elements to prevent per-item cross-fades on filter/search updates.
-- The target must be **in the DOM at navigation time** for the pair to form. If it's behind a Suspense fallback (not rendered yet), no pair forms and it won't morph — render it above the data boundary.
+- The target must be **in the DOM at navigation time** for the pair to form. If it's behind a Suspense fallback (not rendered yet), no pair forms and it won't morph. It works when the target is present at the snapshot — render it above the data boundary, or have its data **cached/prefetched** so it resolves in time.
 
 ## Step 7: Verify Each Navigation Path
 

--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -169,31 +169,6 @@ When navigating between dynamic segments of the same route (e.g., `/collection/[
 
 ---
 
-## Shared Elements Across a Suspense Boundary
-
-A cross-navigation morph needs the target named element present at the navigation snapshot. If the destination `<ViewTransition name>` sits **inside** a `<Suspense>` awaiting a fetch, only the skeleton is in the shell at snapshot time — no pair forms, so nothing morphs. A placement issue, not a limitation.
-
-**It morphs fine when the target is in the shell / cached.** Put the named element in `layout.tsx` keyed only by `params` (fast), and stream the slow data inside:
-
-```tsx
-// app/thing/[slug]/layout.tsx
-export default async function Layout({ children, params }: {
-  children: React.ReactNode;
-  params: Promise<{ slug: string }>;
-}) {
-  const { slug } = await params;
-  return (
-    <ViewTransition name={`thing-${slug}`} share="morph" default="none">
-      <article>{children}</article>
-    </ViewTransition>
-  );
-}
-```
-
-For a *visual* target (album art, product image), back it with a fast, cached, param-only query (e.g. just the cover color) and keep the heavy fetch behind the inner `<Suspense>`.
-
-**Instant routes:** reading `params` in the shell can trip *"params accessed outside `<Suspense>`"* on instant-prerenderable routes. Keep the shell read param-only and cached, or opt that route out of instant.
-
 ## Nested enter/exit — `parentEnter` / `parentExit` (experimental)
 
 Lifts the "nested VTs don't fire enter/exit inside a parent" rule: a nested VT can animate when its **parent** enters/exits (`parentEnter`/`parentExit`, `onParentEnter`/`onParentExit`; `parentEnter="none"` stops propagation). Client-only today (behind `enableViewTransitionParentEnterExit`); SSR support for Suspense reveals landed in React PR #36917 ([commit](https://github.com/react/react/commit/83840902c890f0eb85decda239ef6b1b14945779)). Verify it's in your React (`grep -r "vt-parent-enter" node_modules/next/dist/compiled/react*`) before relying on it.

--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -176,7 +176,7 @@ A shared-element morph needs **both** the source *and* the target named element 
 **Fix: hoist the shared element into the shell, fed only by fast/cached data; stream the slow data inside it.** Put the named element in the route's `layout.tsx` (or above the data `<Suspense>`), keyed only by `params`:
 
 ```tsx
-// app/thing/[slug]/layout.tsx — awaits ONLY params (no slow query)
+// app/thing/[slug]/layout.tsx
 export default async function Layout({ children, params }: LayoutProps<'/thing/[slug]'>) {
   const { slug } = await params;
   return (

--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -169,6 +169,34 @@ When navigating between dynamic segments of the same route (e.g., `/collection/[
 
 ---
 
+## Shared Elements Behind a Data-Fetching `<Suspense>` (the "it only morphs the skeleton" trap)
+
+A shared-element morph needs **both** the source *and* the target named element present **at the navigation snapshot** — the instant the transition starts. If the destination's `<ViewTransition name={...}>` sits **inside** a `<Suspense>` that's waiting on a data fetch, then at snapshot time the destination shell contains only the *skeleton* — the named element doesn't exist yet, no pair forms, and you'll see only the skeleton's auto-named groups animate (never your `name`d group). This looks like "shared elements don't work here," but it's a **placement** problem, not a limitation.
+
+**Fix: hoist the shared element into the shell, fed only by fast/cached data; stream the slow data inside it.** Put the named element in the route's `layout.tsx` (or above the data `<Suspense>`), keyed only by `params`:
+
+```tsx
+// app/thing/[slug]/layout.tsx — awaits ONLY params (no slow query)
+export default async function Layout({ children, params }: LayoutProps<'/thing/[slug]'>) {
+  const { slug } = await params;
+  return (
+    <ViewTransition name={`thing-${slug}`} share="morph" default="none">
+      <article>{children}</article>   {/* the slow header/body stream INSIDE, with their own reveal */}
+    </ViewTransition>
+  );
+}
+```
+
+The morph target exists in the shell the moment you navigate (it only needs `slug` from the URL), so it pairs with the list-side card and morphs immediately; the data fills in after. If the shared element is a *visual* (album art, product image) rather than the whole container, back it with a **fast, cached, param-only** query (e.g. just the cover color/URL) and keep the heavy per-entity fetch behind the inner `<Suspense>`.
+
+### Interaction with instant / prerenderable routes (Cache Components)
+
+Placing the shared element in the shell means reading `params` **outside** the data `<Suspense>`. On instant-prerenderable routes this can trip *"params accessed outside of `<Suspense>` prevents the route from being prerendered."* That's expected — the shared-element shell and a fully-streamed instant route pull in opposite directions. Resolve it by keeping the shell's read **param-only and cached/fast** (so the shell is cheap), or opt the route out of instant prerendering where the morph matters. Do **not** conclude the morph is "structurally impossible" — it's the shared element being mis-placed behind the fetch, plus this params-in-shell tradeoff.
+
+## Nested enter/exit for Suspense reveals — `parentEnter` / `parentExit` (experimental, evolving)
+
+The long-standing rule "nested `<ViewTransition>`s don't fire enter/exit inside a parent VT" is being lifted by the experimental **`parentEnter` / `parentExit`** props (and `onParentEnter` / `onParentExit` handlers): a nested VT can define how *it* animates when a **parent** enters/exits, and `parentEnter="none"` stops the propagation into a subtree. Client support exists today (behind `enableViewTransitionParentEnterExit`, i.e. experimental React); SSR/streaming support for **Suspense reveals** was added in React PR #36917 ([commit](https://github.com/react/react/commit/83840902c890f0eb85decda239ef6b1b14945779)). Treat it as a **future/experimental** capability — verify it's in your bundled React before relying on it (`grep -r "vt-parent-enter" node_modules/next/dist/compiled/react*`). It is *not* a fix for root-captured persistent/floating isolation or the scroll-hang.
+
 ## Server Components
 
 - `<ViewTransition>` works in both Server and Client Components

--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -177,15 +177,23 @@ A shared-element morph needs **both** the source *and* the target named element 
 
 ```tsx
 // app/thing/[slug]/layout.tsx
-export default async function Layout({ children, params }: LayoutProps<'/thing/[slug]'>) {
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ slug: string }>;
+}) {
   const { slug } = await params;
   return (
     <ViewTransition name={`thing-${slug}`} share="morph" default="none">
-      <article>{children}</article>   {/* the slow header/body stream INSIDE, with their own reveal */}
+      <article>{children}</article>
     </ViewTransition>
   );
 }
 ```
+
+The slow header/body stream **inside** `{children}` with their own reveal; the layout only needs `params` (fast), so the morph target is in the shell at navigation time.
 
 The morph target exists in the shell the moment you navigate (it only needs `slug` from the URL), so it pairs with the list-side card and morphs immediately; the data fills in after. If the shared element is a *visual* (album art, product image) rather than the whole container, back it with a **fast, cached, param-only** query (e.g. just the cover color/URL) and keep the heavy per-entity fetch behind the inner `<Suspense>`.
 

--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -36,7 +36,7 @@ When following `implementation.md`, apply these additions:
 
 A bare `<ViewTransition>` in layout works only if pages have **no** VTs of their own.
 
-**Layouts persist across navigations** — `enter`/`exit` only fire on initial mount, not on route changes. Don't use type-keyed maps in layouts.
+**Layouts persist across navigations** — `enter`/`exit` only fire on initial mount, not on route changes. Don't use type-keyed maps in layouts. Because layouts persist, chrome hosted in one (nav, sidebar, player) keeps its state across navigations for free — no `Activity` needed. Reserve `Activity` for in-page show/hide (see `patterns.md` → Composing with Activity).
 
 ---
 
@@ -92,6 +92,39 @@ function handleSort(sort: string) {
 ```
 
 List items wrapped in `<ViewTransition key={item.id}>` will animate reorder. This is the server-component alternative to the client-side `useDeferredValue` pattern in `patterns.md`.
+
+---
+
+## Routing-Driven Tabs
+
+The generalized sliding indicator (`patterns.md` → Sliding Indicator) driven by navigation instead of local state: tabs are `<Link>`s, `active` comes from the URL (a server prop), and `useOptimistic` slides the indicator instantly while the route commits. Key the mounted indicator to committed `active` so the bar lands where navigation actually settles.
+
+```tsx
+'use client';
+import Link from 'next/link';
+import { useOptimistic, useTransition, ViewTransition } from 'react';
+
+export function Tabs({ tabs, active, indicatorName = 'tab-indicator' }) {
+  const [optimisticActive, setOptimisticActive] = useOptimistic(active);
+  const [, startTransition] = useTransition();
+  return (
+    <nav>
+      {tabs.map(t => (
+        <Link key={t.value} href={t.href} scroll={false}
+          aria-current={optimisticActive === t.value ? 'page' : undefined}
+          onNavigate={() => startTransition(() => setOptimisticActive(t.value))}>
+          <span>{t.label}</span>
+          {active === t.value && (
+            <ViewTransition name={indicatorName} share="tab-underline">
+              <span className="active-underline" aria-hidden />
+            </ViewTransition>
+          )}
+        </Link>
+      ))}
+    </nav>
+  );
+}
+```
 
 ---
 

--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -169,18 +169,15 @@ When navigating between dynamic segments of the same route (e.g., `/collection/[
 
 ---
 
-## Shared Elements Behind a Data-Fetching `<Suspense>` (the "it only morphs the skeleton" trap)
+## Shared Elements Across a Suspense Boundary
 
-A shared-element morph needs **both** the source *and* the target named element present **at the navigation snapshot** — the instant the transition starts. If the destination's `<ViewTransition name={...}>` sits **inside** a `<Suspense>` that's waiting on a data fetch, then at snapshot time the destination shell contains only the *skeleton* — the named element doesn't exist yet, no pair forms, and you'll see only the skeleton's auto-named groups animate (never your `name`d group). This looks like "shared elements don't work here," but it's a **placement** problem, not a limitation.
+A cross-navigation morph needs the target named element present at the navigation snapshot. If the destination `<ViewTransition name>` sits **inside** a `<Suspense>` awaiting a fetch, only the skeleton is in the shell at snapshot time — no pair forms, so nothing morphs. A placement issue, not a limitation.
 
-**Fix: hoist the shared element into the shell, fed only by fast/cached data; stream the slow data inside it.** Put the named element in the route's `layout.tsx` (or above the data `<Suspense>`), keyed only by `params`:
+**It morphs fine when the target is in the shell / cached.** Put the named element in `layout.tsx` keyed only by `params` (fast), and stream the slow data inside:
 
 ```tsx
 // app/thing/[slug]/layout.tsx
-export default async function Layout({
-  children,
-  params,
-}: {
+export default async function Layout({ children, params }: {
   children: React.ReactNode;
   params: Promise<{ slug: string }>;
 }) {
@@ -193,17 +190,13 @@ export default async function Layout({
 }
 ```
 
-The slow header/body stream **inside** `{children}` with their own reveal; the layout only needs `params` (fast), so the morph target is in the shell at navigation time.
+For a *visual* target (album art, product image), back it with a fast, cached, param-only query (e.g. just the cover color) and keep the heavy fetch behind the inner `<Suspense>`.
 
-The morph target exists in the shell the moment you navigate (it only needs `slug` from the URL), so it pairs with the list-side card and morphs immediately; the data fills in after. If the shared element is a *visual* (album art, product image) rather than the whole container, back it with a **fast, cached, param-only** query (e.g. just the cover color/URL) and keep the heavy per-entity fetch behind the inner `<Suspense>`.
+**Instant routes:** reading `params` in the shell can trip *"params accessed outside `<Suspense>`"* on instant-prerenderable routes. Keep the shell read param-only and cached, or opt that route out of instant.
 
-### Interaction with instant / prerenderable routes (Cache Components)
+## Nested enter/exit — `parentEnter` / `parentExit` (experimental)
 
-Placing the shared element in the shell means reading `params` **outside** the data `<Suspense>`. On instant-prerenderable routes this can trip *"params accessed outside of `<Suspense>` prevents the route from being prerendered."* That's expected — the shared-element shell and a fully-streamed instant route pull in opposite directions. Resolve it by keeping the shell's read **param-only and cached/fast** (so the shell is cheap), or opt the route out of instant prerendering where the morph matters. Do **not** conclude the morph is "structurally impossible" — it's the shared element being mis-placed behind the fetch, plus this params-in-shell tradeoff.
-
-## Nested enter/exit for Suspense reveals — `parentEnter` / `parentExit` (experimental, evolving)
-
-The long-standing rule "nested `<ViewTransition>`s don't fire enter/exit inside a parent VT" is being lifted by the experimental **`parentEnter` / `parentExit`** props (and `onParentEnter` / `onParentExit` handlers): a nested VT can define how *it* animates when a **parent** enters/exits, and `parentEnter="none"` stops the propagation into a subtree. Client support exists today (behind `enableViewTransitionParentEnterExit`, i.e. experimental React); SSR/streaming support for **Suspense reveals** was added in React PR #36917 ([commit](https://github.com/react/react/commit/83840902c890f0eb85decda239ef6b1b14945779)). Treat it as a **future/experimental** capability — verify it's in your bundled React before relying on it (`grep -r "vt-parent-enter" node_modules/next/dist/compiled/react*`). It is *not* a fix for root-captured persistent/floating isolation or the scroll-hang.
+Lifts the "nested VTs don't fire enter/exit inside a parent" rule: a nested VT can animate when its **parent** enters/exits (`parentEnter`/`parentExit`, `onParentEnter`/`onParentExit`; `parentEnter="none"` stops propagation). Client-only today (behind `enableViewTransitionParentEnterExit`); SSR support for Suspense reveals landed in React PR #36917 ([commit](https://github.com/react/react/commit/83840902c890f0eb85decda239ef6b1b14945779)). Verify it's in your React (`grep -r "vt-parent-enter" node_modules/next/dist/compiled/react*`) before relying on it.
 
 ## Server Components
 

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -114,9 +114,13 @@ Use `key` when content identity changes (state resets). Omit for cross-fades (ta
 
 ## Isolate Elements from Parent Animations
 
+The only way to pull an element out of the browser's animated `root` snapshot is to give it **its own `view-transition-name`**. There is no "exclude from root" primitive.
+
+> **`view-transition-name: none` does NOT isolate anything.** `none` is the CSS *default* — setting it explicitly is a no-op, and the element stays part of the `root` capture. This is a common bug (e.g. a popover with `style={{ viewTransitionName: 'none' }}` still flickers). Isolation always requires a **real, unique name** plus CSS that neutralizes its animation.
+
 ### Persistent Layout Elements
 
-Persistent elements (headers, navbars, sidebars) get captured in the page's transition snapshot. Fix with `viewTransitionName`:
+Persistent elements (headers, navbars, sidebars) get captured in the page's transition snapshot. Fix with a real `viewTransitionName`:
 
 ```jsx
 <nav style={{ viewTransitionName: "persistent-nav" }}>{/* ... */}</nav>
@@ -124,15 +128,23 @@ Persistent elements (headers, navbars, sidebars) get captured in the page's tran
 
 Then add the persistent element isolation CSS from `css-recipes.md`. For `backdrop-blur`/`backdrop-filter`, use the backdrop-blur workaround from `css-recipes.md`.
 
-### Floating Elements
+**`<ViewTransition default="none">` vs. a hand-named group.** Wrapping the element in `<ViewTransition default="none">` also lifts it out of `root` and disables its animation, with *no* CSS — prefer it when animation-off is all you need. But React assigns that boundary an **auto-generated** name you can't target from CSS, so you **cannot** add `z-index` layering or the backdrop-blur `::view-transition-old(...) { display: none }` workaround to it. When you need those (e.g. sticky chrome that must stay above transitioning content, or a blurred sidebar), keep the **hand-named** `viewTransitionName` + explicit CSS. This is inherent, not boilerplate you can delete.
 
-Give popovers/tooltips their own `viewTransitionName`:
+### Floating Elements (popovers, menus, tooltips)
+
+A floating element left **open** while a background transition runs is captured in the `root` snapshot and **flickers as the transition settles**. Give it a real `viewTransitionName` and isolate it:
 
 ```jsx
-<SelectPopover style={{ viewTransitionName: 'popover' }}>{options}</SelectPopover>
+<SelectPopover style={{ viewTransitionName: 'select-popover' }}>{options}</SelectPopover>
 ```
 
-Global fix: see persistent element isolation in `css-recipes.md`.
+```css
+::view-transition-group(select-popover) { animation: none; z-index: 100; }
+::view-transition-old(select-popover),
+::view-transition-new(select-popover) { animation: none; }
+```
+
+A static name is safe as long as only one instance is mounted at a time (e.g. the menu uses `unmountOnHide`). If genuinely rendered in the browser **top layer** (native `popover`/`<dialog>`), the settle re-composite is a browser limitation React can't reach — but most portaled popovers are ordinary divs and the real-name fix resolves the flicker.
 
 ## Shared Controls Between Skeleton and Content
 
@@ -238,6 +250,10 @@ The `types` array (second argument) lets you vary animation based on transition 
 **VT not activating:** Ensure `<ViewTransition>` comes before any DOM node. Ensure state update is inside `startTransition`.
 
 **"Two ViewTransition components with the same name":** Names must be globally unique. Use IDs: `name={`hero-${item.id}`}`.
+
+**Scrolling hangs / feels stuck while a transition animates (esp. a Suspense reveal):** the browser's `::view-transition` overlay is `position: fixed` over the viewport, and the old/new snapshots don't scroll with the page — so scrolling appears frozen until the animation settles. This is a **browser/CSS View Transitions limitation**, not something React can hide (skipping the transition on scroll snaps abruptly to the end). Mitigate by keeping reveal durations short (200–400ms). For genuinely scroll-driven UI, use **gesture transitions** (`useSwipeTransition` / `startGestureTransition`) — those are scrubbed by scroll position so scrolling *drives* the transition instead of fighting it.
+
+**Open popover/menu flickers when a background transition settles:** the floating element is captured in the `root` snapshot. Give it a real `view-transition-name` + isolation CSS — see "Floating Elements" above. (`viewTransitionName: 'none'` does not fix it — that's the CSS default.)
 
 **`router.back()` and browser back/forward skip animation:** Use `router.push()` with an explicit URL instead. See SKILL.md "router.back() and Browser Back Button."
 

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -138,11 +138,7 @@ A floating element left **open** while a background transition runs is captured 
 <SelectPopover style={{ viewTransitionName: 'select-popover' }}>{options}</SelectPopover>
 ```
 
-```css
-::view-transition-group(select-popover) { animation: none; z-index: 100; }
-::view-transition-old(select-popover),
-::view-transition-new(select-popover) { animation: none; }
-```
+Then freeze it — see "Floating Element Isolation" in `css-recipes.md`.
 
 A static name is safe as long as only one instance is mounted at a time (e.g. the menu uses `unmountOnHide`). If genuinely rendered in the browser **top layer** (native `popover`/`<dialog>`), the settle re-composite is a browser limitation React can't reach — but most portaled popovers are ordinary divs and the real-name fix resolves the flicker.
 
@@ -159,15 +155,9 @@ A static name is safe as long as only one instance is mounted at a time (e.g. th
 <input placeholder="Search..." style={{ viewTransitionName: 'search-input' }} />
 ```
 
-```css
-/* the group interpolates position + size = a smooth morph */
-::view-transition-group(search-input) { animation-duration: 220ms; }
-/* no cross-fade of the two snapshots = no ghost/flicker */
-::view-transition-old(search-input),
-::view-transition-new(search-input) { animation: none; }
-```
+Then morph it — see "Skeleton ↔ Content Morph (group-only)" in `css-recipes.md`.
 
-So yes — you *can* "morph the fallback too": the fallback element and the content element sharing one name is what makes the fallback shape animate into the content shape instead of flickering. Blanket-avoiding it ("never put the same element in both") works but forfeits the nicest reveal; the shared-name + group-only morph is the better default.
+So yes — you *can* morph the fallback shape into the content shape: sharing one name across both is what makes it morph instead of flicker. **It only actually morphs when the content is present within the same reveal transition** — i.e. the data is cached/prefetched so the resolved element renders in the same transition that removes the fallback. On a cold/uncached fetch there is no content element yet at the reveal, so nothing pairs with the fallback: you sit on the skeleton and the content enters later as a *separate* transition (a plain enter, no morph). Blanket-avoiding it ("never put the same element in both") works but forfeits the nicest reveal.
 
 Don't put manual `viewTransitionName` on the root DOM node inside `<ViewTransition>` — React's auto-generated name overrides it.
 
@@ -185,7 +175,7 @@ export function Tabs({ tabs, active, indicatorName = 'tab-indicator' }) {
   return (
     <nav>
       {tabs.map(t => {
-        const isCommitted = active === t.value;              // where the bar actually is
+        const isCommitted = active === t.value;
         return (
           <Link key={t.value} href={t.href} scroll={false}
             aria-current={optimisticActive === t.value ? 'page' : undefined}
@@ -204,17 +194,7 @@ export function Tabs({ tabs, active, indicatorName = 'tab-indicator' }) {
 }
 ```
 
-```css
-::view-transition-group(.tab-underline) {
-  animation-duration: 220ms;
-  animation-timing-function: cubic-bezier(0.5, 0, 0.2, 1);
-}
-::view-transition-old(.tab-underline),
-::view-transition-new(.tab-underline) {
-  animation: none;   /* don't fade the two bars — just let the group slide */
-  height: 100%;      /* both snapshots fill so it reads as one solid moving bar */
-}
-```
+See "Sliding Indicator" in `css-recipes.md` for the `share="tab-underline"` CSS.
 
 Key details: the indicator is keyed to the **committed** `active` (so the bar sits where navigation actually landed), while `useOptimistic` drives the *label* state instantly; give each mount point a distinct `indicatorName` so two tab strips on one page don't fight over one name.
 

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -159,6 +159,8 @@ export function Tabs({ tabs, indicatorName = 'tab-indicator' }) {
 }
 ```
 
+Because the state change is a transition, if the newly-active tab renders suspending content the whole update — indicator **and** `aria-current` — waits for it to commit, and the strip feels dead on click. Give the controls an immediate value with `useOptimistic` (drive `aria-current` from it) so feedback is instant while the content streams. The routing variant (`nextjs.md` → Routing-Driven Tabs) does exactly this: optimistic `aria-current`, committed `active` for the bar.
+
 ## Reusable Animated Collapse
 
 ```jsx

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -116,7 +116,7 @@ Use `key` when content identity changes (state resets). Omit for cross-fades (ta
 
 The only way to pull an element out of the browser's animated `root` snapshot is to give it **its own `view-transition-name`**. There is no "exclude from root" primitive.
 
-> **`view-transition-name: none` does NOT isolate anything.** `none` is the CSS *default* — setting it explicitly is a no-op, and the element stays part of the `root` capture. This is a common bug (e.g. a popover with `style={{ viewTransitionName: 'none' }}` still flickers). Isolation always requires a **real, unique name** plus CSS that neutralizes its animation.
+> **`view-transition-name: none` does NOT isolate anything.** `none` is the CSS *default* — setting it explicitly is a no-op, and the element stays part of the `root` capture. This is a common bug (e.g. a popover with `style={{ viewTransitionName: 'none' }}` still flickers). Isolation always requires a **real, unique name**; you then neutralize its animation either with `<ViewTransition default="none">` (no CSS) or with CSS pseudo-element rules (needed when you also want `z-index`/`display` control — see below).
 
 ### Persistent Layout Elements
 
@@ -142,22 +142,20 @@ Then freeze it — see "Floating Element Isolation" in `css-recipes.md`.
 
 A static name is safe as long as only one instance is mounted at a time (e.g. the menu uses `unmountOnHide`). If genuinely rendered in the browser **top layer** (native `popover`/`<dialog>`), the settle re-composite is a browser limitation React can't reach — but most portaled popovers are ordinary divs and the real-name fix resolves the flicker.
 
-## Shared Controls / Text Between Skeleton and Content (fixing the reveal flicker)
+## Suspense reveal flicker: an element shared between fallback and content
 
-**Why an element that appears in *both* the fallback and the resolved content flickers:** they're two different DOM nodes across the Suspense swap. Without a shared name the browser snapshots them separately and **cross-fades** (old fades out while new fades in) — with text or a solid bar of different size/content, that reads as a ghost/flicker. It is **not** a "pin it" problem — pinning (isolation) freezes the element; here you *want* continuity.
+If the **same** element (a title, a heading, a toolbar) is rendered in **both** the Suspense fallback and the resolved content, it briefly **flickers** on reveal — an opacity dip. The reveal cross-fades the fallback out and the content in, and the duplicated element fades against itself. This is a within-page opacity flicker, **not** a shape morph.
 
-**Fix: morph the fallback shape into the content shape.** Give the matching element in fallback and content the **same `view-transition-name`**, and — critically for text/solid shapes — animate only the **group** (position/size) while disabling the old/new cross-fade:
+**Fix (preferred): move it outside the Suspense boundary.** Render the persistent element *above* `<Suspense>` so it mounts once and never takes part in the fallback→content swap:
 
 ```jsx
-// Fallback
-<input disabled placeholder="Search..." style={{ viewTransitionName: 'search-input' }} />
-// Content
-<input placeholder="Search..." style={{ viewTransitionName: 'search-input' }} />
+<h1>{title}</h1>
+<Suspense fallback={<BodySkeleton />}>
+  <Body />
+</Suspense>
 ```
 
-Then morph it — see "Skeleton ↔ Content Morph (group-only)" in `css-recipes.md`.
-
-So yes — you *can* morph the fallback shape into the content shape: sharing one name across both is what makes it morph instead of flicker. **It only actually morphs when the content is present within the same reveal transition** — i.e. the data is cached/prefetched so the resolved element renders in the same transition that removes the fallback. On a cold/uncached fetch there is no content element yet at the reveal, so nothing pairs with the fallback: you sit on the skeleton and the content enters later as a *separate* transition (a plain enter, no morph). Blanket-avoiding it ("never put the same element in both") works but forfeits the nicest reveal.
+**Alternative: pin it** — give it its own `view-transition-name` (isolation, above) so it's excluded from the reveal animation. Moving it out is simpler. If a control genuinely *changes* between fallback and content and must stay inside (e.g. a disabled → enabled search input), giving both the same `view-transition-name` keeps it continuous instead of flickering.
 
 Don't put manual `viewTransitionName` on the root DOM node inside `<ViewTransition>` — React's auto-generated name overrides it.
 
@@ -167,6 +165,7 @@ A single active-indicator (underline, pill) that **slides** to the selected tab 
 
 ```tsx
 'use client';
+import Link from 'next/link';
 import { useOptimistic, useTransition, ViewTransition } from 'react';
 
 export function Tabs({ tabs, active, indicatorName = 'tab-indicator' }) {
@@ -290,7 +289,7 @@ The `types` array (second argument) lets you vary animation based on transition 
 
 **"Two ViewTransition components with the same name":** Names must be globally unique. Use IDs: `name={`hero-${item.id}`}`.
 
-**Scrolling hangs / feels stuck while a transition animates (esp. a Suspense reveal):** the browser's `::view-transition` overlay is `position: fixed` over the viewport, and the old/new snapshots don't scroll with the page — so scrolling appears frozen until the animation settles. This is a **browser/CSS View Transitions limitation**, not something React can hide (skipping the transition on scroll snaps abruptly to the end). Mitigate by keeping reveal durations short (200–400ms). For genuinely scroll-driven UI, use **gesture transitions** (`useSwipeTransition` / `startGestureTransition`) — those are scrubbed by scroll position so scrolling *drives* the transition instead of fighting it.
+**Scrolling hangs / feels stuck while a transition animates (esp. a Suspense reveal):** the browser's `::view-transition` overlay is `position: fixed` over the viewport, and the old/new snapshots don't scroll with the page — so scrolling appears frozen until the animation settles. This is a **browser/CSS View Transitions limitation**, not something React can hide (skipping the transition on scroll snaps abruptly to the end). Mitigate by keeping reveal durations short (200–400ms). For genuinely scroll-driven UI, gesture transitions (the experimental `useSwipeTransition` / `startGestureTransition`, if available in your React build) are scrubbed by scroll position so scrolling *drives* the transition instead of fighting it.
 
 **Open popover/menu flickers when a background transition settles:** the floating element is captured in the `root` snapshot. Give it a real `view-transition-name` + isolation CSS — see "Floating Elements" above. (`viewTransitionName: 'none'` does not fix it — that's the CSS default.)
 

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -132,29 +132,27 @@ Don't put a manual `viewTransitionName` on the root DOM node inside `<ViewTransi
 
 ## Sliding Indicator (tabs)
 
-One shared-name indicator rendered under the **committed** active tab morphs between positions on change (slide the group, disable old/new — see `css-recipes.md` → Sliding Indicator). Key it to committed `active` (bar sits where nav landed); `useOptimistic` drives the label instantly; use a distinct `indicatorName` per tab strip.
+One shared-name indicator rendered under the **active** tab morphs between positions on change (slide the group, disable old/new — see `css-recipes.md` → Sliding Indicator). Render it only under the active tab so exactly one element holds `indicatorName`; use a distinct `indicatorName` per tab strip. Trigger the state change inside `startTransition` so the move animates. Whatever owns `active` drives it — local state here, routing in Next (see `nextjs.md` → Routing-Driven Tabs).
 
 ```tsx
-'use client';
-import Link from 'next/link';
-import { useOptimistic, useTransition, ViewTransition } from 'react';
+import { useState, useTransition, ViewTransition } from 'react';
 
-export function Tabs({ tabs, active, indicatorName = 'tab-indicator' }) {
-  const [optimisticActive, setOptimisticActive] = useOptimistic(active);
+export function Tabs({ tabs, indicatorName = 'tab-indicator' }) {
+  const [active, setActive] = useState(tabs[0].value);
   const [, startTransition] = useTransition();
   return (
     <nav>
       {tabs.map(t => (
-        <Link key={t.value} href={t.href} scroll={false}
-          aria-current={optimisticActive === t.value ? 'page' : undefined}
-          onNavigate={() => startTransition(() => setOptimisticActive(t.value))}>
+        <button key={t.value} type="button"
+          aria-current={active === t.value ? 'page' : undefined}
+          onClick={() => startTransition(() => setActive(t.value))}>
           <span>{t.label}</span>
           {active === t.value && (
             <ViewTransition name={indicatorName} share="tab-underline">
               <span className="active-underline" aria-hidden />
             </ViewTransition>
           )}
-        </Link>
+        </button>
       ))}
     </nav>
   );
@@ -178,7 +176,9 @@ function AnimatedCollapse({ open, children }) {
 <AnimatedCollapse open={open}><SectionContent /></AnimatedCollapse>
 ```
 
-## Preserve State with Activity
+## Composing with Activity
+
+`Activity` is orthogonal to view transitions: it preserves the state of a hidden subtree, `ViewTransition` animates it. Compose them for an in-page show/hide (drawer, panel, tab body) that keeps its scroll/form state while it animates in and out:
 
 ```jsx
 <Activity mode={isVisible ? 'visible' : 'hidden'}>
@@ -187,6 +187,8 @@ function AnimatedCollapse({ open, children }) {
   </ViewTransition>
 </Activity>
 ```
+
+Only reach for Activity when there's state worth preserving — a stateless element (e.g. the sliding indicator above) gains nothing from it. In Next.js, layout-hosted chrome already persists across navigations without Activity (see `nextjs.md`).
 
 ## Exclude Elements with `useOptimistic`
 

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -114,54 +114,25 @@ Use `key` when content identity changes (state resets). Omit for cross-fades (ta
 
 ## Isolate Elements from Parent Animations
 
-The only way to pull an element out of the browser's animated `root` snapshot is to give it **its own `view-transition-name`**. There is no "exclude from root" primitive.
+Pull an element out of the animated `root` snapshot by giving it its own `view-transition-name`. **`view-transition-name: none` is a no-op** — it's the CSS default, so the element stays in `root` (a common flicker bug). Use a real, unique name, then neutralize with `<ViewTransition default="none">` (no CSS) or CSS (needed for `z-index`/`display` control — see `css-recipes.md`).
 
-> **`view-transition-name: none` does NOT isolate anything.** `none` is the CSS *default* — setting it explicitly is a no-op, and the element stays part of the `root` capture. This is a common bug (e.g. a popover with `style={{ viewTransitionName: 'none' }}` still flickers). Isolation always requires a **real, unique name**; you then neutralize its animation either with `<ViewTransition default="none">` (no CSS) or with CSS pseudo-element rules (needed when you also want `z-index`/`display` control — see below).
+- **Persistent chrome** (nav, sidebar, player bar): `<nav style={{ viewTransitionName: 'persistent-nav' }}>` + isolation CSS. `<ViewTransition default="none">` works too, but its auto-name can't take `z-index`/backdrop `display:none` — hand-name when you need those.
+- **Floating elements** (popovers, menus): left open, they're captured in `root` and flicker on settle. Real name + isolation (`css-recipes.md` → Floating Element Isolation). A static name is fine if only one is mounted (`unmountOnHide`); native top-layer (`popover`/`<dialog>`) settle-flicker is a browser limit.
 
-### Persistent Layout Elements
+## Suspense reveal flicker
 
-Persistent elements (headers, navbars, sidebars) get captured in the page's transition snapshot. Fix with a real `viewTransitionName`:
-
-```jsx
-<nav style={{ viewTransitionName: "persistent-nav" }}>{/* ... */}</nav>
-```
-
-Then add the persistent element isolation CSS from `css-recipes.md`. For `backdrop-blur`/`backdrop-filter`, use the backdrop-blur workaround from `css-recipes.md`.
-
-**`<ViewTransition default="none">` vs. a hand-named group.** Wrapping the element in `<ViewTransition default="none">` also lifts it out of `root` and disables its animation, with *no* CSS — prefer it when animation-off is all you need. But React assigns that boundary an **auto-generated** name you can't target from CSS, so you **cannot** add `z-index` layering or the backdrop-blur `::view-transition-old(...) { display: none }` workaround to it. When you need those (e.g. sticky chrome that must stay above transitioning content, or a blurred sidebar), keep the **hand-named** `viewTransitionName` + explicit CSS. This is inherent, not boilerplate you can delete.
-
-### Floating Elements (popovers, menus, tooltips)
-
-A floating element left **open** while a background transition runs is captured in the `root` snapshot and **flickers as the transition settles**. Give it a real `viewTransitionName` and isolate it:
-
-```jsx
-<SelectPopover style={{ viewTransitionName: 'select-popover' }}>{options}</SelectPopover>
-```
-
-Then freeze it — see "Floating Element Isolation" in `css-recipes.md`.
-
-A static name is safe as long as only one instance is mounted at a time (e.g. the menu uses `unmountOnHide`). If genuinely rendered in the browser **top layer** (native `popover`/`<dialog>`), the settle re-composite is a browser limitation React can't reach — but most portaled popovers are ordinary divs and the real-name fix resolves the flicker.
-
-## Suspense reveal flicker: an element shared between fallback and content
-
-If the **same** element (a title, a heading, a toolbar) is rendered in **both** the Suspense fallback and the resolved content, it briefly **flickers** on reveal — an opacity dip. The reveal cross-fades the fallback out and the content in, and the duplicated element fades against itself. This is a within-page opacity flicker, **not** a shape morph.
-
-**Fix (preferred): move it outside the Suspense boundary.** Render the persistent element *above* `<Suspense>` so it mounts once and never takes part in the fallback→content swap:
+An element rendered in **both** the fallback and the content flickers (opacity dip) on reveal — it fades against itself. Not a morph. **Fix: render it outside the `<Suspense>` boundary** (mount once, above it), or pin it with a `view-transition-name`.
 
 ```jsx
 <h1>{title}</h1>
-<Suspense fallback={<BodySkeleton />}>
-  <Body />
-</Suspense>
+<Suspense fallback={<BodySkeleton />}><Body /></Suspense>
 ```
 
-**Alternative: pin it** — give it its own `view-transition-name` (isolation, above) so it's excluded from the reveal animation. Moving it out is simpler. If a control genuinely *changes* between fallback and content and must stay inside (e.g. a disabled → enabled search input), giving both the same `view-transition-name` keeps it continuous instead of flickering.
+Don't put a manual `viewTransitionName` on the root DOM node inside `<ViewTransition>` — React's auto-name overrides it.
 
-Don't put manual `viewTransitionName` on the root DOM node inside `<ViewTransition>` — React's auto-generated name overrides it.
+## Sliding Indicator (tabs)
 
-## Sliding Indicator (tabs / segmented control)
-
-A single active-indicator (underline, pill) that **slides** to the selected tab is the same shared-element mechanism: render the indicator **only under the active tab**, give every tab's indicator the **same `name`**, and it morphs from the old position to the new one on change. Animate the group (the slide); disable old/new so the solid bar doesn't cross-fade.
+One shared-name indicator rendered under the **committed** active tab morphs between positions on change (slide the group, disable old/new — see `css-recipes.md` → Sliding Indicator). Key it to committed `active` (bar sits where nav landed); `useOptimistic` drives the label instantly; use a distinct `indicatorName` per tab strip.
 
 ```tsx
 'use client';
@@ -173,29 +144,22 @@ export function Tabs({ tabs, active, indicatorName = 'tab-indicator' }) {
   const [, startTransition] = useTransition();
   return (
     <nav>
-      {tabs.map(t => {
-        const isCommitted = active === t.value;
-        return (
-          <Link key={t.value} href={t.href} scroll={false}
-            aria-current={optimisticActive === t.value ? 'page' : undefined}
-            onNavigate={() => startTransition(() => setOptimisticActive(t.value))}>
-            <span>{t.label}</span>
-            {isCommitted && (
-              <ViewTransition name={indicatorName} share="tab-underline">
-                <span className="active-underline" aria-hidden />
-              </ViewTransition>
-            )}
-          </Link>
-        );
-      })}
+      {tabs.map(t => (
+        <Link key={t.value} href={t.href} scroll={false}
+          aria-current={optimisticActive === t.value ? 'page' : undefined}
+          onNavigate={() => startTransition(() => setOptimisticActive(t.value))}>
+          <span>{t.label}</span>
+          {active === t.value && (
+            <ViewTransition name={indicatorName} share="tab-underline">
+              <span className="active-underline" aria-hidden />
+            </ViewTransition>
+          )}
+        </Link>
+      ))}
     </nav>
   );
 }
 ```
-
-See "Sliding Indicator" in `css-recipes.md` for the `share="tab-underline"` CSS.
-
-Key details: the indicator is keyed to the **committed** `active` (so the bar sits where navigation actually landed), while `useOptimistic` drives the *label* state instantly; give each mount point a distinct `indicatorName` so two tab strips on one page don't fight over one name.
 
 ## Reusable Animated Collapse
 
@@ -289,9 +253,9 @@ The `types` array (second argument) lets you vary animation based on transition 
 
 **"Two ViewTransition components with the same name":** Names must be globally unique. Use IDs: `name={`hero-${item.id}`}`.
 
-**Scrolling hangs / feels stuck while a transition animates (esp. a Suspense reveal):** the browser's `::view-transition` overlay is `position: fixed` over the viewport, and the old/new snapshots don't scroll with the page — so scrolling appears frozen until the animation settles. This is a **browser/CSS View Transitions limitation**, not something React can hide (skipping the transition on scroll snaps abruptly to the end). Mitigate by keeping reveal durations short (200–400ms). For genuinely scroll-driven UI, gesture transitions (the experimental `useSwipeTransition` / `startGestureTransition`, if available in your React build) are scrubbed by scroll position so scrolling *drives* the transition instead of fighting it.
+**Scrolling hangs while a transition animates:** the `::view-transition` overlay is `position: fixed` and its snapshots don't scroll — a browser limitation, not fixable in React (skipping snaps to the end). Keep reveal durations short; for scroll-driven UI use gesture transitions (experimental `useSwipeTransition`, if available).
 
-**Open popover/menu flickers when a background transition settles:** the floating element is captured in the `root` snapshot. Give it a real `view-transition-name` + isolation CSS — see "Floating Elements" above. (`viewTransitionName: 'none'` does not fix it — that's the CSS default.)
+**Open popover flickers when a background transition settles:** it's captured in `root`. Give it a real `view-transition-name` + isolation (not `none`) — see "Floating Elements".
 
 **`router.back()` and browser back/forward skip animation:** Use `router.push()` with an explicit URL instead. See SKILL.md "router.back() and Browser Back Button."
 

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -146,9 +146,11 @@ A floating element left **open** while a background transition runs is captured 
 
 A static name is safe as long as only one instance is mounted at a time (e.g. the menu uses `unmountOnHide`). If genuinely rendered in the browser **top layer** (native `popover`/`<dialog>`), the settle re-composite is a browser limitation React can't reach — but most portaled popovers are ordinary divs and the real-name fix resolves the flicker.
 
-## Shared Controls Between Skeleton and Content
+## Shared Controls / Text Between Skeleton and Content (fixing the reveal flicker)
 
-Give matching controls in fallback and content the same `viewTransitionName`:
+**Why an element that appears in *both* the fallback and the resolved content flickers:** they're two different DOM nodes across the Suspense swap. Without a shared name the browser snapshots them separately and **cross-fades** (old fades out while new fades in) — with text or a solid bar of different size/content, that reads as a ghost/flicker. It is **not** a "pin it" problem — pinning (isolation) freezes the element; here you *want* continuity.
+
+**Fix: morph the fallback shape into the content shape.** Give the matching element in fallback and content the **same `view-transition-name`**, and — critically for text/solid shapes — animate only the **group** (position/size) while disabling the old/new cross-fade:
 
 ```jsx
 // Fallback
@@ -157,7 +159,64 @@ Give matching controls in fallback and content the same `viewTransitionName`:
 <input placeholder="Search..." style={{ viewTransitionName: 'search-input' }} />
 ```
 
+```css
+/* the group interpolates position + size = a smooth morph */
+::view-transition-group(search-input) { animation-duration: 220ms; }
+/* no cross-fade of the two snapshots = no ghost/flicker */
+::view-transition-old(search-input),
+::view-transition-new(search-input) { animation: none; }
+```
+
+So yes — you *can* "morph the fallback too": the fallback element and the content element sharing one name is what makes the fallback shape animate into the content shape instead of flickering. Blanket-avoiding it ("never put the same element in both") works but forfeits the nicest reveal; the shared-name + group-only morph is the better default.
+
 Don't put manual `viewTransitionName` on the root DOM node inside `<ViewTransition>` — React's auto-generated name overrides it.
+
+## Sliding Indicator (tabs / segmented control)
+
+A single active-indicator (underline, pill) that **slides** to the selected tab is the same shared-element mechanism: render the indicator **only under the active tab**, give every tab's indicator the **same `name`**, and it morphs from the old position to the new one on change. Animate the group (the slide); disable old/new so the solid bar doesn't cross-fade.
+
+```tsx
+'use client';
+import { useOptimistic, useTransition, ViewTransition } from 'react';
+
+export function Tabs({ tabs, active, indicatorName = 'tab-indicator' }) {
+  const [optimisticActive, setOptimisticActive] = useOptimistic(active);
+  const [, startTransition] = useTransition();
+  return (
+    <nav>
+      {tabs.map(t => {
+        const isCommitted = active === t.value;              // where the bar actually is
+        return (
+          <Link key={t.value} href={t.href} scroll={false}
+            aria-current={optimisticActive === t.value ? 'page' : undefined}
+            onNavigate={() => startTransition(() => setOptimisticActive(t.value))}>
+            <span>{t.label}</span>
+            {isCommitted && (
+              <ViewTransition name={indicatorName} share="tab-underline">
+                <span className="active-underline" aria-hidden />
+              </ViewTransition>
+            )}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+```
+
+```css
+::view-transition-group(.tab-underline) {
+  animation-duration: 220ms;
+  animation-timing-function: cubic-bezier(0.5, 0, 0.2, 1);
+}
+::view-transition-old(.tab-underline),
+::view-transition-new(.tab-underline) {
+  animation: none;   /* don't fade the two bars — just let the group slide */
+  height: 100%;      /* both snapshots fill so it reads as one solid moving bar */
+}
+```
+
+Key details: the indicator is keyed to the **committed** `active` (so the bar sits where navigation actually landed), while `useOptimistic` drives the *label* state instantly; give each mount point a distinct `indicatorName` so two tab strips on one page don't fight over one name.
 
 ## Reusable Animated Collapse
 


### PR DESCRIPTION
Improvements to the **react-view-transitions** skill from applying it to real Next.js 16 apps.

Added / clarified:
- Isolation: `view-transition-name: none` is a no-op (CSS default) — use a real name and neutralize with `default="none"` or CSS. `default="none"` can't do `z-index`/backdrop tricks, so hand-named CSS stays necessary for those.
- Floating-element isolation (popovers/menus) recipe + guidance.
- Troubleshooting: scroll hangs during a transition (fixed-overlay browser limitation; short durations, or gesture transitions); popover flicker on settle.
- Suspense reveal flicker: an element in both the fallback and the content flickers — render it outside the boundary (or pin it).
- Sliding indicator (tabs) pattern + CSS recipe.
- Shared elements behind a data `<Suspense>` across routes (nextjs.md): the morph target must be in the shell / cached ahead; note on the instant-route tradeoff.
- Note on experimental `parentEnter`/`parentExit` (nested enter/exit for Suspense reveals), with the React commit link.

CSS lives in `css-recipes.md`; `patterns.md`/`nextjs.md` reference it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)