### PR TITLE
react-view-transitions: field learnings — morphs, isolation, interactivity

### DIFF
--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -20,31 +20,69 @@ Guide for implementing smooth, native-feeling animations using React's View Tran
 
 ## Table of Contents
 
-1. [Core Reference](#when-to-animate)
-   - [When to Animate](#when-to-animate)
-   - [Availability](#availability)
-   - [Core Concepts](#core-concepts)
-   - [Styling with View Transition Classes](#styling-with-view-transition-classes)
-   - [Transition Types](#transition-types)
-   - [Shared Element Transitions](#shared-element-transitions)
-   - [Common Patterns](#common-patterns)
-   - [How Multiple VTs Interact](#how-multiple-vts-interact)
-   - [Next.js Integration](#nextjs-integration)
-   - [Accessibility](#accessibility)
-2. [Implementation Workflow](#implementation-workflow)
-   - [Step 1: Audit the App](#step-1-audit-the-app)
-   - [Step 2: Add CSS Recipes](#step-2-add-css-recipes)
-   - [Step 3: Isolate Persistent Elements](#step-3-isolate-persistent-elements)
-   - [Step 4: Add Directional Page Transitions](#step-4-add-directional-page-transitions)
-   - [Step 5: Add Suspense Reveals](#step-5-add-suspense-reveals)
-   - [Step 6: Add Shared Element Transitions](#step-6-add-shared-element-transitions)
-   - [Step 7: Verify Each Navigation Path](#step-7-verify-each-navigation-path)
-   - [Common Mistakes](#common-mistakes)
-3. [Patterns and Guidelines](#patterns-and-guidelines)
-4. [CSS Animation Recipes](#css-animation-recipes)
-5. [View Transitions in Next.js](#view-transitions-in-nextjs)
+  - When to Animate
+  - Availability
+  - Implementation Workflow
+  - Core Concepts
+  - Styling with View Transition Classes
+  - Transition Types
+  - Shared Element Transitions
+  - Common Patterns
+  - How Multiple VTs Interact
+  - Next.js Integration
+  - Accessibility
+- **Implementation Workflow**
+  - Step 1: Audit the App
+  - Step 2: Add CSS Recipes
+  - Step 3: Isolate Persistent Elements
+  - Step 4: Add Directional Page Transitions
+  - Step 5: Add Suspense Reveals
+  - Step 6: Add Shared Element Transitions
+  - Step 7: Verify Each Navigation Path
+  - Common Mistakes
+- **Patterns and Guidelines**
+  - Searchable Grid with `useDeferredValue`
+  - Card Expand/Collapse with `startTransition`
+  - Type-Safe Transition Helpers
+  - Cross-Fade Without Remount
+  - Isolate Elements from Parent Animations
+  - Suspense reveal flicker
+  - Sliding Indicator (tabs)
+  - Layout Displacement Morph
+  - Reusable Animated Collapse
+  - Composing with Activity
+  - Exclude Elements with `useOptimistic`
+  - View Transition Events
+  - Animation Timing
+  - Troubleshooting
+- **CSS Animation Recipes**
+  - Timing Variables
+  - Fade
+  - Slide (Vertical)
+  - Directional Navigation
+  - Shared Element Morph
+  - Text Morph
+  - Scale
+  - Interactivity During Transitions
+  - Persistent Element Isolation
+  - Reduced Motion
+- **View Transitions in Next.js**
+  - Setup
+  - Next.js Implementation Additions
+  - Layout-Level ViewTransition
+  - The `transitionTypes` Prop on `next/link`
+  - Programmatic Navigation
+  - Server-Side Filtering with `router.replace`
+  - Routing-Driven Tabs
+  - Two-Layer Pattern (Directional + Suspense)
+  - `loading.tsx` as Suspense Boundary
+  - Shared Elements Across Routes
+  - Same-Route Dynamic Segment Transitions
+  - Nested enter/exit — `parentEnter` / `parentExit` (experimental)
+  - Server Components
 
 ---
+
 
 Animate between UI states using the browser's native `document.startViewTransition`. Declare *what* with `<ViewTransition>`, trigger *when* with `startTransition` / `useDeferredValue` / `Suspense`, control *how* with CSS classes. Unsupported browsers skip animations gracefully.
 
@@ -81,7 +119,13 @@ Reserve directional slides for hierarchical navigation (list → detail) and ord
 
 - **Next.js:** Do **not** install `react@canary` — the App Router already bundles React canary internally. `ViewTransition` works out of the box. `npm ls react` may show a stable-looking version; this is expected.
 - **Without Next.js:** Install `react@canary react-dom@canary` (`ViewTransition` is not in stable React).
-- Browser support: Chromium 111+, Firefox 144+, Safari 18.2+. Graceful degradation.
+- Browser support: Chromium 125+, Firefox 144+, Safari 18.2+. React requires the v2 object form of `startViewTransition` and deliberately falls back to not animating on older engines (Chromium 111–124 only has the v1 callback form). Graceful degradation on unsupported browsers.
+
+---
+
+## Implementation Workflow
+
+When adding view transitions to an existing app, **follow the Implementation Workflow section below step by step.** Start with the audit — do not skip it. Copy the CSS recipes from the CSS Animation Recipes section below into the global stylesheet — do not write your own animation CSS.
 
 ---
 
@@ -103,28 +147,36 @@ React auto-assigns a unique `view-transition-name` and calls `document.startView
 
 | Trigger | When it fires |
 |---------|--------------|
-| **enter** | VT first inserted during a Transition |
-| **exit** | VT first removed during a Transition |
-| **update** | DOM mutations inside a VT. With nested VTs, mutation applies to the innermost one |
-| **share** | Named VT unmounts and another with same `name` mounts in same Transition |
+| **enter** | `<ViewTransition>` first inserted during a Transition |
+| **exit** | `<ViewTransition>` first removed during a Transition |
+| **update** | DOM mutations inside a `<ViewTransition>`, or the boundary itself changing size/position due to an immediate sibling. With nested VTs, mutation applies to the innermost one |
+| **share** | Named VT unmounts and another with same `name` mounts in the same Transition |
 
 Only `startTransition`, `useDeferredValue`, or `Suspense` activate VTs. Regular `setState` does not animate.
 
 ### Critical Placement Rule
 
-VT only activates enter/exit if it appears **before any DOM nodes**:
+`<ViewTransition>` only activates enter/exit if it appears **before any DOM nodes**:
 
 ```jsx
 // Works
-<ViewTransition enter="auto" exit="auto"><div>Content</div></ViewTransition>
+<ViewTransition enter="auto" exit="auto">
+  <div>Content</div>
+</ViewTransition>
 
-// Broken — div wraps the VT
-<div><ViewTransition enter="auto" exit="auto"><div>Content</div></ViewTransition></div>
+// Broken — div wraps the VT, suppressing enter/exit
+<div>
+  <ViewTransition enter="auto" exit="auto">
+    <div>Content</div>
+  </ViewTransition>
+</div>
 ```
 
 ---
 
 ## Styling with View Transition Classes
+
+### Props
 
 Values: `"auto"` (browser cross-fade), `"none"` (disabled), `"class-name"` (custom CSS), or `{ [type]: value }` for type-specific animations.
 
@@ -141,11 +193,13 @@ If `default` is `"none"`, all triggers are off unless explicitly listed.
 - `::view-transition-group(.class)` — container
 - `::view-transition-image-pair(.class)` — old + new pair
 
+See the CSS Animation Recipes section below for ready-to-use animation recipes.
+
 ---
 
 ## Transition Types
 
-Tag transitions with `addTransitionType` so VTs can pick different animations. Call it multiple times to stack types — different VTs in the tree react to different types:
+Tag transitions with `addTransitionType` so VTs can pick different animations based on context. Call it multiple times to stack types — different VTs in the tree react to different types:
 
 ```jsx
 startTransition(() => {
@@ -155,7 +209,7 @@ startTransition(() => {
 });
 ```
 
-Map types to CSS classes. Works on `enter`, `exit`, **and** `share`:
+Pass an object to map types to CSS classes. Works on `enter`, `exit`, **and** `share`:
 
 ```jsx
 <ViewTransition
@@ -178,11 +232,27 @@ Map types to CSS classes. Works on `enter`, `exit`, **and** `share`:
 >
 ```
 
-**TypeScript:** `ViewTransitionClassPerType` requires a `default` key.
+**TypeScript:** `ViewTransitionClassPerType` requires a `default` key in the object.
+
+For apps with multiple pages, extract the type-keyed VT into a reusable wrapper:
+
+```jsx
+export function DirectionalTransition({ children }: { children: React.ReactNode }) {
+  return (
+    <ViewTransition
+      enter={{ 'nav-forward': 'nav-forward', 'nav-back': 'nav-back', default: 'none' }}
+      exit={{ 'nav-forward': 'nav-forward', 'nav-back': 'nav-back', default: 'none' }}
+      default="none"
+    >
+      {children}
+    </ViewTransition>
+  );
+}
+```
 
 ### `router.back()` and Browser Back Button
 
-`router.back()` and the browser's back/forward buttons do **not** trigger view transitions (`popstate` is synchronous, incompatible with `startViewTransition`). Use `router.push()` with an explicit URL instead.
+`router.back()` and the browser's back/forward buttons do **not** animate: React renders transitions scheduled during a `popstate` event synchronously (`shouldAttemptEagerTransition`) to keep back/forward instant, and synchronous renders skip view transitions. Traversals also carry no transition types, so type-keyed maps resolve to their `default`. Use `router.push()` with an explicit URL instead.
 
 ### Types and Suspense
 
@@ -199,15 +269,16 @@ Same `name` on two VTs — one unmounting, one mounting — creates a shared ele
   <img src="/thumb.jpg" onClick={() => startTransition(() => onSelect())} />
 </ViewTransition>
 
-// Other view — same name
+// On the other view — same name
 <ViewTransition name="hero-image">
   <img src="/full.jpg" />
 </ViewTransition>
 ```
 
-- Only one VT with a given `name` can be mounted at a time — use unique names. Watch for reusable components: if a component with a named VT is rendered in both a modal/popover *and* a page, both mount simultaneously and break the morph. Either make the name conditional (via a prop) or move the named VT out of the shared component into the specific consumer.
-- `share` takes precedence over `enter`/`exit`. Think through each navigation path: when no pair forms, `enter`/`exit` fires instead. Consider whether the element needs a fallback animation for those paths.
-- Never use fade-out exit on pages with shared morphs — use directional slide.
+- Only one VT with a given `name` can be mounted at a time — use unique names (`photo-${id}`). Watch for reusable components: if a component with a named VT is rendered in both a modal/popover *and* a page, both mount simultaneously and break the morph. Either make the name conditional (via a prop) or move the named VT out of the shared component into the specific consumer.
+- `share` takes precedence over `enter`/`exit`. Think through each navigation path: when no matching pair forms (e.g., the target page doesn't have the same name), `enter`/`exit` fires instead. Consider whether the element needs a fallback animation for those paths.
+- Two ways a wired-up morph silently never fires: (1) `default="none"` with no explicit `share` prop — share resolves to none; (2) type-keyed `share` where the navigation never adds the type — a plain link click resolves the map's `default`. Every link that should morph must add the type (`transitionTypes` on `next/link`, or `addTransitionType`).
+- Never use a fade-out exit on pages with shared morphs — use a directional slide instead.
 
 ---
 
@@ -231,9 +302,13 @@ Same `name` on two VTs — one unmounting, one mounting — creates a shared ele
 
 Trigger inside `startTransition`. Avoid wrapper `<div>`s between list and VT.
 
+### Layout Displacement Morph
+
+Only content inside an activated boundary animates position — everything else teleports to its new layout spot. Wrap the sibling content below a growing/shrinking list in a bare `<ViewTransition>` so it glides instead of jumping. See the Patterns and Guidelines section below → Layout Displacement Morph.
+
 ### Composing Shared Elements with List Identity
 
-Shared elements and list identity are independent concerns — don't confuse one for the other. When a list item contains a shared element, use two nested `<ViewTransition>` boundaries:
+Shared elements and list identity are independent concerns — don't confuse one for the other. When a list item contains a shared element (e.g., an image that morphs into a detail view), use two nested `<ViewTransition>` boundaries:
 
 ```jsx
 {items.map(item => (
@@ -248,7 +323,7 @@ Shared elements and list identity are independent concerns — don't confuse one
 ))}
 ```
 
-The outer VT handles list reorder/enter. The inner VT handles cross-route shared element morph. Missing either layer means that animation silently doesn't happen.
+The outer VT handles list reorder/enter animations. The inner VT handles the cross-route shared element morph. Missing either layer means that animation silently doesn't happen.
 
 ### Force Re-Enter with `key`
 
@@ -258,7 +333,7 @@ The outer VT handles list reorder/enter. The inner VT handles cross-route shared
 </ViewTransition>
 ```
 
-**Caution:** Wrapping `<Suspense>` with key remounts the boundary and refetches.
+**Caution:** If wrapping `<Suspense>`, changing `key` remounts the boundary and refetches.
 
 ### Suspense Fallback to Content
 
@@ -276,15 +351,19 @@ Directional reveal:
 </Suspense>
 ```
 
+For more patterns, see the Patterns and Guidelines section below.
+
 ---
 
 ## How Multiple VTs Interact
 
-Every VT matching the trigger fires simultaneously in a single `document.startViewTransition`. VTs in **different** transitions don't compete.
+Every VT matching the trigger fires simultaneously in a single `document.startViewTransition`. VTs in **different** transitions (navigation vs later Suspense resolve) don't compete.
 
-### Use `default="none"` Liberally
+### Use `default="none"` Deliberately
 
-Without it, every VT fires the browser cross-fade on **every** transition. Always use `default="none"` and explicitly enable only desired triggers.
+Without it, every VT fires the browser cross-fade on **every** transition — Suspense resolves, `useDeferredValue` updates, background revalidations. Use `default="none"` on named/shared elements and type-keyed page VTs.
+
+But know what it turns off: `default="none"` also disables `update` (layout displacement morphs — list reflow, sections gliding when content above changes) and `share` (a named pair with `default="none"` and no explicit `share` prop silently never morphs). Keyed list items and displaced siblings *want* update — leave them bare or set `update="auto"` explicitly.
 
 ### Two Patterns Coexist
 
@@ -295,47 +374,38 @@ They coexist because they fire at different moments. `default="none"` on both pr
 
 ### Nested VT Limitation
 
-When a parent VT exits, nested VTs inside it do **not** fire their own enter/exit — only the outermost VT animates. Per-item staggered animations during page navigation are not possible today. See [react#36135](https://github.com/facebook/react/pull/36135) for an experimental opt-in fix.
+When a parent VT mounts/unmounts **as one unit** with nested VTs inside it, the nested ones do not fire their own enter/exit — only the outermost VT animates. (A child VT mounted inside a *persistent* parent VT fires enter/exit normally.) Per-item staggered animations during page navigation are not possible today; the experimental opt-in is the `parentEnter`/`parentExit` props ([react#36690](https://github.com/facebook/react/pull/36690), experimental channel only).
 
 ---
 
 ## Next.js Integration
 
-See the [View Transitions in Next.js](#view-transitions-in-nextjs) section below.
+For Next.js setup (`experimental.viewTransition` flag, `transitionTypes` prop on `next/link`, App Router patterns, Server Components), see the View Transitions in Next.js section below.
 
 ---
 
 ## Accessibility
 
-Always add reduced motion CSS to your global stylesheet:
+Always add the reduced motion CSS from the CSS Animation Recipes section below to your global stylesheet.
 
-```css
-@media (prefers-reduced-motion: reduce) {
-  ::view-transition-old(*),
-  ::view-transition-new(*),
-  ::view-transition-group(*) {
-    animation-duration: 0s !important;
-    animation-delay: 0s !important;
-  }
-}
-```
+---
 
 ---
 
 # Implementation Workflow
 
-**Follow these steps in order.** Start with the audit — do not skip it. Copy the CSS recipes from the CSS Recipes section below — do not write your own animation CSS.
+Follow these steps in order when adding view transitions to an app. Each step builds on the previous one.
 
 ## Step 1: Audit the App
 
 Before writing any code, scan the codebase thoroughly. Search for:
 
-- **Every `<Link>` and `router.push`** — open every file that contains one
-- **Every `<Suspense>` boundary** — check what its fallback renders
-- **Every page/route component** — each needs a VT placement decision
-- **Persistent elements** (headers, navbars, sidebars) — need `viewTransitionName` isolation
-- **Shared visual elements** on both source and target views
-- **Skeleton-to-content control pairs** — if a fallback renders a control that also exists in the real content, both need a matching `viewTransitionName`
+- **Every `<Link>` and `router.push`** — these are your navigation triggers. Open every file that contains one.
+- **Every `<Suspense>` boundary** — each one is a candidate for a reveal animation. Check what its fallback renders.
+- **Every page/route component** — list them all. Each page needs a VT placement decision.
+- **Persistent elements** — headers, navbars, sidebars, sticky controls that stay on screen across navigations. These need `viewTransitionName` isolation.
+- **Shared visual elements** — images, cards, or avatars that appear on both a source and target view (e.g., a thumbnail in a list and the same image on a detail page).
+- **Skeleton-to-content control pairs** — if a Suspense fallback renders a control (search input, tab bar) that also exists in the real content, both need a matching `viewTransitionName`.
 
 Then classify every navigation and produce a navigation map:
 
@@ -349,28 +419,29 @@ Then classify every navigation and produce a navigation map:
 | (Suspense)      | (content loads)      | —            | slide-up reveal       |
 ```
 
-For each shared element (`name` prop), note where a pair forms and where it doesn't — this determines whether you need `enter`/`exit` as a fallback alongside `share`.
+For each shared element (`name` prop), note every navigation where a pair forms and where it doesn't — this determines whether you need `enter`/`exit` as a fallback alongside `share`.
 
 ## Step 2: Add CSS Recipes
 
-Copy the **complete** CSS recipe set from the CSS Animation Recipes section below into your global stylesheet. Don't write your own — the recipes handle staggered timing, motion blur, and reduced motion.
+Copy the **complete** CSS recipe set from the CSS Animation Recipes section into your global stylesheet. This includes timing variables, shared keyframes, fade, slide (vertical), directional navigation (forward/back), shared element morph, persistent element isolation, and reduced motion.
+
+Do not write your own animation CSS — the recipes handle staggered timing, motion blur on morphs, and reduced motion that are easy to get wrong. You can customize timing variables (`--duration-exit`, `--duration-enter`, `--duration-move`) after the initial setup.
 
 ## Step 3: Isolate Persistent Elements
+
+For every persistent element identified in Step 1, add a `viewTransitionName` style to pull it out of the page content's transition snapshot:
 
 ```jsx
 <header style={{ viewTransitionName: "site-header" }}>...</header>
 ```
 
-```css
-::view-transition-group(site-header) {
-  animation: none;
-  z-index: 100;
-}
-```
+Then add the persistent element isolation CSS from the CSS Animation Recipes section (prevents the element from animating during page transitions). If the element uses `backdrop-blur` or `backdrop-filter`, use the backdrop-blur workaround from the CSS Animation Recipes section instead.
 
-For `backdrop-blur`/`backdrop-filter`, use the backdrop-blur workaround instead.
+If a Suspense fallback mirrors a persistent control (e.g., a skeleton search input), give both the real control and the skeleton the same `viewTransitionName` so they morph in place.
 
 ## Step 4: Add Directional Page Transitions
+
+For hierarchical navigations identified in Step 1, tag the navigation direction using `addTransitionType` inside `startTransition`:
 
 ```jsx
 startTransition(() => {
@@ -379,19 +450,29 @@ startTransition(() => {
 });
 ```
 
-Wrap each **page component** (not layout) in a type-keyed VT:
+Then wrap each **page component** (not layout) in a type-keyed `<ViewTransition>`:
 
 ```jsx
 <ViewTransition
-  enter={{ "nav-forward": "nav-forward", "nav-back": "nav-back", default: "none" }}
-  exit={{ "nav-forward": "nav-forward", "nav-back": "nav-back", default: "none" }}
+  enter={{
+    "nav-forward": "nav-forward",
+    "nav-back": "nav-back",
+    default: "none",
+  }}
+  exit={{
+    "nav-forward": "nav-forward",
+    "nav-back": "nav-back",
+    default: "none",
+  }}
   default="none"
 >
   <div>...page content...</div>
 </ViewTransition>
 ```
 
-Extract into a reusable component so every page doesn't repeat the type map:
+The `nav-forward` and `nav-back` CSS classes from the CSS Animation Recipes section produce horizontal slides. For simpler apps where directional motion isn't needed, a bare `<ViewTransition default="none">` wrapper with `enter="fade-in"` / `exit="fade-out"` works too.
+
+Extract this into a reusable component so every page doesn't repeat the verbose type map:
 
 ```jsx
 export function DirectionalTransition({ children }: { children: React.ReactNode }) {
@@ -407,82 +488,102 @@ export function DirectionalTransition({ children }: { children: React.ReactNode 
 }
 ```
 
-**Rules:** Always pair `enter` with `exit`. Always include `default: "none"`. Place in page components, not layouts. Only use directional slides for hierarchical navigation or ordered sequences (prev/next).
+This also becomes the single place to adjust if you add new transition types later.
+
+**Rules:**
+- Always pair `enter` with `exit` — without an exit animation, the old page disappears instantly while the new one animates in.
+- Always include `default: "none"` in type map objects and `default="none"` on the component — otherwise it fires on every transition.
+- Place the directional `<ViewTransition>` in each page component, not in a layout. Layouts persist across navigations and never trigger enter/exit.
+- Only use directional slides for hierarchical navigation or ordered sequences (prev/next). Lateral/sibling navigation (tab-to-tab) should use a bare `<ViewTransition>` (cross-fade) or `default="none"`.
 
 ## Step 5: Add Suspense Reveals
 
+For every `<Suspense>` boundary identified in Step 1, wrap the fallback and content in separate `<ViewTransition>`s:
+
 ```jsx
-<Suspense fallback={<ViewTransition exit="slide-down"><Skeleton /></ViewTransition>}>
-  <ViewTransition enter="slide-up" default="none"><AsyncContent /></ViewTransition>
+<Suspense
+  fallback={
+    <ViewTransition exit="slide-down">
+      <Skeleton />
+    </ViewTransition>
+  }
+>
+  <ViewTransition enter="slide-up" default="none">
+    <AsyncContent />
+  </ViewTransition>
 </Suspense>
 ```
 
-Use `default="none"` on content VT. Use simple string props (not type maps) — Suspense resolves have no type.
+This example uses `slide-down` / `slide-up` for directional vertical motion. For a simpler reveal, a bare `<ViewTransition>` around the `<Suspense>` gives a cross-fade with zero configuration. Choose based on the spatial meaning — consult the "Choosing the Right Animation Style" table in the main skill file.
+
+**Rules:**
+- Always use `default="none"` on the content `<ViewTransition>` to prevent re-animation on revalidation or unrelated transitions.
+- Use simple string props (not type maps) on Suspense `<ViewTransition>`s — Suspense resolves fire as separate transitions with no type, so type-keyed props won't match.
+- If the same element appears in **both** the fallback and the content (a title, a heading), it flickers on reveal — an opacity dip. Render it **outside** the `<Suspense>` boundary (or pin it), so it isn't in both. See "Suspense reveal flicker" in the Patterns and Guidelines section.
 
 ## Step 6: Add Shared Element Transitions
 
+For every shared visual element identified in Step 1, add matching named `<ViewTransition>` wrappers on both the source and target views:
+
 ```jsx
-// Source view
+// On the source view (e.g., list/grid page)
 <ViewTransition name={`photo-${photo.id}`} share="morph" default="none">
   <Image src={photo.src} ... />
 </ViewTransition>
 
-// Target view — same name
+// On the target view (e.g., detail page) — same name
 <ViewTransition name={`photo-${photo.id}`} share="morph">
   <Image src={photo.src} ... />
 </ViewTransition>
 ```
 
-When list items contain shared elements, compose both patterns — two independent layers:
+The `share="morph"` class uses the morph recipe from the CSS Animation Recipes section (controlled duration + motion blur). For a simpler cross-fade, use `share="auto"` (browser default).
 
-```jsx
-{items.map(item => (
-  <ViewTransition key={item.id}>                                        {/* list identity */}
-    <Link href={`/detail/${item.id}`}>
-      <ViewTransition name={`item-${item.id}`} share="morph" default="none">  {/* shared element */}
-        <Image src={item.image} ... />
-      </ViewTransition>
-    </Link>
-  </ViewTransition>
-))}
-```
+When list items contain shared elements, compose both patterns with two nested `<ViewTransition>` layers — see "Composing Shared Elements with List Identity" in `SKILL.md`.
 
-The outer VT handles list reorder/enter. The inner VT handles cross-route shared element morph. Missing either layer means that animation silently doesn't happen.
-
-**Rules:** Names must be globally unique. Add `default="none"` on list-side shared elements.
+**Rules:**
+- Names must be globally unique — use prefixes like `photo-${id}`.
+- Add `default="none"` on list-side shared elements to prevent per-item cross-fades on filter/search updates.
+- The target must be **in the DOM at navigation time** for the pair to form. If it's behind a Suspense fallback (not rendered yet), no pair forms and it won't morph. It works when the target is present at the snapshot — render it above the data boundary, or have its data **cached/prefetched** so it resolves in time.
 
 ## Step 7: Verify Each Navigation Path
 
-Walk through every row in the navigation map from Step 1:
+Walk through every row in the navigation map from Step 1 and confirm:
 
-- Does the VT mount/unmount, or stay mounted (same-route)?
+- Does the VT mount/unmount on this navigation, or does it stay mounted (same-route)?
 - For named VTs: does a shared pair form? If not, does `enter`/`exit` provide a fallback?
 - Does `default="none"` block an animation you actually want?
-- Do persistent elements stay static?
+- Do persistent elements stay static (not sliding with page content)?
 - Do Suspense reveals animate independently from directional navigations?
+
+If any path produces no animation or competing animations, revisit the relevant step.
 
 ---
 
 ## Common Mistakes
 
-- **Bare VT without `default="none"`** — fires cross-fade on every transition
-- **Directional VT in a layout** — layouts persist, enter/exit won't fire on route changes
-- **Fade-out exit with shared morphs** — conflicts with morph, use directional slide
-- **Writing custom animation CSS** — use the recipes
-- **Missing `default: "none"` in type-keyed objects** — TypeScript requires it, fallback is `"auto"`
-- **Type maps on Suspense reveals** — Suspense resolves have no type, use string props
-- **Raw `viewTransitionName` CSS to trigger animations** — React only starts view transitions when `<ViewTransition>` components are in the tree. Bare `viewTransitionName` is for isolating elements, not triggering animations.
-- **`update` trigger for same-route navigations** — nested VTs steal the mutation from the parent. Use `key` + `name` + `share` instead.
+- **Bare `<ViewTransition>` without props** — without `default="none"`, it fires the browser's default cross-fade on every transition (every navigation, every Suspense resolve, every revalidation). Always set `default="none"` and explicitly enable only the triggers you want.
+- **Directional `<ViewTransition>` in a layout** — layouts persist across navigations and never unmount/remount. `enter`/`exit` props won't fire on route changes. Place the outer type-keyed `<ViewTransition>` in each page component.
+- **Fade-out exit with shared element morphs** — the page dissolving conflicts with the morph. Use a directional slide exit instead.
+- **Writing custom animation CSS** — the recipes in the CSS Animation Recipes section handle staggered timing, motion blur on morphs, and reduced motion. Copy them; don't reinvent them.
+- **Missing `default: "none"` in type-keyed objects** — TypeScript requires a `default` key, and without it the fallback is `"auto"` which fires on every transition.
+- **Type maps on Suspense reveals** — Suspense resolves fire as separate transitions with no type. Type-keyed props won't match — use simple string props instead.
+- **Raw `viewTransitionName` CSS to trigger animations** — React only calls `document.startViewTransition` when `<ViewTransition>` components are in the tree. A bare `viewTransitionName` style is for isolating elements from a parent's snapshot, not for triggering animations.
+- **`update` trigger for same-route navigations** — nested VTs inside the content steal the mutation from the parent, so `update` never fires on the outer VT. Use `key` + `name` + `share` instead.
 - **Named VT in a reusable component** — if a component with a named VT is rendered in both a modal/popover *and* a page, both mount simultaneously and break the morph. Make the name conditional or move it to the specific consumer.
-- **`router.back()` for back navigation** — `router.back()` triggers synchronous `popstate`, incompatible with view transitions. Use `router.push()` with an explicit URL.
+- **`router.back()` for back navigation** — React renders `popstate`-scheduled transitions synchronously (skipping view transitions), and traversals carry no transition types. Use `router.push()` with an explicit URL.
 
-For Next.js-specific steps, see the Next.js section below.
+---
+
+For Next.js-specific implementation steps (config flag, `transitionTypes` on `<Link>`, same-route dynamic segments), see the View Transitions in Next.js section.
 
 ---
 
 # Patterns and Guidelines
 
 ## Searchable Grid with `useDeferredValue`
+
+`useDeferredValue` makes filter updates a transition, activating `<ViewTransition>`:
 
 ```tsx
 'use client';
@@ -506,9 +607,19 @@ export default function SearchableGrid({ itemsPromise }) {
 }
 ```
 
-Per-item named VTs in deferred lists trigger cross-fades on every keystroke. Fix with `default="none"`.
+Per-item `<ViewTransition name={...}>` inside a deferred list triggers cross-fades on every keystroke. Fix with `default="none"`:
+
+```tsx
+{filteredItems.map(item => (
+  <ViewTransition key={item.id} name={`item-${item.id}`} share="morph" default="none">
+    <ItemCard item={item} />
+  </ViewTransition>
+))}
+```
 
 ## Card Expand/Collapse with `startTransition`
+
+Toggle between grid and detail view with shared element morph:
 
 ```tsx
 'use client';
@@ -549,58 +660,166 @@ export default function ItemGrid({ items }) {
 }
 ```
 
+## Type-Safe Transition Helpers
+
+Use `as const` arrays and derived types to prevent ID clashes:
+
+```tsx
+const transitionTypes = ['default', 'transition-to-detail', 'transition-to-list'] as const;
+const animationTypes = ['auto', 'none', 'animate-slide-from-left', 'animate-slide-from-right'] as const;
+
+type TransitionType = (typeof transitionTypes)[number];
+type AnimationType = (typeof animationTypes)[number];
+type TransitionMap = { default: AnimationType } & Partial<Record<Exclude<TransitionType, 'default'>, AnimationType>>;
+
+export function HorizontalTransition({ children, enter, exit }: {
+  children: React.ReactNode;
+  enter: TransitionMap;
+  exit: TransitionMap;
+}) {
+  return <ViewTransition enter={enter} exit={exit}>{children}</ViewTransition>;
+}
+```
+
 ## Cross-Fade Without Remount
 
-Omit `key` to trigger update (cross-fade) instead of exit + enter. Avoids Suspense remount:
+Omit `key` to trigger an update (cross-fade) instead of exit + enter. Avoids Suspense remount/refetch:
 
 ```jsx
-<ViewTransition><TabPanel tab={activeTab} /></ViewTransition>
+<ViewTransition>
+  <TabPanel tab={activeTab} />
+</ViewTransition>
 ```
+
+Use `key` when content identity changes (state resets). Omit for cross-fades (tabs, panels, carousel).
 
 ## Isolate Elements from Parent Animations
 
-Persistent elements get captured in page's transition snapshot. Fix with `viewTransitionName`:
+Pull an element out of the animated `root` snapshot by giving it its own `view-transition-name`. **`view-transition-name: none` is a no-op** — it's the CSS default, so the element stays in `root` (a common flicker bug). Use a real, unique name, then neutralize with `<ViewTransition default="none">` (no CSS) or CSS (needed for `z-index`/`display` control — see the CSS Animation Recipes section).
+
+- **Persistent chrome** (nav, sidebar, player bar): `<nav style={{ viewTransitionName: 'persistent-nav' }}>` + isolation CSS. `<ViewTransition default="none">` works too, but its auto-name can't take `z-index`/backdrop `display:none` — hand-name when you need those.
+- **Floating elements** (popovers, menus): left open, they're captured in `root` and flicker on settle. Real name + isolation (the CSS Animation Recipes section → Floating Element Isolation). A static name is fine if only one is mounted (`unmountOnHide`); native top-layer (`popover`/`<dialog>`) settle-flicker is a browser limit.
+- **Naming an interactive element has a cost:** named participants are skipped by hit-testing while a transition runs — hover, cursor, and clicks fall through to whatever is beneath for the transition's duration (spec behavior; [csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)). Always **portal** a named popover/menu so those fallback hits stay inside its own subtree: rendered inline in a clickable row, mid-transition clicks hover/activate the row behind it, and outside-click detection closes the popover.
+
+## Suspense reveal flicker
+
+An element rendered in **both** the fallback and the content flickers (opacity dip) on reveal — it fades against itself. Not a morph. **Fix: render it outside the `<Suspense>` boundary** (mount once, above it), or pin it with a `view-transition-name`.
 
 ```jsx
-<nav style={{ viewTransitionName: "persistent-nav" }}>{/* ... */}</nav>
+<h1>{title}</h1>
+<Suspense fallback={<BodySkeleton />}><Body /></Suspense>
 ```
 
-```css
-::view-transition-group(persistent-nav) { animation: none; z-index: 100; }
+Don't put a manual `viewTransitionName` on the root DOM node inside `<ViewTransition>` — React's auto-name overrides it.
+
+## Sliding Indicator (tabs)
+
+One shared-name indicator rendered under the **active** tab morphs between positions on change (slide the group, disable old/new — see the CSS Animation Recipes section → Sliding Indicator). Render it only under the active tab so exactly one element holds `indicatorName`; use a distinct `indicatorName` per tab strip. Trigger the state change inside `startTransition` so the move animates. Whatever owns `active` drives it — local state here, routing in Next (see the View Transitions in Next.js section → Routing-Driven Tabs).
+
+```tsx
+import { useState, useTransition, ViewTransition } from 'react';
+
+export function Tabs({ tabs, indicatorName = 'tab-indicator' }) {
+  const [active, setActive] = useState(tabs[0].value);
+  const [, startTransition] = useTransition();
+  return (
+    <nav>
+      {tabs.map(t => (
+        <button key={t.value} type="button"
+          aria-current={active === t.value ? 'page' : undefined}
+          onClick={() => startTransition(() => setActive(t.value))}>
+          <span>{t.label}</span>
+          {active === t.value && (
+            <ViewTransition name={indicatorName} share="tab-underline">
+              <span className="active-underline" aria-hidden />
+            </ViewTransition>
+          )}
+        </button>
+      ))}
+    </nav>
+  );
+}
 ```
 
-Same for floating elements (popovers, tooltips). Global fix: `::view-transition-group(*) { z-index: 100; }`
+Because the state change is a transition, if the newly-active tab renders suspending content the whole update — indicator **and** `aria-current` — waits for it to commit, and the strip feels dead on click. Give the controls an immediate value with `useOptimistic` (drive `aria-current` from it) so feedback is instant while the content streams. The routing variant (the View Transitions in Next.js section → Routing-Driven Tabs) does exactly this: optimistic `aria-current`, committed `active` for the bar.
 
-## Shared Controls Between Skeleton and Content
+## Layout Displacement Morph
 
-Give matching controls the same `viewTransitionName`. Don't put manual `viewTransitionName` on root DOM node inside `<ViewTransition>`.
+Only content inside an activated boundary animates position — everything else teleports to its new layout spot. When a list grows or shrinks, wrap the sibling content below it so it glides instead of jumping:
+
+```jsx
+<FavoritesList />              {/* rows enter/exit */}
+<ViewTransition>               {/* bare: update enabled */}
+  <section>
+    <h2>You Might Also Like</h2>
+    <Recommendations />
+  </section>
+</ViewTransition>
+```
+
+The section — heading included — morphs as one group when rows above are added or removed. Nothing inside the section changed; the *displacement* is the update.
+
+- React activates VT boundaries that are direct children (not behind an intermediate DOM node) of nodes along the changed path — siblings of the mutation and of its ancestors qualify; a VT buried under an extra wrapper element in a sibling does not (deliberate: page-wide re-layout would otherwise fire noisy animations everywhere). Place the boundary as a direct sibling of the changing content.
+- `default="none"` disables exactly this morph — it turns off `update`. Named/shared elements get `default="none"`; displaced siblings and keyed list items stay bare or set `update="auto"`.
 
 ## Reusable Animated Collapse
 
 ```jsx
 function AnimatedCollapse({ open, children }) {
   if (!open) return null;
-  return <ViewTransition enter="expand-in" exit="collapse-out">{children}</ViewTransition>;
+  return (
+    <ViewTransition enter="expand-in" exit="collapse-out">
+      {children}
+    </ViewTransition>
+  );
 }
+
+// Usage: toggle with startTransition
+<button onClick={() => startTransition(() => setOpen(o => !o))}>Toggle</button>
+<AnimatedCollapse open={open}><SectionContent /></AnimatedCollapse>
 ```
 
-## Preserve State with Activity
+## Composing with Activity
+
+`Activity` is orthogonal to view transitions: it preserves the state of a hidden subtree, `ViewTransition` animates it. Compose them for an in-page show/hide (drawer, panel, tab body) that keeps its scroll/form state while it animates in and out:
 
 ```jsx
 <Activity mode={isVisible ? 'visible' : 'hidden'}>
-  <ViewTransition enter="slide-in" exit="slide-out"><Sidebar /></ViewTransition>
+  <ViewTransition enter="slide-in" exit="slide-out">
+    <Sidebar />
+  </ViewTransition>
 </Activity>
 ```
 
+Only reach for Activity when there's state worth preserving — a stateless element (e.g. the sliding indicator above) gains nothing from it. In Next.js, layout-hosted chrome already persists across navigations without Activity (see the View Transitions in Next.js section).
+
 ## Exclude Elements with `useOptimistic`
 
-`useOptimistic` values update before snapshot, excluding them from animation. Use for controls; use committed state for animated content.
+`useOptimistic` values update before the transition snapshot, excluding them from animation. Use for controls (labels); use committed state for animated content:
+
+```tsx
+const [sort, setSort] = useState('newest');
+const [optimisticSort, setOptimisticSort] = useOptimistic(sort);
+
+function cycleSort() {
+  const nextSort = getNextSort(optimisticSort);
+  startTransition(() => {
+    setOptimisticSort(nextSort);  // before snapshot — no animation
+    setSort(nextSort);            // between snapshots — animates
+  });
+}
+
+<button>Sort: {LABELS[optimisticSort]}</button>
+{items.sort(comparators[sort]).map(item => (
+  <ViewTransition key={item.id}><ItemCard item={item} /></ViewTransition>
+))}
+```
 
 ---
 
 ## View Transition Events
 
-Imperative control via `onEnter`, `onExit`, `onUpdate`, `onShare`. Always return cleanup. `onShare` takes precedence.
+Imperative control via `onEnter`, `onExit`, `onUpdate`, `onShare`. Return a cleanup function to cancel your animation when the transition finishes. `onShare` takes precedence over `onEnter`/`onExit`.
 
 ```jsx
 <ViewTransition
@@ -616,7 +835,9 @@ Imperative control via `onEnter`, `onExit`, `onUpdate`, `onShare`. Always return
 </ViewTransition>
 ```
 
-`instance`: `.old`, `.new`, `.group`, `.imagePair`, `.name`
+The `instance` object: `instance.old`, `instance.new`, `instance.group`, `instance.imagePair`, `instance.name`.
+
+The `types` array (second argument) lets you vary animation based on transition type.
 
 ---
 
@@ -624,38 +845,58 @@ Imperative control via `onEnter`, `onExit`, `onUpdate`, `onShare`. Always return
 
 | Interaction | Duration |
 |------------|----------|
-| Direct toggle | 100–200ms |
-| Route transition | 150–250ms |
-| Suspense reveal | 200–400ms |
+| Direct toggle (expand/collapse) | 100–200ms |
+| Route transition (slide) | 150–250ms |
+| Suspense reveal (skeleton → content) | 200–400ms |
 | Shared element morph | 300–500ms |
 
 ---
 
 ## Troubleshooting
 
-**VT not activating:** Ensure VT comes before any DOM node. Ensure `startTransition`.
+**VT not activating:** Ensure `<ViewTransition>` comes before any DOM node. Ensure state update is inside `startTransition`.
 
-**"Two VTs with same name":** Names must be globally unique. Use IDs.
+**"Two ViewTransition components with the same name":** Names must be globally unique. Use IDs: `name={`hero-${item.id}`}`.
 
-**`router.back()` and browser back/forward skip animation:** Use `router.push()` with an explicit URL instead.
+**Scrolling hangs while a transition animates:** the `::view-transition` overlay is `position: fixed` and its snapshots don't scroll — a browser limitation, not fixable in React (skipping snaps to the end). Keep reveal durations short; for scroll-driven UI use gesture transitions (experimental `useSwipeTransition`, if available).
 
-**Only updates animate:** Without `<Suspense>`, React treats swaps as updates. Conditionally render the VT itself, or wrap in `<Suspense>`.
+**Open popover flickers when a background transition settles:** it's captured in `root`. Give it a real `view-transition-name` + isolation (not `none`) — see "Floating Elements".
 
-**Layout VT prevents page VTs from animating:** Nested VTs never fire enter/exit inside a parent VT. If your layout has a VT wrapping `{children}`, page-level enter/exit will silently not work. Remove the layout VT.
+**Popover closes or goes dead when clicked mid-transition:** named participants are skipped by hit-testing while a transition runs; clicks land on what's beneath and read as outside-clicks. Portal the popover (see "Isolate Elements from Parent Animations"); brief dead clicks during the transition remain — that's the price of the name.
+
+**Shared morph silently not firing:** `share` resolved to `none`. Either the VT has `default="none"` with no explicit `share` prop, or `share` is type-keyed and the navigation never adds the type — the link needs `transitionTypes` (or `addTransitionType` in the transition).
+
+**Section below a list teleports instead of gliding:** it's outside any activated boundary, its VT has `default="none"` (which disables `update`), or it isn't an immediate sibling of the changing content. See "Layout Displacement Morph" above.
+
+**`router.back()` and browser back/forward skip animation:** React renders `popstate`-scheduled transitions synchronously (skipping view transitions), and traversals carry no transition types. Use `router.push()` with an explicit URL instead. See SKILL.md "router.back() and Browser Back Button."
+
+**`flushSync` skips animations:** Use `startTransition` instead.
+
+**Only updates animate (no enter/exit):** Without `<Suspense>`, React treats swaps as updates. Conditionally render the VT itself, or wrap in `<Suspense>`.
+
+**Layout VT prevents page VTs from animating:** nested VTs don't fire their own enter/exit when they mount/unmount *as one unit* with a parent VT — only the outermost animates. (A child VT swapped inside a persistent parent fires normally; if page enter/exit is dead under a persistent layout VT, check the page VT isn't below a plain DOM node instead.) If your layout has a VT wrapping `{children}`, remove it and put VTs in pages.
+
+**List reorder not animating with `useOptimistic`:** Optimistic values resolve before snapshot. Use committed state for list order.
 
 **TS error "Property 'default' is missing":** Type-keyed objects require a `default` key.
 
-**Backdrop-blur flickers:** `::view-transition-old(name) { display: none }` + `::view-transition-new(name) { animation: none }`.
+**Hash fragments cause scroll jumps:** Navigate without hash; scroll programmatically after navigation.
 
-**`border-radius` lost:** Apply `border-radius` directly to captured element.
+**Backdrop-blur flickers:** Use the backdrop-blur workaround from the CSS Animation Recipes section.
 
-**Batching:** Multiple updates during animation are batched (A→B→C→D becomes B→D).
+**`border-radius` lost during transitions:** Apply `border-radius` directly to the captured element.
+
+**Skeleton controls slide away:** Give matching controls the same `viewTransitionName`.
+
+**Batching:** Multiple updates during animation are batched. A→B→C→D becomes B→D.
 
 ---
 
 # CSS Animation Recipes
 
-Ready-to-use CSS for `<ViewTransition>` props. Copy into global stylesheet.
+Ready-to-use CSS for `<ViewTransition>` props. Copy into your global stylesheet.
+
+---
 
 ## Timing Variables
 
@@ -686,6 +927,8 @@ Ready-to-use CSS for `<ViewTransition>` props. Copy into global stylesheet.
 }
 ```
 
+---
+
 ## Fade
 
 ```css
@@ -696,6 +939,10 @@ Ready-to-use CSS for `<ViewTransition>` props. Copy into global stylesheet.
   animation: var(--duration-enter) ease-out var(--duration-exit) both fade;
 }
 ```
+
+Usage: `<ViewTransition enter="fade-in" exit="fade-out" />`
+
+---
 
 ## Slide (Vertical)
 
@@ -712,37 +959,16 @@ Ready-to-use CSS for `<ViewTransition>` props. Copy into global stylesheet.
 }
 ```
 
-## Directional Navigation
-
-### Single-Class Approach
-
-```css
-::view-transition-old(.nav-forward) {
-  --slide-offset: -60px;
-  animation:
-    var(--duration-exit) ease-in both fade reverse,
-    var(--duration-move) ease-in-out both slide reverse;
-}
-::view-transition-new(.nav-forward) {
-  --slide-offset: 60px;
-  animation:
-    var(--duration-enter) ease-out var(--duration-exit) both fade,
-    var(--duration-move) ease-in-out both slide;
-}
-
-::view-transition-old(.nav-back) {
-  --slide-offset: 60px;
-  animation:
-    var(--duration-exit) ease-in both fade reverse,
-    var(--duration-move) ease-in-out both slide reverse;
-}
-::view-transition-new(.nav-back) {
-  --slide-offset: -60px;
-  animation:
-    var(--duration-enter) ease-out var(--duration-exit) both fade,
-    var(--duration-move) ease-in-out both slide;
-}
+Usage:
+```jsx
+<Suspense fallback={<ViewTransition exit="slide-down"><Skeleton /></ViewTransition>}>
+  <ViewTransition default="none" enter="slide-up"><Content /></ViewTransition>
+</Suspense>
 ```
+
+---
+
+## Directional Navigation
 
 ### Separate Enter/Exit Classes
 
@@ -774,19 +1000,55 @@ Ready-to-use CSS for `<ViewTransition>` props. Copy into global stylesheet.
 }
 ```
 
+### Single-Class Approach
+
+```css
+::view-transition-old(.nav-forward) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+::view-transition-new(.nav-forward) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+
+::view-transition-old(.nav-back) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+::view-transition-new(.nav-back) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+```
+
+---
+
 ## Shared Element Morph
 
 ```css
 ::view-transition-group(.morph) {
   animation-duration: var(--duration-move);
 }
+
 ::view-transition-image-pair(.morph) {
   animation-name: via-blur;
 }
+
 @keyframes via-blur {
   30% { filter: blur(3px); }
 }
 ```
+
+Usage: `<ViewTransition name={`product-${id}`} share="morph" />`
 
 **Note:** Shared element transitions take raster snapshots. For text with significant size differences (e.g., `<h3>` → `<h1>`), the old snapshot gets scaled up, producing a visible ghost artifact. Use `text-morph` for text shared elements.
 
@@ -808,6 +1070,10 @@ Avoids raster scaling artifacts on text by hiding the old snapshot and showing t
 }
 ```
 
+Usage: `<ViewTransition name={`title-${id}`} share="text-morph" />`
+
+---
+
 ## Scale
 
 ```css
@@ -817,6 +1083,7 @@ Avoids raster scaling artifacts on text by hiding the old snapshot and showing t
 ::view-transition-new(.scale-in) {
   animation: var(--duration-enter) ease-out var(--duration-exit) both scale-up;
 }
+
 @keyframes scale-down {
   from { transform: scale(1); opacity: 1; }
   to { transform: scale(0.85); opacity: 0; }
@@ -826,6 +1093,24 @@ Avoids raster scaling artifacts on text by hiding the old snapshot and showing t
   to { transform: scale(1); opacity: 1; }
 }
 ```
+
+Usage: `<ViewTransition enter="scale-in" exit="scale-out" />`
+
+---
+
+## Interactivity During Transitions
+
+The `::view-transition` overlay covers the viewport and captures all pointer events by default. React partially handles this: when the root group doesn't need to animate, it shrinks the overlay to zero size so the page stays interactive — but it deliberately leaves `pointer-events` alone so in-flight animations still block clicks (so they don't land on whatever is beneath a moving snapshot). To let clicks and hover pass through even while animations run:
+
+```css
+::view-transition {
+  pointer-events: none;
+}
+```
+
+Trade-off: clicks during an animation can now hit live elements underneath still-moving snapshots. And it only restores interactivity for **unnamed** content — elements participating in the transition (anything with a `view-transition-name`) are skipped by hit-testing for the transition's duration, spec behavior with no CSS override ([csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)). Weigh that cost before naming interactive elements, and portal named popovers (see the Patterns and Guidelines section → Isolate Elements from Parent Animations).
+
+---
 
 ## Persistent Element Isolation
 
@@ -838,10 +1123,49 @@ Avoids raster scaling artifacts on text by hiding the old snapshot and showing t
 
 ### Backdrop-Blur Workaround
 
+For elements with `backdrop-filter`, hide the old snapshot to avoid flash:
+
 ```css
-::view-transition-old(persistent-nav) { display: none; }
-::view-transition-new(persistent-nav) { animation: none; }
+::view-transition-old(persistent-nav) {
+  display: none;
+}
+::view-transition-new(persistent-nav) {
+  animation: none;
+}
 ```
+
+### Floating Element Isolation (popovers, menus, tooltips, control clusters)
+
+Same freeze as persistent chrome. A floating/interactive element left rendered while a background transition runs is otherwise captured in the `root` snapshot and flickers as it settles. Give it a real, unique `view-transition-name` (never `none` — that's the CSS default = no isolation) and:
+
+```css
+::view-transition-group(popover) {
+  animation: none;
+  z-index: 100;
+}
+::view-transition-old(popover),
+::view-transition-new(popover) {
+  animation: none;
+}
+```
+
+### Sliding Indicator (tab underline / segmented pill)
+
+One shared-name indicator morphs between positions. Slide the group; disable old/new so the solid bar slides instead of cross-fading:
+
+```css
+::view-transition-group(.tab-underline) {
+  animation-duration: 220ms;
+  animation-timing-function: cubic-bezier(0.5, 0, 0.2, 1);
+}
+::view-transition-old(.tab-underline),
+::view-transition-new(.tab-underline) {
+  animation: none;
+  height: 100%;
+}
+```
+
+---
 
 ## Reduced Motion
 
@@ -862,45 +1186,136 @@ Avoids raster scaling artifacts on text by hiding the old snapshot and showing t
 
 ## Setup
 
+`<ViewTransition>` works out of the box — the bundled React canary ships it, and every `<Link>` navigation already runs inside `React.startTransition`, so react-dom starts a view transition whenever affected `<ViewTransition>` components exist. The documented flag:
+
 ```js
 // next.config.js
-experimental: { viewTransition: true }
+const nextConfig = {
+  experimental: { viewTransition: true },
+};
+module.exports = nextConfig;
 ```
 
-Wraps every `<Link>` navigation in `document.startViewTransition`. Use `default="none"` to prevent competing animations. Do **not** install `react@canary` — the App Router already bundles it.
+Historically this switched the bundled React to the experimental channel; in current Next.js (16.2+) it gates nothing at runtime, but set it anyway to match the documented setup. Because every link click is a transition, any VT with `default="auto"` fires on **every** navigation — use `default="none"` to prevent competing animations.
+
+Do **not** install `react@canary` — see "Availability" for details.
+
+---
 
 ## Next.js Implementation Additions
 
-**After Step 2:** Enable the experimental flag.
+When following the Implementation Workflow section, apply these additions:
 
-**Step 4:** Use `transitionTypes` on `<Link>` (if available — see availability note below):
-```tsx
-<Link href="/photo/1" transitionTypes={["nav-forward"]}>View</Link>
-<Link href="/" transitionTypes={["nav-back"]}>Back</Link>
-```
+**After Step 2:** Enable the experimental flag above.
 
-**After Step 6:** For same-route dynamic segments, use `key` + `name` + `share` pattern.
+**Step 4:** Use `transitionTypes` on `<Link>` — see "The `transitionTypes` Prop" section below for usage and availability.
+
+**After Step 6:** For same-route dynamic segments (e.g., `/collection/[slug]`), use the `key` + `name` + `share` pattern — see Same-Route Dynamic Segment Transitions below.
+
+---
 
 ## Layout-Level ViewTransition
 
-Don't add a layout-level VT wrapping `{children}` if pages have their own VTs — nested VTs never fire enter/exit inside a parent VT, so page-level enter/exit will silently not work. Remove the layout VT entirely. A bare VT in layout works only if pages have no VTs of their own. Layouts persist across navigations — don't use type-keyed maps in layouts.
+**Do NOT add a layout-level VT wrapping `{children}` if pages have their own VTs.** Nested VTs never fire enter/exit when inside a parent VT — page-level enter/exit will silently not work. Remove the layout VT entirely.
 
-## The `transitionTypes` Prop
+A bare `<ViewTransition>` in layout works only if pages have **no** VTs of their own.
 
-Works in Server Components, no wrapper needed:
+**Layouts persist across navigations** — `enter`/`exit` only fire on initial mount, not on route changes. Don't use type-keyed maps in layouts. Because layouts persist, chrome hosted in one (nav, sidebar, player) keeps its state across navigations for free — no `Activity` needed. Reserve `Activity` for in-page show/hide (see the Patterns and Guidelines section → Composing with Activity).
+
+---
+
+## The `transitionTypes` Prop on `next/link`
+
+No wrapper component needed, works in Server Components:
+
 ```tsx
-<Link href="/products/1" transitionTypes={['nav-forward']}>View</Link>
+<Link href="/products/1" transitionTypes={['transition-to-detail']}>View Product</Link>
 ```
 
-**Availability:** Requires `experimental.viewTransition: true`. Available in Next.js 15+ canary builds and Next.js 16+. If unavailable, use `startTransition` + `addTransitionType` + `router.push()`. To check: `grep -r "transitionTypes" node_modules/next/dist/`. Reserve manual `startTransition` for non-link interactions.
+Replaces the manual pattern of `onNavigate` + `startTransition` + `addTransitionType` + `router.push()`. Reserve manual `startTransition` for non-link interactions (buttons, forms).
 
-## `loading.tsx` as Suspense Boundary
+**Availability:** `transitionTypes` shipped in **Next.js 16.2.0** (it is not gated on the `experimental.viewTransition` flag). If unavailable, use `startTransition` + `addTransitionType` + `router.push()` (see Programmatic Navigation below). To check: `grep -r "transitionTypes" node_modules/next/dist/` — if no results, fall back to programmatic navigation.
 
-Next.js `loading.tsx` files are implicit `<Suspense>` boundaries. Wrap the skeleton in `<ViewTransition exit="...">` in `loading.tsx`, and the content in `<ViewTransition enter="..." default="none">` in the page. This is the Next.js-idiomatic equivalent of explicit `<Suspense fallback={...}>`. Same rules apply: use simple string props (not type maps) since Suspense reveals fire without transition types.
+---
+
+## Programmatic Navigation
+
+```tsx
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { startTransition, addTransitionType } from 'react';
+
+function DetailButton({ href }: { href: string }) {
+  const router = useRouter();
+
+  function handleNavigate() {
+    startTransition(() => {
+      addTransitionType('nav-forward');
+      router.push(href);
+    });
+  }
+
+  return <button onClick={handleNavigate}>Open</button>;
+}
+```
+
+---
 
 ## Server-Side Filtering with `router.replace`
 
-For search/sort/filter that re-renders on the server (via URL params), use `startTransition` + `router.replace`. VTs activate because the update is inside `startTransition`. List items wrapped in `<ViewTransition key={item.id}>` animate reorder. This is the server-component alternative to the client-side `useDeferredValue` pattern.
+For search/sort/filter that re-renders on the server (via URL params), use `startTransition` + `router.replace`. VTs activate because the state update is inside `startTransition`:
+
+```tsx
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { startTransition } from 'react';
+
+function handleSort(sort: string) {
+  const router = useRouter();
+  startTransition(() => {
+    router.replace(`?sort=${sort}`);
+  });
+}
+```
+
+List items wrapped in `<ViewTransition key={item.id}>` will animate reorder. This is the server-component alternative to the client-side `useDeferredValue` pattern in the Patterns and Guidelines section.
+
+---
+
+## Routing-Driven Tabs
+
+The generalized sliding indicator (the Patterns and Guidelines section → Sliding Indicator) driven by navigation instead of local state: tabs are `<Link>`s, `active` comes from the URL (a server prop), and `useOptimistic` slides the indicator instantly while the route commits. Key the mounted indicator to committed `active` so the bar lands where navigation actually settles.
+
+```tsx
+'use client';
+import Link from 'next/link';
+import { useOptimistic, useTransition, ViewTransition } from 'react';
+
+export function Tabs({ tabs, active, indicatorName = 'tab-indicator' }) {
+  const [optimisticActive, setOptimisticActive] = useOptimistic(active);
+  const [, startTransition] = useTransition();
+  return (
+    <nav>
+      {tabs.map(t => (
+        <Link key={t.value} href={t.href} scroll={false}
+          aria-current={optimisticActive === t.value ? 'page' : undefined}
+          onNavigate={() => startTransition(() => setOptimisticActive(t.value))}>
+          <span>{t.label}</span>
+          {active === t.value && (
+            <ViewTransition name={indicatorName} share="tab-underline">
+              <span className="active-underline" aria-hidden />
+            </ViewTransition>
+          )}
+        </Link>
+      ))}
+    </nav>
+  );
+}
+```
+
+---
 
 ## Two-Layer Pattern (Directional + Suspense)
 
@@ -920,15 +1335,35 @@ Directional slides + Suspense reveals coexist because they fire at different mom
 </ViewTransition>
 ```
 
+---
+
+## `loading.tsx` as Suspense Boundary
+
+Next.js `loading.tsx` is an implicit `<Suspense>` boundary. Wrap the skeleton in `<ViewTransition exit="...">` in `loading.tsx`, and the content in `<ViewTransition enter="..." default="none">` in the page:
+
+```tsx
+// loading.tsx
+<ViewTransition exit="slide-down"><PhotoGridSkeleton /></ViewTransition>
+
+// page.tsx
+<ViewTransition enter="slide-up" default="none"><PhotoGrid photos={photos} /></ViewTransition>
+```
+
+Same rules as explicit `<Suspense>`: use simple string props (not type maps) since Suspense reveals fire without transition types.
+
+---
+
 ## Shared Elements Across Routes
 
 ```tsx
 // List page
-<Link href={`/products/${product.id}`} transitionTypes={['nav-forward']}>
-  <ViewTransition name={`product-${product.id}`}>
-    <Image src={product.image} alt={product.name} width={400} height={300} />
-  </ViewTransition>
-</Link>
+{products.map((product) => (
+  <Link key={product.id} href={`/products/${product.id}`} transitionTypes={['nav-forward']}>
+    <ViewTransition name={`product-${product.id}`}>
+      <Image src={product.image} alt={product.name} width={400} height={300} />
+    </ViewTransition>
+  </Link>
+))}
 
 // Detail page — same name
 <ViewTransition name={`product-${product.id}`}>
@@ -936,9 +1371,13 @@ Directional slides + Suspense reveals coexist because they fire at different mom
 </ViewTransition>
 ```
 
+If the pair's `share` is type-keyed (or classed via CSS that expects a type), every `<Link>` between the two views must carry the type via `transitionTypes` — a plain link click resolves the share map's `default`, and if that's `none` the morph silently never fires.
+
+---
+
 ## Same-Route Dynamic Segment Transitions
 
-Page stays mounted on dynamic segment change — enter/exit never fire. Use `key` + `name` + `share`:
+When navigating between dynamic segments of the same route (e.g., `/collection/[slug]`), the router swaps subtrees keyed by the segment value (or re-shows Activity-cached ones) rather than doing a plain unmount/mount — so enter/exit don't fire reliably. Use `key` + `name` + `share`:
 
 ```tsx
 <Suspense fallback={<Skeleton />}>
@@ -948,8 +1387,18 @@ Page stays mounted on dynamic segment change — enter/exit never fire. Use `key
 </Suspense>
 ```
 
+- `key={slug}` forces unmount/remount on change
+- `name` + `share="auto"` creates a shared element crossfade
+- VT inside `<Suspense>` (without keying Suspense) keeps old content visible during loading
+
+---
+
+## Nested enter/exit — `parentEnter` / `parentExit` (experimental)
+
+Lifts the "nested VTs don't fire enter/exit inside a parent" rule: a nested VT can animate when its **parent** enters/exits (`parentEnter`/`parentExit`, `onParentEnter`/`onParentExit`; `parentEnter="none"` stops propagation). Experimental-channel only today (behind `enableViewTransitionParentEnterExit = __EXPERIMENTAL__`); SSR support for Suspense reveals landed in React PR #36917 ([commit](https://github.com/facebook/react/commit/83840902c890f0eb85decda239ef6b1b14945779)). Verify it's in the React your app actually runs: `grep -c "parentEnter" node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.production.js` — 0 means unavailable (Next only uses the experimental channel when flags like `blockingSSR`/`taint` are set).
+
 ## Server Components
 
-- `<ViewTransition>` works in Server and Client Components
-- `<Link transitionTypes>` works in Server Components
-- `addTransitionType` and programmatic nav require Client Components
+- `<ViewTransition>` works in both Server and Client Components
+- `<Link transitionTypes>` works in Server Components — no `'use client'` needed
+- `addTransitionType` and `startTransition` for programmatic nav require Client Components

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -762,6 +762,7 @@ Only content inside an activated boundary animates position — everything else 
 The section — heading included — morphs as one group when rows above are added or removed. Nothing inside the section changed; the *displacement* is the update.
 
 - React only measures boundaries that are direct children of nodes along the changed path — a VT buried under an extra wrapper element won't activate. Place the boundary as a direct sibling of the changing content.
+- Sometimes the better fix is no morph at all: pad fixed-size lists to a constant slot count with invisible fillers so the grid never changes height and nothing below it moves.
 - `default="none"` disables exactly this morph — it turns off `update`. Named/shared elements get `default="none"`; displaced siblings and keyed list items stay bare or set `update="auto"`.
 
 ## Reusable Animated Collapse
@@ -1128,6 +1129,8 @@ The root cross-fades on every transition, freezing unnamed content behind a stal
 ```
 
 Named and classed groups still animate — they stack above root. Trade-off: unnamed content swaps instantly, so regions that should fade need their own VT. This also removes the main reason to hand-name static chrome; keep names only for elements that must stack above animating groups.
+
+Pairs well with enter-only reveals: skip the fallback-exit VT entirely (`<ViewTransition enter="auto" default="none">` around the content, nothing on the skeleton) — the skeleton snaps out live while the content fades in.
 
 ---
 

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -64,6 +64,7 @@ Guide for implementing smooth, native-feeling animations using React's View Tran
   - Text Morph
   - Scale
   - Interactivity During Transitions
+  - No Root Cross-Fade (Live Root)
   - Persistent Element Isolation
   - Reduced Motion
 - **View Transitions in Next.js**
@@ -700,6 +701,7 @@ Pull an element out of the animated `root` snapshot by giving it its own `view-t
 - **Persistent chrome** (nav, sidebar, player bar): `<nav style={{ viewTransitionName: 'persistent-nav' }}>` + isolation CSS. `<ViewTransition default="none">` works too, but its auto-name can't take `z-index`/backdrop `display:none` — hand-name when you need those.
 - **Floating elements** (popovers, menus): left open, they're captured in `root` and flicker on settle. Real name + isolation (the CSS Animation Recipes section → Floating Element Isolation). A static name is fine if only one is mounted (`unmountOnHide`); native top-layer (`popover`/`<dialog>`) settle-flicker is a browser limit.
 - **Naming an interactive element has a cost:** named participants are skipped by hit-testing while a transition runs ([csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)) — clicks and hover fall through to whatever is beneath. Portal named popovers/menus; rendered inline in a clickable row, mid-transition clicks activate the row and read as outside-clicks that close the popover.
+- **Third-party floating components** (toast libraries, portals you don't render): put the name on an always-mounted wrapper you own — `<div style={{ viewTransitionName: 'toaster' }} className="pointer-events-none fixed inset-0">`. Library containers often unmount when empty, so naming them directly leaves the group unpinned exactly when a toast appears mid-transition. Name a dialog's backdrop separately from its panel so each pins independently.
 
 ## Suspense reveal flicker
 
@@ -1112,6 +1114,23 @@ Trade-offs: clicks can hit live elements under still-moving snapshots, and it on
 
 ---
 
+## No Root Cross-Fade (Live Root)
+
+The root cross-fades on every transition, freezing unnamed content behind a stale snapshot — hover and active styles stop rendering until it settles. `::view-transition-new(root)` is a **live** capture, so disabling the root animation keeps unnamed regions rendering (and, with the `pointer-events` recipe above, interactive):
+
+```css
+::view-transition-old(root) {
+  display: none;
+}
+::view-transition-new(root) {
+  animation: none;
+}
+```
+
+Named and classed groups still animate — they stack above root. Trade-off: unnamed content swaps instantly, so regions that should fade need their own VT. This also removes the main reason to hand-name static chrome; keep names only for elements that must stack above animating groups.
+
+---
+
 ## Persistent Element Isolation
 
 ```css
@@ -1120,6 +1139,8 @@ Trade-offs: clicks can hit live elements under still-moving snapshots, and it on
   z-index: 100;
 }
 ```
+
+Layer multiple pinned groups with z-index tiers — chrome at `100`, toasts/overlays that must beat everything at `200`.
 
 ### Backdrop-Blur Workaround
 

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -252,7 +252,7 @@ export function DirectionalTransition({ children }: { children: React.ReactNode 
 
 ### `router.back()` and Browser Back Button
 
-`router.back()` and the browser's back/forward buttons do **not** animate: React renders transitions scheduled during a `popstate` event synchronously (`shouldAttemptEagerTransition`) to keep back/forward instant, and synchronous renders skip view transitions. Traversals also carry no transition types, so type-keyed maps resolve to their `default`. Use `router.push()` with an explicit URL instead.
+`router.back()` and the browser's back/forward buttons carry **no transition types**, so type-keyed animations (directional slides) resolve to their `default` and don't play. Untyped animations — shared-element morphs with matching `name`s, bare/`auto` VTs — can still run. (React may also render `popstate`-scheduled transitions eagerly/synchronously to keep back/forward instant, skipping transitions in some cases.) For a fully animated back affordance, use `router.push()` with an explicit URL.
 
 ### Types and Suspense
 
@@ -571,7 +571,7 @@ If any path produces no animation or competing animations, revisit the relevant 
 - **Raw `viewTransitionName` CSS to trigger animations** — React only calls `document.startViewTransition` when `<ViewTransition>` components are in the tree. A bare `viewTransitionName` style is for isolating elements from a parent's snapshot, not for triggering animations.
 - **`update` trigger for same-route navigations** — nested VTs inside the content steal the mutation from the parent, so `update` never fires on the outer VT. Use `key` + `name` + `share` instead.
 - **Named VT in a reusable component** — if a component with a named VT is rendered in both a modal/popover *and* a page, both mount simultaneously and break the morph. Make the name conditional or move it to the specific consumer.
-- **`router.back()` for back navigation** — React renders `popstate`-scheduled transitions synchronously (skipping view transitions), and traversals carry no transition types. Use `router.push()` with an explicit URL.
+- **`router.back()` for back navigation** — traversals carry no transition types, so type-keyed animations don't play (untyped morphs still can). Use `router.push()` with an explicit URL for a fully animated back affordance.
 
 ---
 
@@ -868,7 +868,7 @@ The `types` array (second argument) lets you vary animation based on transition 
 
 **Section below a list teleports instead of gliding:** it's outside any activated boundary, its VT has `default="none"` (which disables `update`), or it isn't an immediate sibling of the changing content. See "Layout Displacement Morph" above.
 
-**`router.back()` and browser back/forward skip animation:** React renders `popstate`-scheduled transitions synchronously (skipping view transitions), and traversals carry no transition types. Use `router.push()` with an explicit URL instead. See SKILL.md "router.back() and Browser Back Button."
+**`router.back()` and browser back/forward skip the directional slide:** traversals carry no transition types, so type-keyed maps resolve to `default` — untyped shared-element morphs still apply. Use `router.push()` with an explicit URL for typed animations. See SKILL.md "router.back() and Browser Back Button."
 
 **`flushSync` skips animations:** Use `startTransition` instead.
 
@@ -1196,7 +1196,9 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-Historically this switched the bundled React to the experimental channel; in current Next.js (16.2+) it gates nothing at runtime, but set it anyway to match the documented setup. Because every link click is a transition, any VT with `default="auto"` fires on **every** navigation — use `default="none"` to prevent competing animations.
+The official docs instruct setting this flag; keep it. Historically it switched the bundled React to the **experimental channel** — required back when `ViewTransition` was experimental-only — but since React released `ViewTransition` to canary (Oct 2025), the canary React that App Router bundles has full support and the flag no longer switches channels. Today the experimental channel is selected by *other* flags (`gestureTransition`, `blockingSSR`, `taint`, `transitionIndicator`), and only experimental-channel features need it: gesture transitions (`useSwipeTransition`) and `parentEnter`/`parentExit`.
+
+Because every link click is a transition, any VT with `default="auto"` fires on **every** navigation — use `default="none"` to prevent competing animations.
 
 Do **not** install `react@canary` — see "Availability" for details.
 
@@ -1395,7 +1397,7 @@ When navigating between dynamic segments of the same route (e.g., `/collection/[
 
 ## Nested enter/exit — `parentEnter` / `parentExit` (experimental)
 
-Lifts the "nested VTs don't fire enter/exit inside a parent" rule: a nested VT can animate when its **parent** enters/exits (`parentEnter`/`parentExit`, `onParentEnter`/`onParentExit`; `parentEnter="none"` stops propagation). Experimental-channel only today (behind `enableViewTransitionParentEnterExit = __EXPERIMENTAL__`); SSR support for Suspense reveals landed in React PR #36917 ([commit](https://github.com/facebook/react/commit/83840902c890f0eb85decda239ef6b1b14945779)). Verify it's in the React your app actually runs: `grep -c "parentEnter" node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.production.js` — 0 means unavailable (Next only uses the experimental channel when flags like `blockingSSR`/`taint` are set).
+Lifts the "nested VTs don't fire enter/exit inside a parent" rule: a nested VT can animate when its **parent** enters/exits (`parentEnter`/`parentExit`, `onParentEnter`/`onParentExit`; `parentEnter="none"` stops propagation). Experimental-channel only today (behind `enableViewTransitionParentEnterExit = __EXPERIMENTAL__`); SSR support for Suspense reveals landed in React PR #36917 ([commit](https://github.com/facebook/react/commit/83840902c890f0eb85decda239ef6b1b14945779)). Verify it's in the React your app actually runs: `grep -c "parentEnter" node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.production.js` — 0 means unavailable (Next only uses the experimental channel when a flag from `needs-experimental-react.ts` is set: `gestureTransition`, `blockingSSR`, `taint`, or `transitionIndicator`).
 
 ## Server Components
 

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -119,7 +119,7 @@ Reserve directional slides for hierarchical navigation (list → detail) and ord
 
 - **Next.js:** Do **not** install `react@canary` — the App Router already bundles React canary internally. `ViewTransition` works out of the box. `npm ls react` may show a stable-looking version; this is expected.
 - **Without Next.js:** Install `react@canary react-dom@canary` (`ViewTransition` is not in stable React).
-- Browser support: Chromium 125+, Firefox 144+, Safari 18.2+. React requires the v2 object form of `startViewTransition` and deliberately falls back to not animating on older engines (Chromium 111–124 only has the v1 callback form). Graceful degradation on unsupported browsers.
+- Browser support: Chromium 125+ (React needs the v2 object form of `startViewTransition`), Firefox 144+, Safari 18.2+. Graceful degradation on unsupported browsers.
 
 ---
 
@@ -252,7 +252,7 @@ export function DirectionalTransition({ children }: { children: React.ReactNode 
 
 ### `router.back()` and Browser Back Button
 
-`router.back()` and the browser's back/forward buttons carry **no transition types**, so type-keyed animations (directional slides) resolve to their `default` and don't play. Untyped animations — shared-element morphs with matching `name`s, bare/`auto` VTs — can still run. (React may also render `popstate`-scheduled transitions eagerly/synchronously to keep back/forward instant, skipping transitions in some cases.) For a fully animated back affordance, use `router.push()` with an explicit URL.
+`router.back()` and the browser's back/forward buttons carry **no transition types**, so type-keyed animations (directional slides) resolve to their `default` and don't play — untyped shared-element morphs still apply. For typed animations, use `router.push()` with an explicit URL.
 
 ### Types and Suspense
 
@@ -363,7 +363,7 @@ Every VT matching the trigger fires simultaneously in a single `document.startVi
 
 Without it, every VT fires the browser cross-fade on **every** transition — Suspense resolves, `useDeferredValue` updates, background revalidations. Use `default="none"` on named/shared elements and type-keyed page VTs.
 
-But know what it turns off: `default="none"` also disables `update` (layout displacement morphs — list reflow, sections gliding when content above changes) and `share` (a named pair with `default="none"` and no explicit `share` prop silently never morphs). Keyed list items and displaced siblings *want* update — leave them bare or set `update="auto"` explicitly.
+But it also turns off `update` (layout/reflow morphs) and `share` (a named pair with no explicit `share` prop never morphs). Keyed list items and displaced siblings *want* update — leave them bare or set `update="auto"`.
 
 ### Two Patterns Coexist
 
@@ -699,7 +699,7 @@ Pull an element out of the animated `root` snapshot by giving it its own `view-t
 
 - **Persistent chrome** (nav, sidebar, player bar): `<nav style={{ viewTransitionName: 'persistent-nav' }}>` + isolation CSS. `<ViewTransition default="none">` works too, but its auto-name can't take `z-index`/backdrop `display:none` — hand-name when you need those.
 - **Floating elements** (popovers, menus): left open, they're captured in `root` and flicker on settle. Real name + isolation (the CSS Animation Recipes section → Floating Element Isolation). A static name is fine if only one is mounted (`unmountOnHide`); native top-layer (`popover`/`<dialog>`) settle-flicker is a browser limit.
-- **Naming an interactive element has a cost:** named participants are skipped by hit-testing while a transition runs — hover, cursor, and clicks fall through to whatever is beneath for the transition's duration (spec behavior; [csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)). Always **portal** a named popover/menu so those fallback hits stay inside its own subtree: rendered inline in a clickable row, mid-transition clicks hover/activate the row behind it, and outside-click detection closes the popover.
+- **Naming an interactive element has a cost:** named participants are skipped by hit-testing while a transition runs ([csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)) — clicks and hover fall through to whatever is beneath. Portal named popovers/menus; rendered inline in a clickable row, mid-transition clicks activate the row and read as outside-clicks that close the popover.
 
 ## Suspense reveal flicker
 
@@ -759,7 +759,7 @@ Only content inside an activated boundary animates position — everything else 
 
 The section — heading included — morphs as one group when rows above are added or removed. Nothing inside the section changed; the *displacement* is the update.
 
-- React activates VT boundaries that are direct children (not behind an intermediate DOM node) of nodes along the changed path — siblings of the mutation and of its ancestors qualify; a VT buried under an extra wrapper element in a sibling does not (deliberate: page-wide re-layout would otherwise fire noisy animations everywhere). Place the boundary as a direct sibling of the changing content.
+- React only measures boundaries that are direct children of nodes along the changed path — a VT buried under an extra wrapper element won't activate. Place the boundary as a direct sibling of the changing content.
 - `default="none"` disables exactly this morph — it turns off `update`. Named/shared elements get `default="none"`; displaced siblings and keyed list items stay bare or set `update="auto"`.
 
 ## Reusable Animated Collapse
@@ -868,13 +868,13 @@ The `types` array (second argument) lets you vary animation based on transition 
 
 **Section below a list teleports instead of gliding:** it's outside any activated boundary, its VT has `default="none"` (which disables `update`), or it isn't an immediate sibling of the changing content. See "Layout Displacement Morph" above.
 
-**`router.back()` and browser back/forward skip the directional slide:** traversals carry no transition types, so type-keyed maps resolve to `default` — untyped shared-element morphs still apply. Use `router.push()` with an explicit URL for typed animations. See SKILL.md "router.back() and Browser Back Button."
+**`router.back()` and browser back/forward skip the directional slide:** traversals carry no transition types, so type-keyed maps resolve to `default` — untyped shared-element morphs still apply. Use `router.push()` for typed animations.
 
 **`flushSync` skips animations:** Use `startTransition` instead.
 
 **Only updates animate (no enter/exit):** Without `<Suspense>`, React treats swaps as updates. Conditionally render the VT itself, or wrap in `<Suspense>`.
 
-**Layout VT prevents page VTs from animating:** nested VTs don't fire their own enter/exit when they mount/unmount *as one unit* with a parent VT — only the outermost animates. (A child VT swapped inside a persistent parent fires normally; if page enter/exit is dead under a persistent layout VT, check the page VT isn't below a plain DOM node instead.) If your layout has a VT wrapping `{children}`, remove it and put VTs in pages.
+**Layout VT prevents page VTs from animating:** nested VTs skip their own enter/exit only when they mount/unmount *as one unit* with a parent VT. If page enter/exit is dead under a persistent layout VT, the usual culprit is a DOM node above the page VT. Keep VTs in pages, not layouts.
 
 **List reorder not animating with `useOptimistic`:** Optimistic values resolve before snapshot. Use committed state for list order.
 
@@ -1100,7 +1100,7 @@ Usage: `<ViewTransition enter="scale-in" exit="scale-out" />`
 
 ## Interactivity During Transitions
 
-The `::view-transition` overlay covers the viewport and captures all pointer events by default. React partially handles this: when the root group doesn't need to animate, it shrinks the overlay to zero size so the page stays interactive — but it deliberately leaves `pointer-events` alone so in-flight animations still block clicks (so they don't land on whatever is beneath a moving snapshot). To let clicks and hover pass through even while animations run:
+The `::view-transition` overlay captures all pointer events. React shrinks it to zero when the root group doesn't animate, but in-flight animations still block clicks. To pass clicks/hover through even while animating:
 
 ```css
 ::view-transition {
@@ -1108,7 +1108,7 @@ The `::view-transition` overlay covers the viewport and captures all pointer eve
 }
 ```
 
-Trade-off: clicks during an animation can now hit live elements underneath still-moving snapshots. And it only restores interactivity for **unnamed** content — elements participating in the transition (anything with a `view-transition-name`) are skipped by hit-testing for the transition's duration, spec behavior with no CSS override ([csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)). Weigh that cost before naming interactive elements, and portal named popovers (see the Patterns and Guidelines section → Isolate Elements from Parent Animations).
+Trade-offs: clicks can hit live elements under still-moving snapshots, and it only helps **unnamed** content — named participants are skipped by hit-testing for the transition's duration, no CSS override ([csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)). Weigh that before naming interactive elements; portal named popovers (see the Patterns and Guidelines section).
 
 ---
 
@@ -1186,7 +1186,7 @@ One shared-name indicator morphs between positions. Slide the group; disable old
 
 ## Setup
 
-`<ViewTransition>` works out of the box — the bundled React canary ships it, and every `<Link>` navigation already runs inside `React.startTransition`, so react-dom starts a view transition whenever affected `<ViewTransition>` components exist. The documented flag:
+`<ViewTransition>` works out of the box — the bundled React canary ships it, and every `<Link>` navigation runs inside `React.startTransition`, so react-dom starts a view transition whenever affected `<ViewTransition>` components exist. Set the documented flag:
 
 ```js
 // next.config.js
@@ -1196,7 +1196,7 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-The official docs instruct setting this flag; keep it. Historically it switched the bundled React to the **experimental channel** — required back when `ViewTransition` was experimental-only — but since React released `ViewTransition` to canary (Oct 2025), the canary React that App Router bundles has full support and the flag no longer switches channels. Today the experimental channel is selected by *other* flags (`gestureTransition`, `blockingSSR`, `taint`, `transitionIndicator`), and only experimental-channel features need it: gesture transitions (`useSwipeTransition`) and `parentEnter`/`parentExit`.
+(Historically the flag switched React to the experimental channel — required before `ViewTransition` reached canary. It no longer does; the experimental channel is only needed for `useSwipeTransition` gestures and `parentEnter`/`parentExit`, selected by other flags like `gestureTransition`.)
 
 Because every link click is a transition, any VT with `default="auto"` fires on **every** navigation — use `default="none"` to prevent competing animations.
 
@@ -1379,7 +1379,7 @@ If the pair's `share` is type-keyed (or classed via CSS that expects a type), ev
 
 ## Same-Route Dynamic Segment Transitions
 
-When navigating between dynamic segments of the same route (e.g., `/collection/[slug]`), the router swaps subtrees keyed by the segment value (or re-shows Activity-cached ones) rather than doing a plain unmount/mount — so enter/exit don't fire reliably. Use `key` + `name` + `share`:
+When navigating between dynamic segments of the same route (e.g., `/collection/[slug]`), the router swaps subtrees keyed by the segment value rather than doing a plain unmount/mount — enter/exit don't fire reliably. Use `key` + `name` + `share`:
 
 ```tsx
 <Suspense fallback={<Skeleton />}>
@@ -1397,7 +1397,7 @@ When navigating between dynamic segments of the same route (e.g., `/collection/[
 
 ## Nested enter/exit — `parentEnter` / `parentExit` (experimental)
 
-Lifts the "nested VTs don't fire enter/exit inside a parent" rule: a nested VT can animate when its **parent** enters/exits (`parentEnter`/`parentExit`, `onParentEnter`/`onParentExit`; `parentEnter="none"` stops propagation). Experimental-channel only today (behind `enableViewTransitionParentEnterExit = __EXPERIMENTAL__`); SSR support for Suspense reveals landed in React PR #36917 ([commit](https://github.com/facebook/react/commit/83840902c890f0eb85decda239ef6b1b14945779)). Verify it's in the React your app actually runs: `grep -c "parentEnter" node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.production.js` — 0 means unavailable (Next only uses the experimental channel when a flag from `needs-experimental-react.ts` is set: `gestureTransition`, `blockingSSR`, `taint`, or `transitionIndicator`).
+Lifts the "nested VTs don't fire enter/exit inside a parent" rule: a nested VT can animate when its **parent** enters/exits (`parentEnter`/`parentExit`, `onParentEnter`/`onParentExit`; `parentEnter="none"` stops propagation). Experimental-channel only today; SSR support landed in React PR #36917 ([commit](https://github.com/facebook/react/commit/83840902c890f0eb85decda239ef6b1b14945779)). Verify it's in the React your app runs: `grep -c "parentEnter" node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.production.js` — 0 means unavailable (Next uses the experimental channel only when `gestureTransition`/`blockingSSR`/`taint`/`transitionIndicator` is set).
 
 ## Server Components
 

--- a/skills/react-view-transitions/AGENTS.md
+++ b/skills/react-view-transitions/AGENTS.md
@@ -20,70 +20,31 @@ Guide for implementing smooth, native-feeling animations using React's View Tran
 
 ## Table of Contents
 
-  - When to Animate
-  - Availability
-  - Implementation Workflow
-  - Core Concepts
-  - Styling with View Transition Classes
-  - Transition Types
-  - Shared Element Transitions
-  - Common Patterns
-  - How Multiple VTs Interact
-  - Next.js Integration
-  - Accessibility
-- **Implementation Workflow**
-  - Step 1: Audit the App
-  - Step 2: Add CSS Recipes
-  - Step 3: Isolate Persistent Elements
-  - Step 4: Add Directional Page Transitions
-  - Step 5: Add Suspense Reveals
-  - Step 6: Add Shared Element Transitions
-  - Step 7: Verify Each Navigation Path
-  - Common Mistakes
-- **Patterns and Guidelines**
-  - Searchable Grid with `useDeferredValue`
-  - Card Expand/Collapse with `startTransition`
-  - Type-Safe Transition Helpers
-  - Cross-Fade Without Remount
-  - Isolate Elements from Parent Animations
-  - Suspense reveal flicker
-  - Sliding Indicator (tabs)
-  - Layout Displacement Morph
-  - Reusable Animated Collapse
-  - Composing with Activity
-  - Exclude Elements with `useOptimistic`
-  - View Transition Events
-  - Animation Timing
-  - Troubleshooting
-- **CSS Animation Recipes**
-  - Timing Variables
-  - Fade
-  - Slide (Vertical)
-  - Directional Navigation
-  - Shared Element Morph
-  - Text Morph
-  - Scale
-  - Interactivity During Transitions
-  - No Root Cross-Fade (Live Root)
-  - Persistent Element Isolation
-  - Reduced Motion
-- **View Transitions in Next.js**
-  - Setup
-  - Next.js Implementation Additions
-  - Layout-Level ViewTransition
-  - The `transitionTypes` Prop on `next/link`
-  - Programmatic Navigation
-  - Server-Side Filtering with `router.replace`
-  - Routing-Driven Tabs
-  - Two-Layer Pattern (Directional + Suspense)
-  - `loading.tsx` as Suspense Boundary
-  - Shared Elements Across Routes
-  - Same-Route Dynamic Segment Transitions
-  - Nested enter/exit — `parentEnter` / `parentExit` (experimental)
-  - Server Components
+1. [Core Reference](#when-to-animate)
+   - [When to Animate](#when-to-animate)
+   - [Availability](#availability)
+   - [Core Concepts](#core-concepts)
+   - [Styling with View Transition Classes](#styling-with-view-transition-classes)
+   - [Transition Types](#transition-types)
+   - [Shared Element Transitions](#shared-element-transitions)
+   - [Common Patterns](#common-patterns)
+   - [How Multiple VTs Interact](#how-multiple-vts-interact)
+   - [Next.js Integration](#nextjs-integration)
+   - [Accessibility](#accessibility)
+2. [Implementation Workflow](#implementation-workflow)
+   - [Step 1: Audit the App](#step-1-audit-the-app)
+   - [Step 2: Add CSS Recipes](#step-2-add-css-recipes)
+   - [Step 3: Isolate Persistent Elements](#step-3-isolate-persistent-elements)
+   - [Step 4: Add Directional Page Transitions](#step-4-add-directional-page-transitions)
+   - [Step 5: Add Suspense Reveals](#step-5-add-suspense-reveals)
+   - [Step 6: Add Shared Element Transitions](#step-6-add-shared-element-transitions)
+   - [Step 7: Verify Each Navigation Path](#step-7-verify-each-navigation-path)
+   - [Common Mistakes](#common-mistakes)
+3. [Patterns and Guidelines](#patterns-and-guidelines)
+4. [CSS Animation Recipes](#css-animation-recipes)
+5. [View Transitions in Next.js](#view-transitions-in-nextjs)
 
 ---
-
 
 Animate between UI states using the browser's native `document.startViewTransition`. Declare *what* with `<ViewTransition>`, trigger *when* with `startTransition` / `useDeferredValue` / `Suspense`, control *how* with CSS classes. Unsupported browsers skip animations gracefully.
 
@@ -120,13 +81,7 @@ Reserve directional slides for hierarchical navigation (list → detail) and ord
 
 - **Next.js:** Do **not** install `react@canary` — the App Router already bundles React canary internally. `ViewTransition` works out of the box. `npm ls react` may show a stable-looking version; this is expected.
 - **Without Next.js:** Install `react@canary react-dom@canary` (`ViewTransition` is not in stable React).
-- Browser support: Chromium 125+ (React needs the v2 object form of `startViewTransition`), Firefox 144+, Safari 18.2+. Graceful degradation on unsupported browsers.
-
----
-
-## Implementation Workflow
-
-When adding view transitions to an existing app, **follow the Implementation Workflow section below step by step.** Start with the audit — do not skip it. Copy the CSS recipes from the CSS Animation Recipes section below into the global stylesheet — do not write your own animation CSS.
+- Browser support: Chromium 111+, Firefox 144+, Safari 18.2+. Graceful degradation.
 
 ---
 
@@ -148,36 +103,28 @@ React auto-assigns a unique `view-transition-name` and calls `document.startView
 
 | Trigger | When it fires |
 |---------|--------------|
-| **enter** | `<ViewTransition>` first inserted during a Transition |
-| **exit** | `<ViewTransition>` first removed during a Transition |
-| **update** | DOM mutations inside a `<ViewTransition>`, or the boundary itself changing size/position due to an immediate sibling. With nested VTs, mutation applies to the innermost one |
-| **share** | Named VT unmounts and another with same `name` mounts in the same Transition |
+| **enter** | VT first inserted during a Transition |
+| **exit** | VT first removed during a Transition |
+| **update** | DOM mutations inside a VT. With nested VTs, mutation applies to the innermost one |
+| **share** | Named VT unmounts and another with same `name` mounts in same Transition |
 
 Only `startTransition`, `useDeferredValue`, or `Suspense` activate VTs. Regular `setState` does not animate.
 
 ### Critical Placement Rule
 
-`<ViewTransition>` only activates enter/exit if it appears **before any DOM nodes**:
+VT only activates enter/exit if it appears **before any DOM nodes**:
 
 ```jsx
 // Works
-<ViewTransition enter="auto" exit="auto">
-  <div>Content</div>
-</ViewTransition>
+<ViewTransition enter="auto" exit="auto"><div>Content</div></ViewTransition>
 
-// Broken — div wraps the VT, suppressing enter/exit
-<div>
-  <ViewTransition enter="auto" exit="auto">
-    <div>Content</div>
-  </ViewTransition>
-</div>
+// Broken — div wraps the VT
+<div><ViewTransition enter="auto" exit="auto"><div>Content</div></ViewTransition></div>
 ```
 
 ---
 
 ## Styling with View Transition Classes
-
-### Props
 
 Values: `"auto"` (browser cross-fade), `"none"` (disabled), `"class-name"` (custom CSS), or `{ [type]: value }` for type-specific animations.
 
@@ -194,13 +141,11 @@ If `default` is `"none"`, all triggers are off unless explicitly listed.
 - `::view-transition-group(.class)` — container
 - `::view-transition-image-pair(.class)` — old + new pair
 
-See the CSS Animation Recipes section below for ready-to-use animation recipes.
-
 ---
 
 ## Transition Types
 
-Tag transitions with `addTransitionType` so VTs can pick different animations based on context. Call it multiple times to stack types — different VTs in the tree react to different types:
+Tag transitions with `addTransitionType` so VTs can pick different animations. Call it multiple times to stack types — different VTs in the tree react to different types:
 
 ```jsx
 startTransition(() => {
@@ -210,7 +155,7 @@ startTransition(() => {
 });
 ```
 
-Pass an object to map types to CSS classes. Works on `enter`, `exit`, **and** `share`:
+Map types to CSS classes. Works on `enter`, `exit`, **and** `share`:
 
 ```jsx
 <ViewTransition
@@ -233,27 +178,11 @@ Pass an object to map types to CSS classes. Works on `enter`, `exit`, **and** `s
 >
 ```
 
-**TypeScript:** `ViewTransitionClassPerType` requires a `default` key in the object.
-
-For apps with multiple pages, extract the type-keyed VT into a reusable wrapper:
-
-```jsx
-export function DirectionalTransition({ children }: { children: React.ReactNode }) {
-  return (
-    <ViewTransition
-      enter={{ 'nav-forward': 'nav-forward', 'nav-back': 'nav-back', default: 'none' }}
-      exit={{ 'nav-forward': 'nav-forward', 'nav-back': 'nav-back', default: 'none' }}
-      default="none"
-    >
-      {children}
-    </ViewTransition>
-  );
-}
-```
+**TypeScript:** `ViewTransitionClassPerType` requires a `default` key.
 
 ### `router.back()` and Browser Back Button
 
-`router.back()` and the browser's back/forward buttons carry **no transition types**, so type-keyed animations (directional slides) resolve to their `default` and don't play — untyped shared-element morphs still apply. For typed animations, use `router.push()` with an explicit URL.
+`router.back()` and the browser's back/forward buttons do **not** trigger view transitions (`popstate` is synchronous, incompatible with `startViewTransition`). Use `router.push()` with an explicit URL instead.
 
 ### Types and Suspense
 
@@ -270,16 +199,15 @@ Same `name` on two VTs — one unmounting, one mounting — creates a shared ele
   <img src="/thumb.jpg" onClick={() => startTransition(() => onSelect())} />
 </ViewTransition>
 
-// On the other view — same name
+// Other view — same name
 <ViewTransition name="hero-image">
   <img src="/full.jpg" />
 </ViewTransition>
 ```
 
-- Only one VT with a given `name` can be mounted at a time — use unique names (`photo-${id}`). Watch for reusable components: if a component with a named VT is rendered in both a modal/popover *and* a page, both mount simultaneously and break the morph. Either make the name conditional (via a prop) or move the named VT out of the shared component into the specific consumer.
-- `share` takes precedence over `enter`/`exit`. Think through each navigation path: when no matching pair forms (e.g., the target page doesn't have the same name), `enter`/`exit` fires instead. Consider whether the element needs a fallback animation for those paths.
-- Two ways a wired-up morph silently never fires: (1) `default="none"` with no explicit `share` prop — share resolves to none; (2) type-keyed `share` where the navigation never adds the type — a plain link click resolves the map's `default`. Every link that should morph must add the type (`transitionTypes` on `next/link`, or `addTransitionType`).
-- Never use a fade-out exit on pages with shared morphs — use a directional slide instead.
+- Only one VT with a given `name` can be mounted at a time — use unique names. Watch for reusable components: if a component with a named VT is rendered in both a modal/popover *and* a page, both mount simultaneously and break the morph. Either make the name conditional (via a prop) or move the named VT out of the shared component into the specific consumer.
+- `share` takes precedence over `enter`/`exit`. Think through each navigation path: when no pair forms, `enter`/`exit` fires instead. Consider whether the element needs a fallback animation for those paths.
+- Never use fade-out exit on pages with shared morphs — use directional slide.
 
 ---
 
@@ -303,13 +231,9 @@ Same `name` on two VTs — one unmounting, one mounting — creates a shared ele
 
 Trigger inside `startTransition`. Avoid wrapper `<div>`s between list and VT.
 
-### Layout Displacement Morph
-
-Only content inside an activated boundary animates position — everything else teleports to its new layout spot. Wrap the sibling content below a growing/shrinking list in a bare `<ViewTransition>` so it glides instead of jumping. See the Patterns and Guidelines section below → Layout Displacement Morph.
-
 ### Composing Shared Elements with List Identity
 
-Shared elements and list identity are independent concerns — don't confuse one for the other. When a list item contains a shared element (e.g., an image that morphs into a detail view), use two nested `<ViewTransition>` boundaries:
+Shared elements and list identity are independent concerns — don't confuse one for the other. When a list item contains a shared element, use two nested `<ViewTransition>` boundaries:
 
 ```jsx
 {items.map(item => (
@@ -324,7 +248,7 @@ Shared elements and list identity are independent concerns — don't confuse one
 ))}
 ```
 
-The outer VT handles list reorder/enter animations. The inner VT handles the cross-route shared element morph. Missing either layer means that animation silently doesn't happen.
+The outer VT handles list reorder/enter. The inner VT handles cross-route shared element morph. Missing either layer means that animation silently doesn't happen.
 
 ### Force Re-Enter with `key`
 
@@ -334,7 +258,7 @@ The outer VT handles list reorder/enter animations. The inner VT handles the cro
 </ViewTransition>
 ```
 
-**Caution:** If wrapping `<Suspense>`, changing `key` remounts the boundary and refetches.
+**Caution:** Wrapping `<Suspense>` with key remounts the boundary and refetches.
 
 ### Suspense Fallback to Content
 
@@ -352,19 +276,15 @@ Directional reveal:
 </Suspense>
 ```
 
-For more patterns, see the Patterns and Guidelines section below.
-
 ---
 
 ## How Multiple VTs Interact
 
-Every VT matching the trigger fires simultaneously in a single `document.startViewTransition`. VTs in **different** transitions (navigation vs later Suspense resolve) don't compete.
+Every VT matching the trigger fires simultaneously in a single `document.startViewTransition`. VTs in **different** transitions don't compete.
 
-### Use `default="none"` Deliberately
+### Use `default="none"` Liberally
 
-Without it, every VT fires the browser cross-fade on **every** transition — Suspense resolves, `useDeferredValue` updates, background revalidations. Use `default="none"` on named/shared elements and type-keyed page VTs.
-
-But it also turns off `update` (layout/reflow morphs) and `share` (a named pair with no explicit `share` prop never morphs). Keyed list items and displaced siblings *want* update — leave them bare or set `update="auto"`.
+Without it, every VT fires the browser cross-fade on **every** transition. Always use `default="none"` and explicitly enable only desired triggers.
 
 ### Two Patterns Coexist
 
@@ -375,38 +295,47 @@ They coexist because they fire at different moments. `default="none"` on both pr
 
 ### Nested VT Limitation
 
-When a parent VT mounts/unmounts **as one unit** with nested VTs inside it, the nested ones do not fire their own enter/exit — only the outermost VT animates. (A child VT mounted inside a *persistent* parent VT fires enter/exit normally.) Per-item staggered animations during page navigation are not possible today; the experimental opt-in is the `parentEnter`/`parentExit` props ([react#36690](https://github.com/facebook/react/pull/36690), experimental channel only).
+When a parent VT exits, nested VTs inside it do **not** fire their own enter/exit — only the outermost VT animates. Per-item staggered animations during page navigation are not possible today. See [react#36135](https://github.com/facebook/react/pull/36135) for an experimental opt-in fix.
 
 ---
 
 ## Next.js Integration
 
-For Next.js setup (`experimental.viewTransition` flag, `transitionTypes` prop on `next/link`, App Router patterns, Server Components), see the View Transitions in Next.js section below.
+See the [View Transitions in Next.js](#view-transitions-in-nextjs) section below.
 
 ---
 
 ## Accessibility
 
-Always add the reduced motion CSS from the CSS Animation Recipes section below to your global stylesheet.
+Always add reduced motion CSS to your global stylesheet:
 
----
+```css
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(*),
+  ::view-transition-new(*),
+  ::view-transition-group(*) {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+  }
+}
+```
 
 ---
 
 # Implementation Workflow
 
-Follow these steps in order when adding view transitions to an app. Each step builds on the previous one.
+**Follow these steps in order.** Start with the audit — do not skip it. Copy the CSS recipes from the CSS Recipes section below — do not write your own animation CSS.
 
 ## Step 1: Audit the App
 
 Before writing any code, scan the codebase thoroughly. Search for:
 
-- **Every `<Link>` and `router.push`** — these are your navigation triggers. Open every file that contains one.
-- **Every `<Suspense>` boundary** — each one is a candidate for a reveal animation. Check what its fallback renders.
-- **Every page/route component** — list them all. Each page needs a VT placement decision.
-- **Persistent elements** — headers, navbars, sidebars, sticky controls that stay on screen across navigations. These need `viewTransitionName` isolation.
-- **Shared visual elements** — images, cards, or avatars that appear on both a source and target view (e.g., a thumbnail in a list and the same image on a detail page).
-- **Skeleton-to-content control pairs** — if a Suspense fallback renders a control (search input, tab bar) that also exists in the real content, both need a matching `viewTransitionName`.
+- **Every `<Link>` and `router.push`** — open every file that contains one
+- **Every `<Suspense>` boundary** — check what its fallback renders
+- **Every page/route component** — each needs a VT placement decision
+- **Persistent elements** (headers, navbars, sidebars) — need `viewTransitionName` isolation
+- **Shared visual elements** on both source and target views
+- **Skeleton-to-content control pairs** — if a fallback renders a control that also exists in the real content, both need a matching `viewTransitionName`
 
 Then classify every navigation and produce a navigation map:
 
@@ -420,29 +349,28 @@ Then classify every navigation and produce a navigation map:
 | (Suspense)      | (content loads)      | —            | slide-up reveal       |
 ```
 
-For each shared element (`name` prop), note every navigation where a pair forms and where it doesn't — this determines whether you need `enter`/`exit` as a fallback alongside `share`.
+For each shared element (`name` prop), note where a pair forms and where it doesn't — this determines whether you need `enter`/`exit` as a fallback alongside `share`.
 
 ## Step 2: Add CSS Recipes
 
-Copy the **complete** CSS recipe set from the CSS Animation Recipes section into your global stylesheet. This includes timing variables, shared keyframes, fade, slide (vertical), directional navigation (forward/back), shared element morph, persistent element isolation, and reduced motion.
-
-Do not write your own animation CSS — the recipes handle staggered timing, motion blur on morphs, and reduced motion that are easy to get wrong. You can customize timing variables (`--duration-exit`, `--duration-enter`, `--duration-move`) after the initial setup.
+Copy the **complete** CSS recipe set from the CSS Animation Recipes section below into your global stylesheet. Don't write your own — the recipes handle staggered timing, motion blur, and reduced motion.
 
 ## Step 3: Isolate Persistent Elements
-
-For every persistent element identified in Step 1, add a `viewTransitionName` style to pull it out of the page content's transition snapshot:
 
 ```jsx
 <header style={{ viewTransitionName: "site-header" }}>...</header>
 ```
 
-Then add the persistent element isolation CSS from the CSS Animation Recipes section (prevents the element from animating during page transitions). If the element uses `backdrop-blur` or `backdrop-filter`, use the backdrop-blur workaround from the CSS Animation Recipes section instead.
+```css
+::view-transition-group(site-header) {
+  animation: none;
+  z-index: 100;
+}
+```
 
-If a Suspense fallback mirrors a persistent control (e.g., a skeleton search input), give both the real control and the skeleton the same `viewTransitionName` so they morph in place.
+For `backdrop-blur`/`backdrop-filter`, use the backdrop-blur workaround instead.
 
 ## Step 4: Add Directional Page Transitions
-
-For hierarchical navigations identified in Step 1, tag the navigation direction using `addTransitionType` inside `startTransition`:
 
 ```jsx
 startTransition(() => {
@@ -451,29 +379,19 @@ startTransition(() => {
 });
 ```
 
-Then wrap each **page component** (not layout) in a type-keyed `<ViewTransition>`:
+Wrap each **page component** (not layout) in a type-keyed VT:
 
 ```jsx
 <ViewTransition
-  enter={{
-    "nav-forward": "nav-forward",
-    "nav-back": "nav-back",
-    default: "none",
-  }}
-  exit={{
-    "nav-forward": "nav-forward",
-    "nav-back": "nav-back",
-    default: "none",
-  }}
+  enter={{ "nav-forward": "nav-forward", "nav-back": "nav-back", default: "none" }}
+  exit={{ "nav-forward": "nav-forward", "nav-back": "nav-back", default: "none" }}
   default="none"
 >
   <div>...page content...</div>
 </ViewTransition>
 ```
 
-The `nav-forward` and `nav-back` CSS classes from the CSS Animation Recipes section produce horizontal slides. For simpler apps where directional motion isn't needed, a bare `<ViewTransition default="none">` wrapper with `enter="fade-in"` / `exit="fade-out"` works too.
-
-Extract this into a reusable component so every page doesn't repeat the verbose type map:
+Extract into a reusable component so every page doesn't repeat the type map:
 
 ```jsx
 export function DirectionalTransition({ children }: { children: React.ReactNode }) {
@@ -489,102 +407,82 @@ export function DirectionalTransition({ children }: { children: React.ReactNode 
 }
 ```
 
-This also becomes the single place to adjust if you add new transition types later.
-
-**Rules:**
-- Always pair `enter` with `exit` — without an exit animation, the old page disappears instantly while the new one animates in.
-- Always include `default: "none"` in type map objects and `default="none"` on the component — otherwise it fires on every transition.
-- Place the directional `<ViewTransition>` in each page component, not in a layout. Layouts persist across navigations and never trigger enter/exit.
-- Only use directional slides for hierarchical navigation or ordered sequences (prev/next). Lateral/sibling navigation (tab-to-tab) should use a bare `<ViewTransition>` (cross-fade) or `default="none"`.
+**Rules:** Always pair `enter` with `exit`. Always include `default: "none"`. Place in page components, not layouts. Only use directional slides for hierarchical navigation or ordered sequences (prev/next).
 
 ## Step 5: Add Suspense Reveals
 
-For every `<Suspense>` boundary identified in Step 1, wrap the fallback and content in separate `<ViewTransition>`s:
-
 ```jsx
-<Suspense
-  fallback={
-    <ViewTransition exit="slide-down">
-      <Skeleton />
-    </ViewTransition>
-  }
->
-  <ViewTransition enter="slide-up" default="none">
-    <AsyncContent />
-  </ViewTransition>
+<Suspense fallback={<ViewTransition exit="slide-down"><Skeleton /></ViewTransition>}>
+  <ViewTransition enter="slide-up" default="none"><AsyncContent /></ViewTransition>
 </Suspense>
 ```
 
-This example uses `slide-down` / `slide-up` for directional vertical motion. For a simpler reveal, a bare `<ViewTransition>` around the `<Suspense>` gives a cross-fade with zero configuration. Choose based on the spatial meaning — consult the "Choosing the Right Animation Style" table in the main skill file.
-
-**Rules:**
-- Always use `default="none"` on the content `<ViewTransition>` to prevent re-animation on revalidation or unrelated transitions.
-- Use simple string props (not type maps) on Suspense `<ViewTransition>`s — Suspense resolves fire as separate transitions with no type, so type-keyed props won't match.
-- If the same element appears in **both** the fallback and the content (a title, a heading), it flickers on reveal — an opacity dip. Render it **outside** the `<Suspense>` boundary (or pin it), so it isn't in both. See "Suspense reveal flicker" in the Patterns and Guidelines section.
+Use `default="none"` on content VT. Use simple string props (not type maps) — Suspense resolves have no type.
 
 ## Step 6: Add Shared Element Transitions
 
-For every shared visual element identified in Step 1, add matching named `<ViewTransition>` wrappers on both the source and target views:
-
 ```jsx
-// On the source view (e.g., list/grid page)
+// Source view
 <ViewTransition name={`photo-${photo.id}`} share="morph" default="none">
   <Image src={photo.src} ... />
 </ViewTransition>
 
-// On the target view (e.g., detail page) — same name
+// Target view — same name
 <ViewTransition name={`photo-${photo.id}`} share="morph">
   <Image src={photo.src} ... />
 </ViewTransition>
 ```
 
-The `share="morph"` class uses the morph recipe from the CSS Animation Recipes section (controlled duration + motion blur). For a simpler cross-fade, use `share="auto"` (browser default).
+When list items contain shared elements, compose both patterns — two independent layers:
 
-When list items contain shared elements, compose both patterns with two nested `<ViewTransition>` layers — see "Composing Shared Elements with List Identity" in `SKILL.md`.
+```jsx
+{items.map(item => (
+  <ViewTransition key={item.id}>                                        {/* list identity */}
+    <Link href={`/detail/${item.id}`}>
+      <ViewTransition name={`item-${item.id}`} share="morph" default="none">  {/* shared element */}
+        <Image src={item.image} ... />
+      </ViewTransition>
+    </Link>
+  </ViewTransition>
+))}
+```
 
-**Rules:**
-- Names must be globally unique — use prefixes like `photo-${id}`.
-- Add `default="none"` on list-side shared elements to prevent per-item cross-fades on filter/search updates.
-- The target must be **in the DOM at navigation time** for the pair to form. If it's behind a Suspense fallback (not rendered yet), no pair forms and it won't morph. It works when the target is present at the snapshot — render it above the data boundary, or have its data **cached/prefetched** so it resolves in time.
+The outer VT handles list reorder/enter. The inner VT handles cross-route shared element morph. Missing either layer means that animation silently doesn't happen.
+
+**Rules:** Names must be globally unique. Add `default="none"` on list-side shared elements.
 
 ## Step 7: Verify Each Navigation Path
 
-Walk through every row in the navigation map from Step 1 and confirm:
+Walk through every row in the navigation map from Step 1:
 
-- Does the VT mount/unmount on this navigation, or does it stay mounted (same-route)?
+- Does the VT mount/unmount, or stay mounted (same-route)?
 - For named VTs: does a shared pair form? If not, does `enter`/`exit` provide a fallback?
 - Does `default="none"` block an animation you actually want?
-- Do persistent elements stay static (not sliding with page content)?
+- Do persistent elements stay static?
 - Do Suspense reveals animate independently from directional navigations?
-
-If any path produces no animation or competing animations, revisit the relevant step.
 
 ---
 
 ## Common Mistakes
 
-- **Bare `<ViewTransition>` without props** — without `default="none"`, it fires the browser's default cross-fade on every transition (every navigation, every Suspense resolve, every revalidation). Always set `default="none"` and explicitly enable only the triggers you want.
-- **Directional `<ViewTransition>` in a layout** — layouts persist across navigations and never unmount/remount. `enter`/`exit` props won't fire on route changes. Place the outer type-keyed `<ViewTransition>` in each page component.
-- **Fade-out exit with shared element morphs** — the page dissolving conflicts with the morph. Use a directional slide exit instead.
-- **Writing custom animation CSS** — the recipes in the CSS Animation Recipes section handle staggered timing, motion blur on morphs, and reduced motion. Copy them; don't reinvent them.
-- **Missing `default: "none"` in type-keyed objects** — TypeScript requires a `default` key, and without it the fallback is `"auto"` which fires on every transition.
-- **Type maps on Suspense reveals** — Suspense resolves fire as separate transitions with no type. Type-keyed props won't match — use simple string props instead.
-- **Raw `viewTransitionName` CSS to trigger animations** — React only calls `document.startViewTransition` when `<ViewTransition>` components are in the tree. A bare `viewTransitionName` style is for isolating elements from a parent's snapshot, not for triggering animations.
-- **`update` trigger for same-route navigations** — nested VTs inside the content steal the mutation from the parent, so `update` never fires on the outer VT. Use `key` + `name` + `share` instead.
+- **Bare VT without `default="none"`** — fires cross-fade on every transition
+- **Directional VT in a layout** — layouts persist, enter/exit won't fire on route changes
+- **Fade-out exit with shared morphs** — conflicts with morph, use directional slide
+- **Writing custom animation CSS** — use the recipes
+- **Missing `default: "none"` in type-keyed objects** — TypeScript requires it, fallback is `"auto"`
+- **Type maps on Suspense reveals** — Suspense resolves have no type, use string props
+- **Raw `viewTransitionName` CSS to trigger animations** — React only starts view transitions when `<ViewTransition>` components are in the tree. Bare `viewTransitionName` is for isolating elements, not triggering animations.
+- **`update` trigger for same-route navigations** — nested VTs steal the mutation from the parent. Use `key` + `name` + `share` instead.
 - **Named VT in a reusable component** — if a component with a named VT is rendered in both a modal/popover *and* a page, both mount simultaneously and break the morph. Make the name conditional or move it to the specific consumer.
-- **`router.back()` for back navigation** — traversals carry no transition types, so type-keyed animations don't play (untyped morphs still can). Use `router.push()` with an explicit URL for a fully animated back affordance.
+- **`router.back()` for back navigation** — `router.back()` triggers synchronous `popstate`, incompatible with view transitions. Use `router.push()` with an explicit URL.
 
----
-
-For Next.js-specific implementation steps (config flag, `transitionTypes` on `<Link>`, same-route dynamic segments), see the View Transitions in Next.js section.
+For Next.js-specific steps, see the Next.js section below.
 
 ---
 
 # Patterns and Guidelines
 
 ## Searchable Grid with `useDeferredValue`
-
-`useDeferredValue` makes filter updates a transition, activating `<ViewTransition>`:
 
 ```tsx
 'use client';
@@ -608,19 +506,9 @@ export default function SearchableGrid({ itemsPromise }) {
 }
 ```
 
-Per-item `<ViewTransition name={...}>` inside a deferred list triggers cross-fades on every keystroke. Fix with `default="none"`:
-
-```tsx
-{filteredItems.map(item => (
-  <ViewTransition key={item.id} name={`item-${item.id}`} share="morph" default="none">
-    <ItemCard item={item} />
-  </ViewTransition>
-))}
-```
+Per-item named VTs in deferred lists trigger cross-fades on every keystroke. Fix with `default="none"`.
 
 ## Card Expand/Collapse with `startTransition`
-
-Toggle between grid and detail view with shared element morph:
 
 ```tsx
 'use client';
@@ -661,168 +549,58 @@ export default function ItemGrid({ items }) {
 }
 ```
 
-## Type-Safe Transition Helpers
-
-Use `as const` arrays and derived types to prevent ID clashes:
-
-```tsx
-const transitionTypes = ['default', 'transition-to-detail', 'transition-to-list'] as const;
-const animationTypes = ['auto', 'none', 'animate-slide-from-left', 'animate-slide-from-right'] as const;
-
-type TransitionType = (typeof transitionTypes)[number];
-type AnimationType = (typeof animationTypes)[number];
-type TransitionMap = { default: AnimationType } & Partial<Record<Exclude<TransitionType, 'default'>, AnimationType>>;
-
-export function HorizontalTransition({ children, enter, exit }: {
-  children: React.ReactNode;
-  enter: TransitionMap;
-  exit: TransitionMap;
-}) {
-  return <ViewTransition enter={enter} exit={exit}>{children}</ViewTransition>;
-}
-```
-
 ## Cross-Fade Without Remount
 
-Omit `key` to trigger an update (cross-fade) instead of exit + enter. Avoids Suspense remount/refetch:
+Omit `key` to trigger update (cross-fade) instead of exit + enter. Avoids Suspense remount:
 
 ```jsx
-<ViewTransition>
-  <TabPanel tab={activeTab} />
-</ViewTransition>
+<ViewTransition><TabPanel tab={activeTab} /></ViewTransition>
 ```
-
-Use `key` when content identity changes (state resets). Omit for cross-fades (tabs, panels, carousel).
 
 ## Isolate Elements from Parent Animations
 
-Pull an element out of the animated `root` snapshot by giving it its own `view-transition-name`. **`view-transition-name: none` is a no-op** — it's the CSS default, so the element stays in `root` (a common flicker bug). Use a real, unique name, then neutralize with `<ViewTransition default="none">` (no CSS) or CSS (needed for `z-index`/`display` control — see the CSS Animation Recipes section).
-
-- **Persistent chrome** (nav, sidebar, player bar): `<nav style={{ viewTransitionName: 'persistent-nav' }}>` + isolation CSS. `<ViewTransition default="none">` works too, but its auto-name can't take `z-index`/backdrop `display:none` — hand-name when you need those.
-- **Floating elements** (popovers, menus): left open, they're captured in `root` and flicker on settle. Real name + isolation (the CSS Animation Recipes section → Floating Element Isolation). A static name is fine if only one is mounted (`unmountOnHide`); native top-layer (`popover`/`<dialog>`) settle-flicker is a browser limit.
-- **Naming an interactive element has a cost:** named participants are skipped by hit-testing while a transition runs ([csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)) — clicks and hover fall through to whatever is beneath. Portal named popovers/menus; rendered inline in a clickable row, mid-transition clicks activate the row and read as outside-clicks that close the popover.
-- **Third-party floating components** (toast libraries, portals you don't render): put the name on an always-mounted wrapper you own — `<div style={{ viewTransitionName: 'toaster' }} className="pointer-events-none fixed inset-0">`. Library containers often unmount when empty, so naming them directly leaves the group unpinned exactly when a toast appears mid-transition. Name a dialog's backdrop separately from its panel so each pins independently.
-
-## Suspense reveal flicker
-
-An element rendered in **both** the fallback and the content flickers (opacity dip) on reveal — it fades against itself. Not a morph. **Fix: render it outside the `<Suspense>` boundary** (mount once, above it), or pin it with a `view-transition-name`.
+Persistent elements get captured in page's transition snapshot. Fix with `viewTransitionName`:
 
 ```jsx
-<h1>{title}</h1>
-<Suspense fallback={<BodySkeleton />}><Body /></Suspense>
+<nav style={{ viewTransitionName: "persistent-nav" }}>{/* ... */}</nav>
 ```
 
-Don't put a manual `viewTransitionName` on the root DOM node inside `<ViewTransition>` — React's auto-name overrides it.
-
-## Sliding Indicator (tabs)
-
-One shared-name indicator rendered under the **active** tab morphs between positions on change (slide the group, disable old/new — see the CSS Animation Recipes section → Sliding Indicator). Render it only under the active tab so exactly one element holds `indicatorName`; use a distinct `indicatorName` per tab strip. Trigger the state change inside `startTransition` so the move animates. Whatever owns `active` drives it — local state here, routing in Next (see the View Transitions in Next.js section → Routing-Driven Tabs).
-
-```tsx
-import { useState, useTransition, ViewTransition } from 'react';
-
-export function Tabs({ tabs, indicatorName = 'tab-indicator' }) {
-  const [active, setActive] = useState(tabs[0].value);
-  const [, startTransition] = useTransition();
-  return (
-    <nav>
-      {tabs.map(t => (
-        <button key={t.value} type="button"
-          aria-current={active === t.value ? 'page' : undefined}
-          onClick={() => startTransition(() => setActive(t.value))}>
-          <span>{t.label}</span>
-          {active === t.value && (
-            <ViewTransition name={indicatorName} share="tab-underline">
-              <span className="active-underline" aria-hidden />
-            </ViewTransition>
-          )}
-        </button>
-      ))}
-    </nav>
-  );
-}
+```css
+::view-transition-group(persistent-nav) { animation: none; z-index: 100; }
 ```
 
-Because the state change is a transition, if the newly-active tab renders suspending content the whole update — indicator **and** `aria-current` — waits for it to commit, and the strip feels dead on click. Give the controls an immediate value with `useOptimistic` (drive `aria-current` from it) so feedback is instant while the content streams. The routing variant (the View Transitions in Next.js section → Routing-Driven Tabs) does exactly this: optimistic `aria-current`, committed `active` for the bar.
+Same for floating elements (popovers, tooltips). Global fix: `::view-transition-group(*) { z-index: 100; }`
 
-## Layout Displacement Morph
+## Shared Controls Between Skeleton and Content
 
-Only content inside an activated boundary animates position — everything else teleports to its new layout spot. When a list grows or shrinks, wrap the sibling content below it so it glides instead of jumping:
-
-```jsx
-<FavoritesList />              {/* rows enter/exit */}
-<ViewTransition>               {/* bare: update enabled */}
-  <section>
-    <h2>You Might Also Like</h2>
-    <Recommendations />
-  </section>
-</ViewTransition>
-```
-
-The section — heading included — morphs as one group when rows above are added or removed. Nothing inside the section changed; the *displacement* is the update.
-
-- React only measures boundaries that are direct children of nodes along the changed path — a VT buried under an extra wrapper element won't activate. Place the boundary as a direct sibling of the changing content.
-- Sometimes the better fix is no morph at all: pad fixed-size lists to a constant slot count with invisible fillers so the grid never changes height and nothing below it moves.
-- `default="none"` disables exactly this morph — it turns off `update`. Named/shared elements get `default="none"`; displaced siblings and keyed list items stay bare or set `update="auto"`.
+Give matching controls the same `viewTransitionName`. Don't put manual `viewTransitionName` on root DOM node inside `<ViewTransition>`.
 
 ## Reusable Animated Collapse
 
 ```jsx
 function AnimatedCollapse({ open, children }) {
   if (!open) return null;
-  return (
-    <ViewTransition enter="expand-in" exit="collapse-out">
-      {children}
-    </ViewTransition>
-  );
+  return <ViewTransition enter="expand-in" exit="collapse-out">{children}</ViewTransition>;
 }
-
-// Usage: toggle with startTransition
-<button onClick={() => startTransition(() => setOpen(o => !o))}>Toggle</button>
-<AnimatedCollapse open={open}><SectionContent /></AnimatedCollapse>
 ```
 
-## Composing with Activity
-
-`Activity` is orthogonal to view transitions: it preserves the state of a hidden subtree, `ViewTransition` animates it. Compose them for an in-page show/hide (drawer, panel, tab body) that keeps its scroll/form state while it animates in and out:
+## Preserve State with Activity
 
 ```jsx
 <Activity mode={isVisible ? 'visible' : 'hidden'}>
-  <ViewTransition enter="slide-in" exit="slide-out">
-    <Sidebar />
-  </ViewTransition>
+  <ViewTransition enter="slide-in" exit="slide-out"><Sidebar /></ViewTransition>
 </Activity>
 ```
 
-Only reach for Activity when there's state worth preserving — a stateless element (e.g. the sliding indicator above) gains nothing from it. In Next.js, layout-hosted chrome already persists across navigations without Activity (see the View Transitions in Next.js section).
-
 ## Exclude Elements with `useOptimistic`
 
-`useOptimistic` values update before the transition snapshot, excluding them from animation. Use for controls (labels); use committed state for animated content:
-
-```tsx
-const [sort, setSort] = useState('newest');
-const [optimisticSort, setOptimisticSort] = useOptimistic(sort);
-
-function cycleSort() {
-  const nextSort = getNextSort(optimisticSort);
-  startTransition(() => {
-    setOptimisticSort(nextSort);  // before snapshot — no animation
-    setSort(nextSort);            // between snapshots — animates
-  });
-}
-
-<button>Sort: {LABELS[optimisticSort]}</button>
-{items.sort(comparators[sort]).map(item => (
-  <ViewTransition key={item.id}><ItemCard item={item} /></ViewTransition>
-))}
-```
+`useOptimistic` values update before snapshot, excluding them from animation. Use for controls; use committed state for animated content.
 
 ---
 
 ## View Transition Events
 
-Imperative control via `onEnter`, `onExit`, `onUpdate`, `onShare`. Return a cleanup function to cancel your animation when the transition finishes. `onShare` takes precedence over `onEnter`/`onExit`.
+Imperative control via `onEnter`, `onExit`, `onUpdate`, `onShare`. Always return cleanup. `onShare` takes precedence.
 
 ```jsx
 <ViewTransition
@@ -838,9 +616,7 @@ Imperative control via `onEnter`, `onExit`, `onUpdate`, `onShare`. Return a clea
 </ViewTransition>
 ```
 
-The `instance` object: `instance.old`, `instance.new`, `instance.group`, `instance.imagePair`, `instance.name`.
-
-The `types` array (second argument) lets you vary animation based on transition type.
+`instance`: `.old`, `.new`, `.group`, `.imagePair`, `.name`
 
 ---
 
@@ -848,58 +624,38 @@ The `types` array (second argument) lets you vary animation based on transition 
 
 | Interaction | Duration |
 |------------|----------|
-| Direct toggle (expand/collapse) | 100–200ms |
-| Route transition (slide) | 150–250ms |
-| Suspense reveal (skeleton → content) | 200–400ms |
+| Direct toggle | 100–200ms |
+| Route transition | 150–250ms |
+| Suspense reveal | 200–400ms |
 | Shared element morph | 300–500ms |
 
 ---
 
 ## Troubleshooting
 
-**VT not activating:** Ensure `<ViewTransition>` comes before any DOM node. Ensure state update is inside `startTransition`.
+**VT not activating:** Ensure VT comes before any DOM node. Ensure `startTransition`.
 
-**"Two ViewTransition components with the same name":** Names must be globally unique. Use IDs: `name={`hero-${item.id}`}`.
+**"Two VTs with same name":** Names must be globally unique. Use IDs.
 
-**Scrolling hangs while a transition animates:** the `::view-transition` overlay is `position: fixed` and its snapshots don't scroll — a browser limitation, not fixable in React (skipping snaps to the end). Keep reveal durations short; for scroll-driven UI use gesture transitions (experimental `useSwipeTransition`, if available).
+**`router.back()` and browser back/forward skip animation:** Use `router.push()` with an explicit URL instead.
 
-**Open popover flickers when a background transition settles:** it's captured in `root`. Give it a real `view-transition-name` + isolation (not `none`) — see "Floating Elements".
+**Only updates animate:** Without `<Suspense>`, React treats swaps as updates. Conditionally render the VT itself, or wrap in `<Suspense>`.
 
-**Popover closes or goes dead when clicked mid-transition:** named participants are skipped by hit-testing while a transition runs; clicks land on what's beneath and read as outside-clicks. Portal the popover (see "Isolate Elements from Parent Animations"); brief dead clicks during the transition remain — that's the price of the name.
-
-**Shared morph silently not firing:** `share` resolved to `none`. Either the VT has `default="none"` with no explicit `share` prop, or `share` is type-keyed and the navigation never adds the type — the link needs `transitionTypes` (or `addTransitionType` in the transition).
-
-**Section below a list teleports instead of gliding:** it's outside any activated boundary, its VT has `default="none"` (which disables `update`), or it isn't an immediate sibling of the changing content. See "Layout Displacement Morph" above.
-
-**`router.back()` and browser back/forward skip the directional slide:** traversals carry no transition types, so type-keyed maps resolve to `default` — untyped shared-element morphs still apply. Use `router.push()` for typed animations.
-
-**`flushSync` skips animations:** Use `startTransition` instead.
-
-**Only updates animate (no enter/exit):** Without `<Suspense>`, React treats swaps as updates. Conditionally render the VT itself, or wrap in `<Suspense>`.
-
-**Layout VT prevents page VTs from animating:** nested VTs skip their own enter/exit only when they mount/unmount *as one unit* with a parent VT. If page enter/exit is dead under a persistent layout VT, the usual culprit is a DOM node above the page VT. Keep VTs in pages, not layouts.
-
-**List reorder not animating with `useOptimistic`:** Optimistic values resolve before snapshot. Use committed state for list order.
+**Layout VT prevents page VTs from animating:** Nested VTs never fire enter/exit inside a parent VT. If your layout has a VT wrapping `{children}`, page-level enter/exit will silently not work. Remove the layout VT.
 
 **TS error "Property 'default' is missing":** Type-keyed objects require a `default` key.
 
-**Hash fragments cause scroll jumps:** Navigate without hash; scroll programmatically after navigation.
+**Backdrop-blur flickers:** `::view-transition-old(name) { display: none }` + `::view-transition-new(name) { animation: none }`.
 
-**Backdrop-blur flickers:** Use the backdrop-blur workaround from the CSS Animation Recipes section.
+**`border-radius` lost:** Apply `border-radius` directly to captured element.
 
-**`border-radius` lost during transitions:** Apply `border-radius` directly to the captured element.
-
-**Skeleton controls slide away:** Give matching controls the same `viewTransitionName`.
-
-**Batching:** Multiple updates during animation are batched. A→B→C→D becomes B→D.
+**Batching:** Multiple updates during animation are batched (A→B→C→D becomes B→D).
 
 ---
 
 # CSS Animation Recipes
 
-Ready-to-use CSS for `<ViewTransition>` props. Copy into your global stylesheet.
-
----
+Ready-to-use CSS for `<ViewTransition>` props. Copy into global stylesheet.
 
 ## Timing Variables
 
@@ -930,8 +686,6 @@ Ready-to-use CSS for `<ViewTransition>` props. Copy into your global stylesheet.
 }
 ```
 
----
-
 ## Fade
 
 ```css
@@ -942,10 +696,6 @@ Ready-to-use CSS for `<ViewTransition>` props. Copy into your global stylesheet.
   animation: var(--duration-enter) ease-out var(--duration-exit) both fade;
 }
 ```
-
-Usage: `<ViewTransition enter="fade-in" exit="fade-out" />`
-
----
 
 ## Slide (Vertical)
 
@@ -962,46 +712,7 @@ Usage: `<ViewTransition enter="fade-in" exit="fade-out" />`
 }
 ```
 
-Usage:
-```jsx
-<Suspense fallback={<ViewTransition exit="slide-down"><Skeleton /></ViewTransition>}>
-  <ViewTransition default="none" enter="slide-up"><Content /></ViewTransition>
-</Suspense>
-```
-
----
-
 ## Directional Navigation
-
-### Separate Enter/Exit Classes
-
-```css
-::view-transition-new(.slide-from-right) {
-  --slide-offset: 60px;
-  animation:
-    var(--duration-enter) ease-out var(--duration-exit) both fade,
-    var(--duration-move) ease-in-out both slide;
-}
-::view-transition-old(.slide-to-left) {
-  --slide-offset: -60px;
-  animation:
-    var(--duration-exit) ease-in both fade reverse,
-    var(--duration-move) ease-in-out both slide reverse;
-}
-
-::view-transition-new(.slide-from-left) {
-  --slide-offset: -60px;
-  animation:
-    var(--duration-enter) ease-out var(--duration-exit) both fade,
-    var(--duration-move) ease-in-out both slide;
-}
-::view-transition-old(.slide-to-right) {
-  --slide-offset: 60px;
-  animation:
-    var(--duration-exit) ease-in both fade reverse,
-    var(--duration-move) ease-in-out both slide reverse;
-}
-```
 
 ### Single-Class Approach
 
@@ -1033,7 +744,35 @@ Usage:
 }
 ```
 
----
+### Separate Enter/Exit Classes
+
+```css
+::view-transition-new(.slide-from-right) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+::view-transition-old(.slide-to-left) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+
+::view-transition-new(.slide-from-left) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+::view-transition-old(.slide-to-right) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+```
 
 ## Shared Element Morph
 
@@ -1041,17 +780,13 @@ Usage:
 ::view-transition-group(.morph) {
   animation-duration: var(--duration-move);
 }
-
 ::view-transition-image-pair(.morph) {
   animation-name: via-blur;
 }
-
 @keyframes via-blur {
   30% { filter: blur(3px); }
 }
 ```
-
-Usage: `<ViewTransition name={`product-${id}`} share="morph" />`
 
 **Note:** Shared element transitions take raster snapshots. For text with significant size differences (e.g., `<h3>` → `<h1>`), the old snapshot gets scaled up, producing a visible ghost artifact. Use `text-morph` for text shared elements.
 
@@ -1073,10 +808,6 @@ Avoids raster scaling artifacts on text by hiding the old snapshot and showing t
 }
 ```
 
-Usage: `<ViewTransition name={`title-${id}`} share="text-morph" />`
-
----
-
 ## Scale
 
 ```css
@@ -1086,7 +817,6 @@ Usage: `<ViewTransition name={`title-${id}`} share="text-morph" />`
 ::view-transition-new(.scale-in) {
   animation: var(--duration-enter) ease-out var(--duration-exit) both scale-up;
 }
-
 @keyframes scale-down {
   from { transform: scale(1); opacity: 1; }
   to { transform: scale(0.85); opacity: 0; }
@@ -1097,43 +827,6 @@ Usage: `<ViewTransition name={`title-${id}`} share="text-morph" />`
 }
 ```
 
-Usage: `<ViewTransition enter="scale-in" exit="scale-out" />`
-
----
-
-## Interactivity During Transitions
-
-The `::view-transition` overlay captures all pointer events. React shrinks it to zero when the root group doesn't animate, but in-flight animations still block clicks. To pass clicks/hover through even while animating:
-
-```css
-::view-transition {
-  pointer-events: none;
-}
-```
-
-Trade-offs: clicks can hit live elements under still-moving snapshots, and it only helps **unnamed** content — named participants are skipped by hit-testing for the transition's duration, no CSS override ([csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)). Weigh that before naming interactive elements; portal named popovers (see the Patterns and Guidelines section).
-
----
-
-## No Root Cross-Fade (Live Root)
-
-The root cross-fades on every transition, freezing unnamed content behind a stale snapshot — hover and active styles stop rendering until it settles. `::view-transition-new(root)` is a **live** capture, so disabling the root animation keeps unnamed regions rendering (and, with the `pointer-events` recipe above, interactive):
-
-```css
-::view-transition-old(root) {
-  display: none;
-}
-::view-transition-new(root) {
-  animation: none;
-}
-```
-
-Named and classed groups still animate — they stack above root. Trade-off: unnamed content swaps instantly, so regions that should fade need their own VT. This also removes the main reason to hand-name static chrome; keep names only for elements that must stack above animating groups.
-
-Pairs well with enter-only reveals: skip the fallback-exit VT entirely (`<ViewTransition enter="auto" default="none">` around the content, nothing on the skeleton) — the skeleton snaps out live while the content fades in.
-
----
-
 ## Persistent Element Isolation
 
 ```css
@@ -1143,53 +836,12 @@ Pairs well with enter-only reveals: skip the fallback-exit VT entirely (`<ViewTr
 }
 ```
 
-Layer multiple pinned groups with z-index tiers — chrome at `100`, toasts/overlays that must beat everything at `200`.
-
 ### Backdrop-Blur Workaround
 
-For elements with `backdrop-filter`, hide the old snapshot to avoid flash:
-
 ```css
-::view-transition-old(persistent-nav) {
-  display: none;
-}
-::view-transition-new(persistent-nav) {
-  animation: none;
-}
+::view-transition-old(persistent-nav) { display: none; }
+::view-transition-new(persistent-nav) { animation: none; }
 ```
-
-### Floating Element Isolation (popovers, menus, tooltips, control clusters)
-
-Same freeze as persistent chrome. A floating/interactive element left rendered while a background transition runs is otherwise captured in the `root` snapshot and flickers as it settles. Give it a real, unique `view-transition-name` (never `none` — that's the CSS default = no isolation) and:
-
-```css
-::view-transition-group(popover) {
-  animation: none;
-  z-index: 100;
-}
-::view-transition-old(popover),
-::view-transition-new(popover) {
-  animation: none;
-}
-```
-
-### Sliding Indicator (tab underline / segmented pill)
-
-One shared-name indicator morphs between positions. Slide the group; disable old/new so the solid bar slides instead of cross-fading:
-
-```css
-::view-transition-group(.tab-underline) {
-  animation-duration: 220ms;
-  animation-timing-function: cubic-bezier(0.5, 0, 0.2, 1);
-}
-::view-transition-old(.tab-underline),
-::view-transition-new(.tab-underline) {
-  animation: none;
-  height: 100%;
-}
-```
-
----
 
 ## Reduced Motion
 
@@ -1210,138 +862,45 @@ One shared-name indicator morphs between positions. Slide the group; disable old
 
 ## Setup
 
-`<ViewTransition>` works out of the box — the bundled React canary ships it, and every `<Link>` navigation runs inside `React.startTransition`, so react-dom starts a view transition whenever affected `<ViewTransition>` components exist. Set the documented flag:
-
 ```js
 // next.config.js
-const nextConfig = {
-  experimental: { viewTransition: true },
-};
-module.exports = nextConfig;
+experimental: { viewTransition: true }
 ```
 
-(Historically the flag switched React to the experimental channel — required before `ViewTransition` reached canary. It no longer does; the experimental channel is only needed for `useSwipeTransition` gestures and `parentEnter`/`parentExit`, selected by other flags like `gestureTransition`.)
-
-Because every link click is a transition, any VT with `default="auto"` fires on **every** navigation — use `default="none"` to prevent competing animations.
-
-Do **not** install `react@canary` — see "Availability" for details.
-
----
+Wraps every `<Link>` navigation in `document.startViewTransition`. Use `default="none"` to prevent competing animations. Do **not** install `react@canary` — the App Router already bundles it.
 
 ## Next.js Implementation Additions
 
-When following the Implementation Workflow section, apply these additions:
+**After Step 2:** Enable the experimental flag.
 
-**After Step 2:** Enable the experimental flag above.
+**Step 4:** Use `transitionTypes` on `<Link>` (if available — see availability note below):
+```tsx
+<Link href="/photo/1" transitionTypes={["nav-forward"]}>View</Link>
+<Link href="/" transitionTypes={["nav-back"]}>Back</Link>
+```
 
-**Step 4:** Use `transitionTypes` on `<Link>` — see "The `transitionTypes` Prop" section below for usage and availability.
-
-**After Step 6:** For same-route dynamic segments (e.g., `/collection/[slug]`), use the `key` + `name` + `share` pattern — see Same-Route Dynamic Segment Transitions below.
-
----
+**After Step 6:** For same-route dynamic segments, use `key` + `name` + `share` pattern.
 
 ## Layout-Level ViewTransition
 
-**Do NOT add a layout-level VT wrapping `{children}` if pages have their own VTs.** Nested VTs never fire enter/exit when inside a parent VT — page-level enter/exit will silently not work. Remove the layout VT entirely.
+Don't add a layout-level VT wrapping `{children}` if pages have their own VTs — nested VTs never fire enter/exit inside a parent VT, so page-level enter/exit will silently not work. Remove the layout VT entirely. A bare VT in layout works only if pages have no VTs of their own. Layouts persist across navigations — don't use type-keyed maps in layouts.
 
-A bare `<ViewTransition>` in layout works only if pages have **no** VTs of their own.
+## The `transitionTypes` Prop
 
-**Layouts persist across navigations** — `enter`/`exit` only fire on initial mount, not on route changes. Don't use type-keyed maps in layouts. Because layouts persist, chrome hosted in one (nav, sidebar, player) keeps its state across navigations for free — no `Activity` needed. Reserve `Activity` for in-page show/hide (see the Patterns and Guidelines section → Composing with Activity).
-
----
-
-## The `transitionTypes` Prop on `next/link`
-
-No wrapper component needed, works in Server Components:
-
+Works in Server Components, no wrapper needed:
 ```tsx
-<Link href="/products/1" transitionTypes={['transition-to-detail']}>View Product</Link>
+<Link href="/products/1" transitionTypes={['nav-forward']}>View</Link>
 ```
 
-Replaces the manual pattern of `onNavigate` + `startTransition` + `addTransitionType` + `router.push()`. Reserve manual `startTransition` for non-link interactions (buttons, forms).
+**Availability:** Requires `experimental.viewTransition: true`. Available in Next.js 15+ canary builds and Next.js 16+. If unavailable, use `startTransition` + `addTransitionType` + `router.push()`. To check: `grep -r "transitionTypes" node_modules/next/dist/`. Reserve manual `startTransition` for non-link interactions.
 
-**Availability:** `transitionTypes` shipped in **Next.js 16.2.0** (it is not gated on the `experimental.viewTransition` flag). If unavailable, use `startTransition` + `addTransitionType` + `router.push()` (see Programmatic Navigation below). To check: `grep -r "transitionTypes" node_modules/next/dist/` — if no results, fall back to programmatic navigation.
+## `loading.tsx` as Suspense Boundary
 
----
-
-## Programmatic Navigation
-
-```tsx
-'use client';
-
-import { useRouter } from 'next/navigation';
-import { startTransition, addTransitionType } from 'react';
-
-function DetailButton({ href }: { href: string }) {
-  const router = useRouter();
-
-  function handleNavigate() {
-    startTransition(() => {
-      addTransitionType('nav-forward');
-      router.push(href);
-    });
-  }
-
-  return <button onClick={handleNavigate}>Open</button>;
-}
-```
-
----
+Next.js `loading.tsx` files are implicit `<Suspense>` boundaries. Wrap the skeleton in `<ViewTransition exit="...">` in `loading.tsx`, and the content in `<ViewTransition enter="..." default="none">` in the page. This is the Next.js-idiomatic equivalent of explicit `<Suspense fallback={...}>`. Same rules apply: use simple string props (not type maps) since Suspense reveals fire without transition types.
 
 ## Server-Side Filtering with `router.replace`
 
-For search/sort/filter that re-renders on the server (via URL params), use `startTransition` + `router.replace`. VTs activate because the state update is inside `startTransition`:
-
-```tsx
-'use client';
-
-import { useRouter } from 'next/navigation';
-import { startTransition } from 'react';
-
-function handleSort(sort: string) {
-  const router = useRouter();
-  startTransition(() => {
-    router.replace(`?sort=${sort}`);
-  });
-}
-```
-
-List items wrapped in `<ViewTransition key={item.id}>` will animate reorder. This is the server-component alternative to the client-side `useDeferredValue` pattern in the Patterns and Guidelines section.
-
----
-
-## Routing-Driven Tabs
-
-The generalized sliding indicator (the Patterns and Guidelines section → Sliding Indicator) driven by navigation instead of local state: tabs are `<Link>`s, `active` comes from the URL (a server prop), and `useOptimistic` slides the indicator instantly while the route commits. Key the mounted indicator to committed `active` so the bar lands where navigation actually settles.
-
-```tsx
-'use client';
-import Link from 'next/link';
-import { useOptimistic, useTransition, ViewTransition } from 'react';
-
-export function Tabs({ tabs, active, indicatorName = 'tab-indicator' }) {
-  const [optimisticActive, setOptimisticActive] = useOptimistic(active);
-  const [, startTransition] = useTransition();
-  return (
-    <nav>
-      {tabs.map(t => (
-        <Link key={t.value} href={t.href} scroll={false}
-          aria-current={optimisticActive === t.value ? 'page' : undefined}
-          onNavigate={() => startTransition(() => setOptimisticActive(t.value))}>
-          <span>{t.label}</span>
-          {active === t.value && (
-            <ViewTransition name={indicatorName} share="tab-underline">
-              <span className="active-underline" aria-hidden />
-            </ViewTransition>
-          )}
-        </Link>
-      ))}
-    </nav>
-  );
-}
-```
-
----
+For search/sort/filter that re-renders on the server (via URL params), use `startTransition` + `router.replace`. VTs activate because the update is inside `startTransition`. List items wrapped in `<ViewTransition key={item.id}>` animate reorder. This is the server-component alternative to the client-side `useDeferredValue` pattern.
 
 ## Two-Layer Pattern (Directional + Suspense)
 
@@ -1361,35 +920,15 @@ Directional slides + Suspense reveals coexist because they fire at different mom
 </ViewTransition>
 ```
 
----
-
-## `loading.tsx` as Suspense Boundary
-
-Next.js `loading.tsx` is an implicit `<Suspense>` boundary. Wrap the skeleton in `<ViewTransition exit="...">` in `loading.tsx`, and the content in `<ViewTransition enter="..." default="none">` in the page:
-
-```tsx
-// loading.tsx
-<ViewTransition exit="slide-down"><PhotoGridSkeleton /></ViewTransition>
-
-// page.tsx
-<ViewTransition enter="slide-up" default="none"><PhotoGrid photos={photos} /></ViewTransition>
-```
-
-Same rules as explicit `<Suspense>`: use simple string props (not type maps) since Suspense reveals fire without transition types.
-
----
-
 ## Shared Elements Across Routes
 
 ```tsx
 // List page
-{products.map((product) => (
-  <Link key={product.id} href={`/products/${product.id}`} transitionTypes={['nav-forward']}>
-    <ViewTransition name={`product-${product.id}`}>
-      <Image src={product.image} alt={product.name} width={400} height={300} />
-    </ViewTransition>
-  </Link>
-))}
+<Link href={`/products/${product.id}`} transitionTypes={['nav-forward']}>
+  <ViewTransition name={`product-${product.id}`}>
+    <Image src={product.image} alt={product.name} width={400} height={300} />
+  </ViewTransition>
+</Link>
 
 // Detail page — same name
 <ViewTransition name={`product-${product.id}`}>
@@ -1397,13 +936,9 @@ Same rules as explicit `<Suspense>`: use simple string props (not type maps) sin
 </ViewTransition>
 ```
 
-If the pair's `share` is type-keyed (or classed via CSS that expects a type), every `<Link>` between the two views must carry the type via `transitionTypes` — a plain link click resolves the share map's `default`, and if that's `none` the morph silently never fires.
-
----
-
 ## Same-Route Dynamic Segment Transitions
 
-When navigating between dynamic segments of the same route (e.g., `/collection/[slug]`), the router swaps subtrees keyed by the segment value rather than doing a plain unmount/mount — enter/exit don't fire reliably. Use `key` + `name` + `share`:
+Page stays mounted on dynamic segment change — enter/exit never fire. Use `key` + `name` + `share`:
 
 ```tsx
 <Suspense fallback={<Skeleton />}>
@@ -1413,18 +948,8 @@ When navigating between dynamic segments of the same route (e.g., `/collection/[
 </Suspense>
 ```
 
-- `key={slug}` forces unmount/remount on change
-- `name` + `share="auto"` creates a shared element crossfade
-- VT inside `<Suspense>` (without keying Suspense) keeps old content visible during loading
-
----
-
-## Nested enter/exit — `parentEnter` / `parentExit` (experimental)
-
-Lifts the "nested VTs don't fire enter/exit inside a parent" rule: a nested VT can animate when its **parent** enters/exits (`parentEnter`/`parentExit`, `onParentEnter`/`onParentExit`; `parentEnter="none"` stops propagation). Experimental-channel only today; SSR support landed in React PR #36917 ([commit](https://github.com/facebook/react/commit/83840902c890f0eb85decda239ef6b1b14945779)). Verify it's in the React your app runs: `grep -c "parentEnter" node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.production.js` — 0 means unavailable (Next uses the experimental channel only when `gestureTransition`/`blockingSSR`/`taint`/`transitionIndicator` is set).
-
 ## Server Components
 
-- `<ViewTransition>` works in both Server and Client Components
-- `<Link transitionTypes>` works in Server Components — no `'use client'` needed
-- `addTransitionType` and `startTransition` for programmatic nav require Client Components
+- `<ViewTransition>` works in Server and Client Components
+- `<Link transitionTypes>` works in Server Components
+- `addTransitionType` and programmatic nav require Client Components

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -74,7 +74,7 @@ React auto-assigns a unique `view-transition-name` and calls `document.startView
 |---------|--------------|
 | **enter** | `<ViewTransition>` first inserted during a Transition |
 | **exit** | `<ViewTransition>` first removed during a Transition |
-| **update** | DOM mutations inside a `<ViewTransition>`, or the boundary itself moving/resizing because content around it changed. With nested VTs, mutation applies to the innermost one |
+| **update** | DOM mutations inside a `<ViewTransition>`, or the boundary itself changing size/position due to an immediate sibling. With nested VTs, mutation applies to the innermost one |
 | **share** | Named VT unmounts and another with same `name` mounts in the same Transition |
 
 Only `startTransition`, `useDeferredValue`, or `Suspense` activate VTs. Regular `setState` does not animate.
@@ -229,19 +229,7 @@ Trigger inside `startTransition`. Avoid wrapper `<div>`s between list and VT.
 
 ### Layout Displacement Morph
 
-Only content inside an activated boundary animates position — everything else teleports to its new layout spot. When a list grows/shrinks, wrap the *sibling* content below it so it glides instead of jumping:
-
-```jsx
-<FavoritesList />              {/* rows enter/exit */}
-<ViewTransition>               {/* bare: update enabled */}
-  <section>
-    <h2>You Might Also Like</h2>
-    <Recommendations />
-  </section>
-</ViewTransition>
-```
-
-The section — heading included — morphs as one group when rows above are added or removed. `default="none"` disables exactly this: nothing inside the section changed, so the *displacement* is the update.
+Only content inside an activated boundary animates position — everything else teleports to its new layout spot. Wrap the sibling content below a growing/shrinking list in a bare `<ViewTransition>` so it glides instead of jumping. See `references/patterns.md` → Layout Displacement Morph.
 
 ### Composing Shared Elements with List Identity
 

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -44,7 +44,7 @@ Reserve directional slides for hierarchical navigation (list → detail) and ord
 
 - **Next.js:** Do **not** install `react@canary` — the App Router already bundles React canary internally. `ViewTransition` works out of the box. `npm ls react` may show a stable-looking version; this is expected.
 - **Without Next.js:** Install `react@canary react-dom@canary` (`ViewTransition` is not in stable React).
-- Browser support: Chromium 111+, Firefox 144+, Safari 18.2+. Graceful degradation on unsupported browsers.
+- Browser support: Chromium 125+, Firefox 144+, Safari 18.2+. React requires the v2 object form of `startViewTransition` and deliberately falls back to not animating on older engines (Chromium 111–124 only has the v1 callback form). Graceful degradation on unsupported browsers.
 
 ---
 
@@ -177,7 +177,7 @@ export function DirectionalTransition({ children }: { children: React.ReactNode 
 
 ### `router.back()` and Browser Back Button
 
-`router.back()` and the browser's back/forward buttons do **not** trigger view transitions (`popstate` is synchronous, incompatible with `startViewTransition`). Use `router.push()` with an explicit URL instead.
+`router.back()` and the browser's back/forward buttons do **not** animate: React renders transitions scheduled during a `popstate` event synchronously (`shouldAttemptEagerTransition`) to keep back/forward instant, and synchronous renders skip view transitions. Traversals also carry no transition types, so type-keyed maps resolve to their `default`. Use `router.push()` with an explicit URL instead.
 
 ### Types and Suspense
 
@@ -299,7 +299,7 @@ They coexist because they fire at different moments. `default="none"` on both pr
 
 ### Nested VT Limitation
 
-When a parent VT exits, nested VTs inside it do **not** fire their own enter/exit — only the outermost VT animates. Per-item staggered animations during page navigation are not possible today. See [react#36135](https://github.com/facebook/react/pull/36135) for an experimental opt-in fix.
+When a parent VT mounts/unmounts **as one unit** with nested VTs inside it, the nested ones do not fire their own enter/exit — only the outermost VT animates. (A child VT mounted inside a *persistent* parent VT fires enter/exit normally.) Per-item staggered animations during page navigation are not possible today; the experimental opt-in is the `parentEnter`/`parentExit` props ([react#36690](https://github.com/facebook/react/pull/36690), experimental channel only).
 
 ---
 

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -74,7 +74,7 @@ React auto-assigns a unique `view-transition-name` and calls `document.startView
 |---------|--------------|
 | **enter** | `<ViewTransition>` first inserted during a Transition |
 | **exit** | `<ViewTransition>` first removed during a Transition |
-| **update** | DOM mutations inside a `<ViewTransition>`. With nested VTs, mutation applies to the innermost one |
+| **update** | DOM mutations inside a `<ViewTransition>`, or the boundary itself moving/resizing because content around it changed. With nested VTs, mutation applies to the innermost one |
 | **share** | Named VT unmounts and another with same `name` mounts in the same Transition |
 
 Only `startTransition`, `useDeferredValue`, or `Suspense` activate VTs. Regular `setState` does not animate.
@@ -202,6 +202,7 @@ Same `name` on two VTs — one unmounting, one mounting — creates a shared ele
 
 - Only one VT with a given `name` can be mounted at a time — use unique names (`photo-${id}`). Watch for reusable components: if a component with a named VT is rendered in both a modal/popover *and* a page, both mount simultaneously and break the morph. Either make the name conditional (via a prop) or move the named VT out of the shared component into the specific consumer.
 - `share` takes precedence over `enter`/`exit`. Think through each navigation path: when no matching pair forms (e.g., the target page doesn't have the same name), `enter`/`exit` fires instead. Consider whether the element needs a fallback animation for those paths.
+- Two ways a wired-up morph silently never fires: (1) `default="none"` with no explicit `share` prop — share resolves to none; (2) type-keyed `share` where the navigation never adds the type — a plain link click resolves the map's `default`. Every link that should morph must add the type (`transitionTypes` on `next/link`, or `addTransitionType`).
 - Never use a fade-out exit on pages with shared morphs — use a directional slide instead.
 
 ---
@@ -225,6 +226,22 @@ Same `name` on two VTs — one unmounting, one mounting — creates a shared ele
 ```
 
 Trigger inside `startTransition`. Avoid wrapper `<div>`s between list and VT.
+
+### Layout Displacement Morph
+
+Only content inside an activated boundary animates position — everything else teleports to its new layout spot. When a list grows/shrinks, wrap the *sibling* content below it so it glides instead of jumping:
+
+```jsx
+<FavoritesList />              {/* rows enter/exit */}
+<ViewTransition>               {/* bare: update enabled */}
+  <section>
+    <h2>You Might Also Like</h2>
+    <Recommendations />
+  </section>
+</ViewTransition>
+```
+
+The section — heading included — morphs as one group when rows above are added or removed. `default="none"` disables exactly this: nothing inside the section changed, so the *displacement* is the update.
 
 ### Composing Shared Elements with List Identity
 
@@ -279,9 +296,11 @@ For more patterns, see `references/patterns.md`.
 
 Every VT matching the trigger fires simultaneously in a single `document.startViewTransition`. VTs in **different** transitions (navigation vs later Suspense resolve) don't compete.
 
-### Use `default="none"` Liberally
+### Use `default="none"` Deliberately
 
-Without it, every VT fires the browser cross-fade on **every** transition — Suspense resolves, `useDeferredValue` updates, background revalidations. Always use `default="none"` and explicitly enable only desired triggers.
+Without it, every VT fires the browser cross-fade on **every** transition — Suspense resolves, `useDeferredValue` updates, background revalidations. Use `default="none"` on named/shared elements and type-keyed page VTs.
+
+But know what it turns off: `default="none"` also disables `update` (layout displacement morphs — list reflow, sections gliding when content above changes) and `share` (a named pair with `default="none"` and no explicit `share` prop silently never morphs). Keyed list items and displaced siblings *want* update — leave them bare or set `update="auto"` explicitly.
 
 ### Two Patterns Coexist
 

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -177,7 +177,7 @@ export function DirectionalTransition({ children }: { children: React.ReactNode 
 
 ### `router.back()` and Browser Back Button
 
-`router.back()` and the browser's back/forward buttons do **not** animate: React renders transitions scheduled during a `popstate` event synchronously (`shouldAttemptEagerTransition`) to keep back/forward instant, and synchronous renders skip view transitions. Traversals also carry no transition types, so type-keyed maps resolve to their `default`. Use `router.push()` with an explicit URL instead.
+`router.back()` and the browser's back/forward buttons carry **no transition types**, so type-keyed animations (directional slides) resolve to their `default` and don't play. Untyped animations — shared-element morphs with matching `name`s, bare/`auto` VTs — can still run. (React may also render `popstate`-scheduled transitions eagerly/synchronously to keep back/forward instant, skipping transitions in some cases.) For a fully animated back affordance, use `router.push()` with an explicit URL.
 
 ### Types and Suspense
 

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -44,7 +44,7 @@ Reserve directional slides for hierarchical navigation (list → detail) and ord
 
 - **Next.js:** Do **not** install `react@canary` — the App Router already bundles React canary internally. `ViewTransition` works out of the box. `npm ls react` may show a stable-looking version; this is expected.
 - **Without Next.js:** Install `react@canary react-dom@canary` (`ViewTransition` is not in stable React).
-- Browser support: Chromium 125+, Firefox 144+, Safari 18.2+. React requires the v2 object form of `startViewTransition` and deliberately falls back to not animating on older engines (Chromium 111–124 only has the v1 callback form). Graceful degradation on unsupported browsers.
+- Browser support: Chromium 125+ (React needs the v2 object form of `startViewTransition`), Firefox 144+, Safari 18.2+. Graceful degradation on unsupported browsers.
 
 ---
 
@@ -177,7 +177,7 @@ export function DirectionalTransition({ children }: { children: React.ReactNode 
 
 ### `router.back()` and Browser Back Button
 
-`router.back()` and the browser's back/forward buttons carry **no transition types**, so type-keyed animations (directional slides) resolve to their `default` and don't play. Untyped animations — shared-element morphs with matching `name`s, bare/`auto` VTs — can still run. (React may also render `popstate`-scheduled transitions eagerly/synchronously to keep back/forward instant, skipping transitions in some cases.) For a fully animated back affordance, use `router.push()` with an explicit URL.
+`router.back()` and the browser's back/forward buttons carry **no transition types**, so type-keyed animations (directional slides) resolve to their `default` and don't play — untyped shared-element morphs still apply. For typed animations, use `router.push()` with an explicit URL.
 
 ### Types and Suspense
 
@@ -288,7 +288,7 @@ Every VT matching the trigger fires simultaneously in a single `document.startVi
 
 Without it, every VT fires the browser cross-fade on **every** transition — Suspense resolves, `useDeferredValue` updates, background revalidations. Use `default="none"` on named/shared elements and type-keyed page VTs.
 
-But know what it turns off: `default="none"` also disables `update` (layout displacement morphs — list reflow, sections gliding when content above changes) and `share` (a named pair with `default="none"` and no explicit `share` prop silently never morphs). Keyed list items and displaced siblings *want* update — leave them bare or set `update="auto"` explicitly.
+But it also turns off `update` (layout/reflow morphs) and `share` (a named pair with no explicit `share` prop never morphs). Keyed list items and displaced siblings *want* update — leave them bare or set `update="auto"`.
 
 ### Two Patterns Coexist
 

--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -50,7 +50,7 @@ Reserve directional slides for hierarchical navigation (list → detail) and ord
 
 ## Implementation Workflow
 
-When adding view transitions to an existing app, **follow `references/implementation.md` step by step.** Start with the audit — do not skip it. Copy the CSS recipes from `references/css-recipes.md` into the global stylesheet — do not write your own animation CSS.
+When adding view transitions to an existing app, **follow [references/implementation.md](references/implementation.md) step by step.** Start with the audit — do not skip it. Copy the CSS recipes from [references/css-recipes.md](references/css-recipes.md) into the global stylesheet — do not write your own animation CSS.
 
 ---
 
@@ -118,7 +118,7 @@ If `default` is `"none"`, all triggers are off unless explicitly listed.
 - `::view-transition-group(.class)` — container
 - `::view-transition-image-pair(.class)` — old + new pair
 
-See `references/css-recipes.md` for ready-to-use animation recipes.
+See [references/css-recipes.md](references/css-recipes.md) for ready-to-use animation recipes.
 
 ---
 
@@ -229,7 +229,7 @@ Trigger inside `startTransition`. Avoid wrapper `<div>`s between list and VT.
 
 ### Layout Displacement Morph
 
-Only content inside an activated boundary animates position — everything else teleports to its new layout spot. Wrap the sibling content below a growing/shrinking list in a bare `<ViewTransition>` so it glides instead of jumping. See `references/patterns.md` → Layout Displacement Morph.
+Only content inside an activated boundary animates position — everything else teleports to its new layout spot. Wrap the sibling content below a growing/shrinking list in a bare `<ViewTransition>` so it glides instead of jumping. See [Layout Displacement Morph](references/patterns.md#layout-displacement-morph).
 
 ### Composing Shared Elements with List Identity
 
@@ -276,7 +276,7 @@ Directional reveal:
 </Suspense>
 ```
 
-For more patterns, see `references/patterns.md`.
+For more patterns, see [references/patterns.md](references/patterns.md).
 
 ---
 
@@ -305,22 +305,22 @@ When a parent VT mounts/unmounts **as one unit** with nested VTs inside it, the 
 
 ## Next.js Integration
 
-For Next.js setup (`experimental.viewTransition` flag, `transitionTypes` prop on `next/link`, App Router patterns, Server Components), see `references/nextjs.md`.
+For Next.js setup (`experimental.viewTransition` flag, `transitionTypes` prop on `next/link`, App Router patterns, Server Components), see [references/nextjs.md](references/nextjs.md).
 
 ---
 
 ## Accessibility
 
-Always add the reduced motion CSS from `references/css-recipes.md` to your global stylesheet.
+Always add the reduced motion CSS from [references/css-recipes.md](references/css-recipes.md#reduced-motion) to your global stylesheet.
 
 ---
 
 ## Reference Files
 
-- **`references/implementation.md`** — Step-by-step implementation workflow.
-- **`references/patterns.md`** — Patterns, animation timing, events API, troubleshooting.
-- **`references/css-recipes.md`** — Ready-to-use CSS animation recipes.
-- **`references/nextjs.md`** — Next.js App Router patterns and Server Component details.
+- **[references/implementation.md](references/implementation.md)** — Step-by-step implementation workflow.
+- **[references/patterns.md](references/patterns.md)** — Patterns, animation timing, events API, troubleshooting.
+- **[references/css-recipes.md](references/css-recipes.md)** — Ready-to-use CSS animation recipes.
+- **[references/nextjs.md](references/nextjs.md)** — Next.js App Router patterns and Server Component details.
 
 ## Full Compiled Document
 

--- a/skills/react-view-transitions/references/css-recipes.md
+++ b/skills/react-view-transitions/references/css-recipes.md
@@ -233,6 +233,8 @@ The root cross-fades on every transition, freezing unnamed content behind a stal
 
 Named and classed groups still animate — they stack above root. Trade-off: unnamed content swaps instantly, so regions that should fade need their own VT. This also removes the main reason to hand-name static chrome; keep names only for elements that must stack above animating groups.
 
+Pairs well with enter-only reveals: skip the fallback-exit VT entirely (`<ViewTransition enter="auto" default="none">` around the content, nothing on the skeleton) — the skeleton snaps out live while the content fades in.
+
 ---
 
 ## Persistent Element Isolation

--- a/skills/react-view-transitions/references/css-recipes.md
+++ b/skills/react-view-transitions/references/css-recipes.md
@@ -206,7 +206,7 @@ Usage: `<ViewTransition enter="scale-in" exit="scale-out" />`
 
 ## Interactivity During Transitions
 
-The `::view-transition` overlay covers the viewport and blocks all interaction by default. Let clicks and hover pass through to the live page:
+The `::view-transition` overlay covers the viewport and captures all pointer events by default. React partially handles this: when the root group doesn't need to animate, it shrinks the overlay to zero size so the page stays interactive — but it deliberately leaves `pointer-events` alone so in-flight animations still block clicks (so they don't land on whatever is beneath a moving snapshot). To let clicks and hover pass through even while animations run:
 
 ```css
 ::view-transition {
@@ -214,7 +214,7 @@ The `::view-transition` overlay covers the viewport and blocks all interaction b
 }
 ```
 
-This only restores interactivity for **unnamed** content. Elements participating in the transition (anything with a `view-transition-name`) are skipped by hit-testing for the transition's duration — spec behavior, no CSS override ([csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)). Weigh that cost before naming interactive elements, and portal named popovers (see `patterns.md` → Isolate Elements from Parent Animations).
+Trade-off: clicks during an animation can now hit live elements underneath still-moving snapshots. And it only restores interactivity for **unnamed** content — elements participating in the transition (anything with a `view-transition-name`) are skipped by hit-testing for the transition's duration, spec behavior with no CSS override ([csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)). Weigh that cost before naming interactive elements, and portal named popovers (see `patterns.md` → Isolate Elements from Parent Animations).
 
 ---
 

--- a/skills/react-view-transitions/references/css-recipes.md
+++ b/skills/react-view-transitions/references/css-recipes.md
@@ -218,6 +218,23 @@ Trade-offs: clicks can hit live elements under still-moving snapshots, and it on
 
 ---
 
+## No Root Cross-Fade (Live Root)
+
+The root cross-fades on every transition, freezing unnamed content behind a stale snapshot — hover and active styles stop rendering until it settles. `::view-transition-new(root)` is a **live** capture, so disabling the root animation keeps unnamed regions rendering (and, with the `pointer-events` recipe above, interactive):
+
+```css
+::view-transition-old(root) {
+  display: none;
+}
+::view-transition-new(root) {
+  animation: none;
+}
+```
+
+Named and classed groups still animate — they stack above root. Trade-off: unnamed content swaps instantly, so regions that should fade need their own VT. This also removes the main reason to hand-name static chrome; keep names only for elements that must stack above animating groups.
+
+---
+
 ## Persistent Element Isolation
 
 ```css
@@ -226,6 +243,8 @@ Trade-offs: clicks can hit live elements under still-moving snapshots, and it on
   z-index: 100;
 }
 ```
+
+Layer multiple pinned groups with z-index tiers — chrome at `100`, toasts/overlays that must beat everything at `200`.
 
 ### Backdrop-Blur Workaround
 

--- a/skills/react-view-transitions/references/css-recipes.md
+++ b/skills/react-view-transitions/references/css-recipes.md
@@ -204,6 +204,20 @@ Usage: `<ViewTransition enter="scale-in" exit="scale-out" />`
 
 ---
 
+## Interactivity During Transitions
+
+The `::view-transition` overlay covers the viewport and blocks all interaction by default. Let clicks and hover pass through to the live page:
+
+```css
+::view-transition {
+  pointer-events: none;
+}
+```
+
+This only restores interactivity for **unnamed** content. Elements participating in the transition (anything with a `view-transition-name`) are skipped by hit-testing for the transition's duration — spec behavior, no CSS override ([csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)). Weigh that cost before naming interactive elements, and portal named popovers (see `patterns.md` → Isolate Elements from Parent Animations).
+
+---
+
 ## Persistent Element Isolation
 
 ```css

--- a/skills/react-view-transitions/references/css-recipes.md
+++ b/skills/react-view-transitions/references/css-recipes.md
@@ -206,7 +206,7 @@ Usage: `<ViewTransition enter="scale-in" exit="scale-out" />`
 
 ## Interactivity During Transitions
 
-The `::view-transition` overlay covers the viewport and captures all pointer events by default. React partially handles this: when the root group doesn't need to animate, it shrinks the overlay to zero size so the page stays interactive — but it deliberately leaves `pointer-events` alone so in-flight animations still block clicks (so they don't land on whatever is beneath a moving snapshot). To let clicks and hover pass through even while animations run:
+The `::view-transition` overlay captures all pointer events. React shrinks it to zero when the root group doesn't animate, but in-flight animations still block clicks. To pass clicks/hover through even while animating:
 
 ```css
 ::view-transition {
@@ -214,7 +214,7 @@ The `::view-transition` overlay covers the viewport and captures all pointer eve
 }
 ```
 
-Trade-off: clicks during an animation can now hit live elements underneath still-moving snapshots. And it only restores interactivity for **unnamed** content — elements participating in the transition (anything with a `view-transition-name`) are skipped by hit-testing for the transition's duration, spec behavior with no CSS override ([csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)). Weigh that cost before naming interactive elements, and portal named popovers (see `patterns.md` → Isolate Elements from Parent Animations).
+Trade-offs: clicks can hit live elements under still-moving snapshots, and it only helps **unnamed** content — named participants are skipped by hit-testing for the transition's duration, no CSS override ([csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)). Weigh that before naming interactive elements; portal named popovers (see `patterns.md`).
 
 ---
 

--- a/skills/react-view-transitions/references/css-recipes.md
+++ b/skills/react-view-transitions/references/css-recipes.md
@@ -214,7 +214,7 @@ The `::view-transition` overlay captures all pointer events. React shrinks it to
 }
 ```
 
-Trade-offs: clicks can hit live elements under still-moving snapshots, and it only helps **unnamed** content — named participants are skipped by hit-testing for the transition's duration, no CSS override ([csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)). Weigh that before naming interactive elements; portal named popovers (see `patterns.md`).
+Trade-offs: clicks can hit live elements under still-moving snapshots, and it only helps **unnamed** content — named participants are skipped by hit-testing for the transition's duration, no CSS override ([csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)). Weigh that before naming interactive elements; portal named popovers (see [Isolate Elements from Parent Animations](patterns.md#isolate-elements-from-parent-animations)).
 
 ---
 

--- a/skills/react-view-transitions/references/implementation.md
+++ b/skills/react-view-transitions/references/implementation.md
@@ -177,7 +177,7 @@ If any path produces no animation or competing animations, revisit the relevant 
 - **Raw `viewTransitionName` CSS to trigger animations** — React only calls `document.startViewTransition` when `<ViewTransition>` components are in the tree. A bare `viewTransitionName` style is for isolating elements from a parent's snapshot, not for triggering animations.
 - **`update` trigger for same-route navigations** — nested VTs inside the content steal the mutation from the parent, so `update` never fires on the outer VT. Use `key` + `name` + `share` instead.
 - **Named VT in a reusable component** — if a component with a named VT is rendered in both a modal/popover *and* a page, both mount simultaneously and break the morph. Make the name conditional or move it to the specific consumer.
-- **`router.back()` for back navigation** — `router.back()` triggers synchronous `popstate`, incompatible with view transitions. Use `router.push()` with an explicit URL.
+- **`router.back()` for back navigation** — React renders `popstate`-scheduled transitions synchronously (skipping view transitions), and traversals carry no transition types. Use `router.push()` with an explicit URL.
 
 ---
 

--- a/skills/react-view-transitions/references/implementation.md
+++ b/skills/react-view-transitions/references/implementation.md
@@ -177,7 +177,7 @@ If any path produces no animation or competing animations, revisit the relevant 
 - **Raw `viewTransitionName` CSS to trigger animations** — React only calls `document.startViewTransition` when `<ViewTransition>` components are in the tree. A bare `viewTransitionName` style is for isolating elements from a parent's snapshot, not for triggering animations.
 - **`update` trigger for same-route navigations** — nested VTs inside the content steal the mutation from the parent, so `update` never fires on the outer VT. Use `key` + `name` + `share` instead.
 - **Named VT in a reusable component** — if a component with a named VT is rendered in both a modal/popover *and* a page, both mount simultaneously and break the morph. Make the name conditional or move it to the specific consumer.
-- **`router.back()` for back navigation** — React renders `popstate`-scheduled transitions synchronously (skipping view transitions), and traversals carry no transition types. Use `router.push()` with an explicit URL.
+- **`router.back()` for back navigation** — traversals carry no transition types, so type-keyed animations don't play (untyped morphs still can). Use `router.push()` with an explicit URL for a fully animated back affordance.
 
 ---
 

--- a/skills/react-view-transitions/references/implementation.md
+++ b/skills/react-view-transitions/references/implementation.md
@@ -29,7 +29,7 @@ For each shared element (`name` prop), note every navigation where a pair forms 
 
 ## Step 2: Add CSS Recipes
 
-Copy the **complete** CSS recipe set from `css-recipes.md` into your global stylesheet. This includes timing variables, shared keyframes, fade, slide (vertical), directional navigation (forward/back), shared element morph, persistent element isolation, and reduced motion.
+Copy the **complete** CSS recipe set from [css-recipes.md](css-recipes.md) into your global stylesheet. This includes timing variables, shared keyframes, fade, slide (vertical), directional navigation (forward/back), shared element morph, persistent element isolation, and reduced motion.
 
 Do not write your own animation CSS — the recipes handle staggered timing, motion blur on morphs, and reduced motion that are easy to get wrong. You can customize timing variables (`--duration-exit`, `--duration-enter`, `--duration-move`) after the initial setup.
 
@@ -41,7 +41,7 @@ For every persistent element identified in Step 1, add a `viewTransitionName` st
 <header style={{ viewTransitionName: "site-header" }}>...</header>
 ```
 
-Then add the persistent element isolation CSS from `css-recipes.md` (prevents the element from animating during page transitions). If the element uses `backdrop-blur` or `backdrop-filter`, use the backdrop-blur workaround from `css-recipes.md` instead.
+Then add the [Persistent Element Isolation](css-recipes.md#persistent-element-isolation) CSS (prevents the element from animating during page transitions). If the element uses `backdrop-blur` or `backdrop-filter`, use the [Backdrop-Blur Workaround](css-recipes.md#backdrop-blur-workaround) instead.
 
 If a Suspense fallback mirrors a persistent control (e.g., a skeleton search input), give both the real control and the skeleton the same `viewTransitionName` so they morph in place.
 
@@ -76,7 +76,7 @@ Then wrap each **page component** (not layout) in a type-keyed `<ViewTransition>
 </ViewTransition>
 ```
 
-The `nav-forward` and `nav-back` CSS classes from `css-recipes.md` produce horizontal slides. For simpler apps where directional motion isn't needed, a bare `<ViewTransition default="none">` wrapper with `enter="fade-in"` / `exit="fade-out"` works too.
+The `nav-forward` and `nav-back` CSS classes from [Directional Navigation](css-recipes.md#directional-navigation) produce horizontal slides. For simpler apps where directional motion isn't needed, a bare `<ViewTransition default="none">` wrapper with `enter="fade-in"` / `exit="fade-out"` works too.
 
 Extract this into a reusable component so every page doesn't repeat the verbose type map:
 
@@ -125,7 +125,7 @@ This example uses `slide-down` / `slide-up` for directional vertical motion. For
 **Rules:**
 - Always use `default="none"` on the content `<ViewTransition>` to prevent re-animation on revalidation or unrelated transitions.
 - Use simple string props (not type maps) on Suspense `<ViewTransition>`s — Suspense resolves fire as separate transitions with no type, so type-keyed props won't match.
-- If the same element appears in **both** the fallback and the content (a title, a heading), it flickers on reveal — an opacity dip. Render it **outside** the `<Suspense>` boundary (or pin it), so it isn't in both. See "Suspense reveal flicker" in `patterns.md`.
+- If the same element appears in **both** the fallback and the content (a title, a heading), it flickers on reveal — an opacity dip. Render it **outside** the `<Suspense>` boundary (or pin it), so it isn't in both. See [Suspense reveal flicker](patterns.md#suspense-reveal-flicker).
 
 ## Step 6: Add Shared Element Transitions
 
@@ -143,9 +143,9 @@ For every shared visual element identified in Step 1, add matching named `<ViewT
 </ViewTransition>
 ```
 
-The `share="morph"` class uses the morph recipe from `css-recipes.md` (controlled duration + motion blur). For a simpler cross-fade, use `share="auto"` (browser default).
+The `share="morph"` class uses the [Shared Element Morph](css-recipes.md#shared-element-morph) recipe (controlled duration + motion blur). For a simpler cross-fade, use `share="auto"` (browser default).
 
-When list items contain shared elements, compose both patterns with two nested `<ViewTransition>` layers — see "Composing Shared Elements with List Identity" in `SKILL.md`.
+When list items contain shared elements, compose both patterns with two nested `<ViewTransition>` layers — see [Composing Shared Elements with List Identity](../SKILL.md#composing-shared-elements-with-list-identity).
 
 **Rules:**
 - Names must be globally unique — use prefixes like `photo-${id}`.
@@ -171,7 +171,7 @@ If any path produces no animation or competing animations, revisit the relevant 
 - **Bare `<ViewTransition>` without props** — without `default="none"`, it fires the browser's default cross-fade on every transition (every navigation, every Suspense resolve, every revalidation). Always set `default="none"` and explicitly enable only the triggers you want.
 - **Directional `<ViewTransition>` in a layout** — layouts persist across navigations and never unmount/remount. `enter`/`exit` props won't fire on route changes. Place the outer type-keyed `<ViewTransition>` in each page component.
 - **Fade-out exit with shared element morphs** — the page dissolving conflicts with the morph. Use a directional slide exit instead.
-- **Writing custom animation CSS** — the recipes in `css-recipes.md` handle staggered timing, motion blur on morphs, and reduced motion. Copy them; don't reinvent them.
+- **Writing custom animation CSS** — the recipes in [css-recipes.md](css-recipes.md) handle staggered timing, motion blur on morphs, and reduced motion. Copy them; don't reinvent them.
 - **Missing `default: "none"` in type-keyed objects** — TypeScript requires a `default` key, and without it the fallback is `"auto"` which fires on every transition.
 - **Type maps on Suspense reveals** — Suspense resolves fire as separate transitions with no type. Type-keyed props won't match — use simple string props instead.
 - **Raw `viewTransitionName` CSS to trigger animations** — React only calls `document.startViewTransition` when `<ViewTransition>` components are in the tree. A bare `viewTransitionName` style is for isolating elements from a parent's snapshot, not for triggering animations.
@@ -181,4 +181,4 @@ If any path produces no animation or competing animations, revisit the relevant 
 
 ---
 
-For Next.js-specific implementation steps (config flag, `transitionTypes` on `<Link>`, same-route dynamic segments), see `nextjs.md`.
+For Next.js-specific implementation steps (config flag, `transitionTypes` on `<Link>`, same-route dynamic segments), see [nextjs.md](nextjs.md).

--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-`<ViewTransition>` works out of the box for `startTransition`/`Suspense` updates. To also animate `<Link>` navigations:
+`<ViewTransition>` works out of the box — the bundled React canary ships it, and every `<Link>` navigation already runs inside `React.startTransition`, so react-dom starts a view transition whenever affected `<ViewTransition>` components exist. The documented flag:
 
 ```js
 // next.config.js
@@ -12,7 +12,7 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-This wraps every `<Link>` navigation in `document.startViewTransition`. Any VT with `default="auto"` fires on **every** link click — use `default="none"` to prevent competing animations.
+Historically this switched the bundled React to the experimental channel; in current Next.js (16.2+) it gates nothing at runtime, but set it anyway to match the documented setup. Because every link click is a transition, any VT with `default="auto"` fires on **every** navigation — use `default="none"` to prevent competing animations.
 
 Do **not** install `react@canary` — see SKILL.md "Availability" for details.
 
@@ -50,7 +50,7 @@ No wrapper component needed, works in Server Components:
 
 Replaces the manual pattern of `onNavigate` + `startTransition` + `addTransitionType` + `router.push()`. Reserve manual `startTransition` for non-link interactions (buttons, forms).
 
-**Availability:** `transitionTypes` requires `experimental.viewTransition: true` and is available in Next.js 15+ canary builds and Next.js 16+. If unavailable, use `startTransition` + `addTransitionType` + `router.push()` (see Programmatic Navigation below). To check: `grep -r "transitionTypes" node_modules/next/dist/` — if no results, fall back to programmatic navigation.
+**Availability:** `transitionTypes` shipped in **Next.js 16.2.0** (it is not gated on the `experimental.viewTransition` flag). If unavailable, use `startTransition` + `addTransitionType` + `router.push()` (see Programmatic Navigation below). To check: `grep -r "transitionTypes" node_modules/next/dist/` — if no results, fall back to programmatic navigation.
 
 ---
 
@@ -62,12 +62,17 @@ Replaces the manual pattern of `onNavigate` + `startTransition` + `addTransition
 import { useRouter } from 'next/navigation';
 import { startTransition, addTransitionType } from 'react';
 
-function handleNavigate(href: string) {
+function DetailButton({ href }: { href: string }) {
   const router = useRouter();
-  startTransition(() => {
-    addTransitionType('nav-forward');
-    router.push(href);
-  });
+
+  function handleNavigate() {
+    startTransition(() => {
+      addTransitionType('nav-forward');
+      router.push(href);
+    });
+  }
+
+  return <button onClick={handleNavigate}>Open</button>;
 }
 ```
 
@@ -188,7 +193,7 @@ If the pair's `share` is type-keyed (or classed via CSS that expects a type), ev
 
 ## Same-Route Dynamic Segment Transitions
 
-When navigating between dynamic segments of the same route (e.g., `/collection/[slug]`), the page stays mounted — enter/exit never fire. Use `key` + `name` + `share`:
+When navigating between dynamic segments of the same route (e.g., `/collection/[slug]`), the router swaps subtrees keyed by the segment value (or re-shows Activity-cached ones) rather than doing a plain unmount/mount — so enter/exit don't fire reliably. Use `key` + `name` + `share`:
 
 ```tsx
 <Suspense fallback={<Skeleton />}>
@@ -206,7 +211,7 @@ When navigating between dynamic segments of the same route (e.g., `/collection/[
 
 ## Nested enter/exit — `parentEnter` / `parentExit` (experimental)
 
-Lifts the "nested VTs don't fire enter/exit inside a parent" rule: a nested VT can animate when its **parent** enters/exits (`parentEnter`/`parentExit`, `onParentEnter`/`onParentExit`; `parentEnter="none"` stops propagation). Client-only today (behind `enableViewTransitionParentEnterExit`); SSR support for Suspense reveals landed in React PR #36917 ([commit](https://github.com/react/react/commit/83840902c890f0eb85decda239ef6b1b14945779)). Verify it's in your React (`grep -r "vt-parent-enter" node_modules/next/dist/compiled/react*`) before relying on it.
+Lifts the "nested VTs don't fire enter/exit inside a parent" rule: a nested VT can animate when its **parent** enters/exits (`parentEnter`/`parentExit`, `onParentEnter`/`onParentExit`; `parentEnter="none"` stops propagation). Experimental-channel only today (behind `enableViewTransitionParentEnterExit = __EXPERIMENTAL__`); SSR support for Suspense reveals landed in React PR #36917 ([commit](https://github.com/facebook/react/commit/83840902c890f0eb85decda239ef6b1b14945779)). Verify it's in the React your app actually runs: `grep -c "parentEnter" node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.production.js` — 0 means unavailable (Next only uses the experimental channel when flags like `blockingSSR`/`taint` are set).
 
 ## Server Components
 

--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -182,6 +182,8 @@ Same rules as explicit `<Suspense>`: use simple string props (not type maps) sin
 </ViewTransition>
 ```
 
+If the pair's `share` is type-keyed (or classed via CSS that expects a type), every `<Link>` between the two views must carry the type via `transitionTypes` — a plain link click resolves the share map's `default`, and if that's `none` the morph silently never fires.
+
 ---
 
 ## Same-Route Dynamic Segment Transitions

--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -12,7 +12,9 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-Historically this switched the bundled React to the experimental channel; in current Next.js (16.2+) it gates nothing at runtime, but set it anyway to match the documented setup. Because every link click is a transition, any VT with `default="auto"` fires on **every** navigation — use `default="none"` to prevent competing animations.
+The official docs instruct setting this flag; keep it. Historically it switched the bundled React to the **experimental channel** — required back when `ViewTransition` was experimental-only — but since React released `ViewTransition` to canary (Oct 2025), the canary React that App Router bundles has full support and the flag no longer switches channels. Today the experimental channel is selected by *other* flags (`gestureTransition`, `blockingSSR`, `taint`, `transitionIndicator`), and only experimental-channel features need it: gesture transitions (`useSwipeTransition`) and `parentEnter`/`parentExit`.
+
+Because every link click is a transition, any VT with `default="auto"` fires on **every** navigation — use `default="none"` to prevent competing animations.
 
 Do **not** install `react@canary` — see SKILL.md "Availability" for details.
 
@@ -211,7 +213,7 @@ When navigating between dynamic segments of the same route (e.g., `/collection/[
 
 ## Nested enter/exit — `parentEnter` / `parentExit` (experimental)
 
-Lifts the "nested VTs don't fire enter/exit inside a parent" rule: a nested VT can animate when its **parent** enters/exits (`parentEnter`/`parentExit`, `onParentEnter`/`onParentExit`; `parentEnter="none"` stops propagation). Experimental-channel only today (behind `enableViewTransitionParentEnterExit = __EXPERIMENTAL__`); SSR support for Suspense reveals landed in React PR #36917 ([commit](https://github.com/facebook/react/commit/83840902c890f0eb85decda239ef6b1b14945779)). Verify it's in the React your app actually runs: `grep -c "parentEnter" node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.production.js` — 0 means unavailable (Next only uses the experimental channel when flags like `blockingSSR`/`taint` are set).
+Lifts the "nested VTs don't fire enter/exit inside a parent" rule: a nested VT can animate when its **parent** enters/exits (`parentEnter`/`parentExit`, `onParentEnter`/`onParentExit`; `parentEnter="none"` stops propagation). Experimental-channel only today (behind `enableViewTransitionParentEnterExit = __EXPERIMENTAL__`); SSR support for Suspense reveals landed in React PR #36917 ([commit](https://github.com/facebook/react/commit/83840902c890f0eb85decda239ef6b1b14945779)). Verify it's in the React your app actually runs: `grep -c "parentEnter" node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.production.js` — 0 means unavailable (Next only uses the experimental channel when a flag from `needs-experimental-react.ts` is set: `gestureTransition`, `blockingSSR`, `taint`, or `transitionIndicator`).
 
 ## Server Components
 

--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-`<ViewTransition>` works out of the box — the bundled React canary ships it, and every `<Link>` navigation already runs inside `React.startTransition`, so react-dom starts a view transition whenever affected `<ViewTransition>` components exist. The documented flag:
+`<ViewTransition>` works out of the box — the bundled React canary ships it, and every `<Link>` navigation runs inside `React.startTransition`, so react-dom starts a view transition whenever affected `<ViewTransition>` components exist. Set the documented flag:
 
 ```js
 // next.config.js
@@ -12,7 +12,7 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-The official docs instruct setting this flag; keep it. Historically it switched the bundled React to the **experimental channel** — required back when `ViewTransition` was experimental-only — but since React released `ViewTransition` to canary (Oct 2025), the canary React that App Router bundles has full support and the flag no longer switches channels. Today the experimental channel is selected by *other* flags (`gestureTransition`, `blockingSSR`, `taint`, `transitionIndicator`), and only experimental-channel features need it: gesture transitions (`useSwipeTransition`) and `parentEnter`/`parentExit`.
+(Historically the flag switched React to the experimental channel — required before `ViewTransition` reached canary. It no longer does; the experimental channel is only needed for `useSwipeTransition` gestures and `parentEnter`/`parentExit`, selected by other flags like `gestureTransition`.)
 
 Because every link click is a transition, any VT with `default="auto"` fires on **every** navigation — use `default="none"` to prevent competing animations.
 
@@ -195,7 +195,7 @@ If the pair's `share` is type-keyed (or classed via CSS that expects a type), ev
 
 ## Same-Route Dynamic Segment Transitions
 
-When navigating between dynamic segments of the same route (e.g., `/collection/[slug]`), the router swaps subtrees keyed by the segment value (or re-shows Activity-cached ones) rather than doing a plain unmount/mount — so enter/exit don't fire reliably. Use `key` + `name` + `share`:
+When navigating between dynamic segments of the same route (e.g., `/collection/[slug]`), the router swaps subtrees keyed by the segment value rather than doing a plain unmount/mount — enter/exit don't fire reliably. Use `key` + `name` + `share`:
 
 ```tsx
 <Suspense fallback={<Skeleton />}>
@@ -213,7 +213,7 @@ When navigating between dynamic segments of the same route (e.g., `/collection/[
 
 ## Nested enter/exit — `parentEnter` / `parentExit` (experimental)
 
-Lifts the "nested VTs don't fire enter/exit inside a parent" rule: a nested VT can animate when its **parent** enters/exits (`parentEnter`/`parentExit`, `onParentEnter`/`onParentExit`; `parentEnter="none"` stops propagation). Experimental-channel only today (behind `enableViewTransitionParentEnterExit = __EXPERIMENTAL__`); SSR support for Suspense reveals landed in React PR #36917 ([commit](https://github.com/facebook/react/commit/83840902c890f0eb85decda239ef6b1b14945779)). Verify it's in the React your app actually runs: `grep -c "parentEnter" node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.production.js` — 0 means unavailable (Next only uses the experimental channel when a flag from `needs-experimental-react.ts` is set: `gestureTransition`, `blockingSSR`, `taint`, or `transitionIndicator`).
+Lifts the "nested VTs don't fire enter/exit inside a parent" rule: a nested VT can animate when its **parent** enters/exits (`parentEnter`/`parentExit`, `onParentEnter`/`onParentExit`; `parentEnter="none"` stops propagation). Experimental-channel only today; SSR support landed in React PR #36917 ([commit](https://github.com/facebook/react/commit/83840902c890f0eb85decda239ef6b1b14945779)). Verify it's in the React your app runs: `grep -c "parentEnter" node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.production.js` — 0 means unavailable (Next uses the experimental channel only when `gestureTransition`/`blockingSSR`/`taint`/`transitionIndicator` is set).
 
 ## Server Components
 

--- a/skills/react-view-transitions/references/nextjs.md
+++ b/skills/react-view-transitions/references/nextjs.md
@@ -16,19 +16,19 @@ module.exports = nextConfig;
 
 Because every link click is a transition, any VT with `default="auto"` fires on **every** navigation — use `default="none"` to prevent competing animations.
 
-Do **not** install `react@canary` — see SKILL.md "Availability" for details.
+Do **not** install `react@canary` — see [Availability](../SKILL.md#availability) for details.
 
 ---
 
 ## Next.js Implementation Additions
 
-When following `implementation.md`, apply these additions:
+When following [implementation.md](implementation.md), apply these additions:
 
 **After Step 2:** Enable the experimental flag above.
 
-**Step 4:** Use `transitionTypes` on `<Link>` — see "The `transitionTypes` Prop" section below for usage and availability.
+**Step 4:** Use `transitionTypes` on `<Link>` — see [The `transitionTypes` Prop](#the-transitiontypes-prop-on-nextlink) for usage and availability.
 
-**After Step 6:** For same-route dynamic segments (e.g., `/collection/[slug]`), use the `key` + `name` + `share` pattern — see Same-Route Dynamic Segment Transitions below.
+**After Step 6:** For same-route dynamic segments (e.g., `/collection/[slug]`), use the `key` + `name` + `share` pattern — see [Same-Route Dynamic Segment Transitions](#same-route-dynamic-segment-transitions).
 
 ---
 
@@ -38,7 +38,7 @@ When following `implementation.md`, apply these additions:
 
 A bare `<ViewTransition>` in layout works only if pages have **no** VTs of their own.
 
-**Layouts persist across navigations** — `enter`/`exit` only fire on initial mount, not on route changes. Don't use type-keyed maps in layouts. Because layouts persist, chrome hosted in one (nav, sidebar, player) keeps its state across navigations for free — no `Activity` needed. Reserve `Activity` for in-page show/hide (see `patterns.md` → Composing with Activity).
+**Layouts persist across navigations** — `enter`/`exit` only fire on initial mount, not on route changes. Don't use type-keyed maps in layouts. Because layouts persist, chrome hosted in one (nav, sidebar, player) keeps its state across navigations for free — no `Activity` needed. Reserve `Activity` for in-page show/hide (see [Composing with Activity](patterns.md#composing-with-activity)).
 
 ---
 
@@ -52,7 +52,7 @@ No wrapper component needed, works in Server Components:
 
 Replaces the manual pattern of `onNavigate` + `startTransition` + `addTransitionType` + `router.push()`. Reserve manual `startTransition` for non-link interactions (buttons, forms).
 
-**Availability:** `transitionTypes` shipped in **Next.js 16.2.0** (it is not gated on the `experimental.viewTransition` flag). If unavailable, use `startTransition` + `addTransitionType` + `router.push()` (see Programmatic Navigation below). To check: `grep -r "transitionTypes" node_modules/next/dist/` — if no results, fall back to programmatic navigation.
+**Availability:** `transitionTypes` shipped in **Next.js 16.2.0** (it is not gated on the `experimental.viewTransition` flag). If unavailable, use `startTransition` + `addTransitionType` + `router.push()` (see [Programmatic Navigation](#programmatic-navigation)). To check: `grep -r "transitionTypes" node_modules/next/dist/` — if no results, fall back to programmatic navigation.
 
 ---
 
@@ -98,13 +98,13 @@ function handleSort(sort: string) {
 }
 ```
 
-List items wrapped in `<ViewTransition key={item.id}>` will animate reorder. This is the server-component alternative to the client-side `useDeferredValue` pattern in `patterns.md`.
+List items wrapped in `<ViewTransition key={item.id}>` will animate reorder. This is the server-component alternative to the client-side [Searchable Grid](patterns.md#searchable-grid-with-usedeferredvalue) pattern.
 
 ---
 
 ## Routing-Driven Tabs
 
-The generalized sliding indicator (`patterns.md` → Sliding Indicator) driven by navigation instead of local state: tabs are `<Link>`s, `active` comes from the URL (a server prop), and `useOptimistic` slides the indicator instantly while the route commits. Key the mounted indicator to committed `active` so the bar lands where navigation actually settles.
+The generalized sliding indicator ([Sliding Indicator](patterns.md#sliding-indicator-tabs)) driven by navigation instead of local state: tabs are `<Link>`s, `active` comes from the URL (a server prop), and `useOptimistic` slides the indicator instantly while the route commits. Key the mounted indicator to committed `active` so the bar lands where navigation actually settles.
 
 ```tsx
 'use client';

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -180,6 +180,7 @@ Only content inside an activated boundary animates position — everything else 
 The section — heading included — morphs as one group when rows above are added or removed. Nothing inside the section changed; the *displacement* is the update.
 
 - React only measures boundaries that are direct children of nodes along the changed path — a VT buried under an extra wrapper element won't activate. Place the boundary as a direct sibling of the changing content.
+- Sometimes the better fix is no morph at all: pad fixed-size lists to a constant slot count with invisible fillers so the grid never changes height and nothing below it moves.
 - `default="none"` disables exactly this morph — it turns off `update`. Named/shared elements get `default="none"`; displaced siblings and keyed list items stay bare or set `update="auto"`.
 
 ## Reusable Animated Collapse

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -162,6 +162,25 @@ export function Tabs({ tabs, indicatorName = 'tab-indicator' }) {
 
 Because the state change is a transition, if the newly-active tab renders suspending content the whole update — indicator **and** `aria-current` — waits for it to commit, and the strip feels dead on click. Give the controls an immediate value with `useOptimistic` (drive `aria-current` from it) so feedback is instant while the content streams. The routing variant (`nextjs.md` → Routing-Driven Tabs) does exactly this: optimistic `aria-current`, committed `active` for the bar.
 
+## Layout Displacement Morph
+
+Only content inside an activated boundary animates position — everything else teleports to its new layout spot. When a list grows or shrinks, wrap the sibling content below it so it glides instead of jumping:
+
+```jsx
+<FavoritesList />              {/* rows enter/exit */}
+<ViewTransition>               {/* bare: update enabled */}
+  <section>
+    <h2>You Might Also Like</h2>
+    <Recommendations />
+  </section>
+</ViewTransition>
+```
+
+The section — heading included — morphs as one group when rows above are added or removed. Nothing inside the section changed; the *displacement* is the update.
+
+- React only activates this for **immediate siblings** of the mutation (deliberate: page-wide re-layout would otherwise fire noisy animations everywhere). Place the boundary as a direct sibling of the changing content.
+- `default="none"` disables exactly this morph — it turns off `update`. Named/shared elements get `default="none"`; displaced siblings and keyed list items stay bare or set `update="auto"`.
+
 ## Reusable Animated Collapse
 
 ```jsx
@@ -266,7 +285,7 @@ The `types` array (second argument) lets you vary animation based on transition 
 
 **Shared morph silently not firing:** `share` resolved to `none`. Either the VT has `default="none"` with no explicit `share` prop, or `share` is type-keyed and the navigation never adds the type — the link needs `transitionTypes` (or `addTransitionType` in the transition).
 
-**Section below a list teleports instead of gliding:** it's outside any activated boundary, or its VT has `default="none"` (which disables `update`). Wrap the section in a bare `<ViewTransition>` — see SKILL.md → Layout Displacement Morph.
+**Section below a list teleports instead of gliding:** it's outside any activated boundary, its VT has `default="none"` (which disables `update`), or it isn't an immediate sibling of the changing content. See "Layout Displacement Morph" above.
 
 **`router.back()` and browser back/forward skip animation:** Use `router.push()` with an explicit URL instead. See SKILL.md "router.back() and Browser Back Button."
 

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -178,7 +178,7 @@ Only content inside an activated boundary animates position — everything else 
 
 The section — heading included — morphs as one group when rows above are added or removed. Nothing inside the section changed; the *displacement* is the update.
 
-- React only activates this for **immediate siblings** of the mutation (deliberate: page-wide re-layout would otherwise fire noisy animations everywhere). Place the boundary as a direct sibling of the changing content.
+- React activates VT boundaries that are direct children (not behind an intermediate DOM node) of nodes along the changed path — siblings of the mutation and of its ancestors qualify; a VT buried under an extra wrapper element in a sibling does not (deliberate: page-wide re-layout would otherwise fire noisy animations everywhere). Place the boundary as a direct sibling of the changing content.
 - `default="none"` disables exactly this morph — it turns off `update`. Named/shared elements get `default="none"`; displaced siblings and keyed list items stay bare or set `update="auto"`.
 
 ## Reusable Animated Collapse
@@ -238,7 +238,7 @@ function cycleSort() {
 
 ## View Transition Events
 
-Imperative control via `onEnter`, `onExit`, `onUpdate`, `onShare`. Always return a cleanup function. `onShare` takes precedence over `onEnter`/`onExit`.
+Imperative control via `onEnter`, `onExit`, `onUpdate`, `onShare`. Return a cleanup function to cancel your animation when the transition finishes. `onShare` takes precedence over `onEnter`/`onExit`.
 
 ```jsx
 <ViewTransition
@@ -287,13 +287,13 @@ The `types` array (second argument) lets you vary animation based on transition 
 
 **Section below a list teleports instead of gliding:** it's outside any activated boundary, its VT has `default="none"` (which disables `update`), or it isn't an immediate sibling of the changing content. See "Layout Displacement Morph" above.
 
-**`router.back()` and browser back/forward skip animation:** Use `router.push()` with an explicit URL instead. See SKILL.md "router.back() and Browser Back Button."
+**`router.back()` and browser back/forward skip animation:** React renders `popstate`-scheduled transitions synchronously (skipping view transitions), and traversals carry no transition types. Use `router.push()` with an explicit URL instead. See SKILL.md "router.back() and Browser Back Button."
 
 **`flushSync` skips animations:** Use `startTransition` instead.
 
 **Only updates animate (no enter/exit):** Without `<Suspense>`, React treats swaps as updates. Conditionally render the VT itself, or wrap in `<Suspense>`.
 
-**Layout VT prevents page VTs from animating:** Nested VTs never fire enter/exit inside a parent VT. If your layout has a VT wrapping `{children}`, page-level enter/exit will silently not work. Remove the layout VT.
+**Layout VT prevents page VTs from animating:** nested VTs don't fire their own enter/exit when they mount/unmount *as one unit* with a parent VT — only the outermost animates. (A child VT swapped inside a persistent parent fires normally; if page enter/exit is dead under a persistent layout VT, check the page VT isn't below a plain DOM node instead.) If your layout has a VT wrapping `{children}`, remove it and put VTs in pages.
 
 **List reorder not animating with `useOptimistic`:** Optimistic values resolve before snapshot. Use committed state for list order.
 

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -118,6 +118,7 @@ Pull an element out of the animated `root` snapshot by giving it its own `view-t
 
 - **Persistent chrome** (nav, sidebar, player bar): `<nav style={{ viewTransitionName: 'persistent-nav' }}>` + isolation CSS. `<ViewTransition default="none">` works too, but its auto-name can't take `z-index`/backdrop `display:none` — hand-name when you need those.
 - **Floating elements** (popovers, menus): left open, they're captured in `root` and flicker on settle. Real name + isolation (`css-recipes.md` → Floating Element Isolation). A static name is fine if only one is mounted (`unmountOnHide`); native top-layer (`popover`/`<dialog>`) settle-flicker is a browser limit.
+- **Naming an interactive element has a cost:** named participants are skipped by hit-testing while a transition runs — hover, cursor, and clicks fall through to whatever is beneath for the transition's duration (spec behavior; [csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)). Always **portal** a named popover/menu so those fallback hits stay inside its own subtree: rendered inline in a clickable row, mid-transition clicks hover/activate the row behind it, and outside-click detection closes the popover.
 
 ## Suspense reveal flicker
 
@@ -260,6 +261,12 @@ The `types` array (second argument) lets you vary animation based on transition 
 **Scrolling hangs while a transition animates:** the `::view-transition` overlay is `position: fixed` and its snapshots don't scroll — a browser limitation, not fixable in React (skipping snaps to the end). Keep reveal durations short; for scroll-driven UI use gesture transitions (experimental `useSwipeTransition`, if available).
 
 **Open popover flickers when a background transition settles:** it's captured in `root`. Give it a real `view-transition-name` + isolation (not `none`) — see "Floating Elements".
+
+**Popover closes or goes dead when clicked mid-transition:** named participants are skipped by hit-testing while a transition runs; clicks land on what's beneath and read as outside-clicks. Portal the popover (see "Isolate Elements from Parent Animations"); brief dead clicks during the transition remain — that's the price of the name.
+
+**Shared morph silently not firing:** `share` resolved to `none`. Either the VT has `default="none"` with no explicit `share` prop, or `share` is type-keyed and the navigation never adds the type — the link needs `transitionTypes` (or `addTransitionType` in the transition).
+
+**Section below a list teleports instead of gliding:** it's outside any activated boundary, or its VT has `default="none"` (which disables `update`). Wrap the section in a bare `<ViewTransition>` — see SKILL.md → Layout Displacement Morph.
 
 **`router.back()` and browser back/forward skip animation:** Use `router.push()` with an explicit URL instead. See SKILL.md "router.back() and Browser Back Button."
 

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -119,6 +119,7 @@ Pull an element out of the animated `root` snapshot by giving it its own `view-t
 - **Persistent chrome** (nav, sidebar, player bar): `<nav style={{ viewTransitionName: 'persistent-nav' }}>` + isolation CSS. `<ViewTransition default="none">` works too, but its auto-name can't take `z-index`/backdrop `display:none` — hand-name when you need those.
 - **Floating elements** (popovers, menus): left open, they're captured in `root` and flicker on settle. Real name + isolation (`css-recipes.md` → Floating Element Isolation). A static name is fine if only one is mounted (`unmountOnHide`); native top-layer (`popover`/`<dialog>`) settle-flicker is a browser limit.
 - **Naming an interactive element has a cost:** named participants are skipped by hit-testing while a transition runs ([csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)) — clicks and hover fall through to whatever is beneath. Portal named popovers/menus; rendered inline in a clickable row, mid-transition clicks activate the row and read as outside-clicks that close the popover.
+- **Third-party floating components** (toast libraries, portals you don't render): put the name on an always-mounted wrapper you own — `<div style={{ viewTransitionName: 'toaster' }} className="pointer-events-none fixed inset-0">`. Library containers often unmount when empty, so naming them directly leaves the group unpinned exactly when a toast appears mid-transition. Name a dialog's backdrop separately from its panel so each pins independently.
 
 ## Suspense reveal flicker
 

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -287,7 +287,7 @@ The `types` array (second argument) lets you vary animation based on transition 
 
 **Section below a list teleports instead of gliding:** it's outside any activated boundary, its VT has `default="none"` (which disables `update`), or it isn't an immediate sibling of the changing content. See "Layout Displacement Morph" above.
 
-**`router.back()` and browser back/forward skip animation:** React renders `popstate`-scheduled transitions synchronously (skipping view transitions), and traversals carry no transition types. Use `router.push()` with an explicit URL instead. See SKILL.md "router.back() and Browser Back Button."
+**`router.back()` and browser back/forward skip the directional slide:** traversals carry no transition types, so type-keyed maps resolve to `default` — untyped shared-element morphs still apply. Use `router.push()` with an explicit URL for typed animations. See SKILL.md "router.back() and Browser Back Button."
 
 **`flushSync` skips animations:** Use `startTransition` instead.
 

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -114,10 +114,10 @@ Use `key` when content identity changes (state resets). Omit for cross-fades (ta
 
 ## Isolate Elements from Parent Animations
 
-Pull an element out of the animated `root` snapshot by giving it its own `view-transition-name`. **`view-transition-name: none` is a no-op** — it's the CSS default, so the element stays in `root` (a common flicker bug). Use a real, unique name, then neutralize with `<ViewTransition default="none">` (no CSS) or CSS (needed for `z-index`/`display` control — see `css-recipes.md`).
+Pull an element out of the animated `root` snapshot by giving it its own `view-transition-name`. **`view-transition-name: none` is a no-op** — it's the CSS default, so the element stays in `root` (a common flicker bug). Use a real, unique name, then neutralize with `<ViewTransition default="none">` (no CSS) or CSS (needed for `z-index`/`display` control — see [css-recipes.md](css-recipes.md#persistent-element-isolation)).
 
 - **Persistent chrome** (nav, sidebar, player bar): `<nav style={{ viewTransitionName: 'persistent-nav' }}>` + isolation CSS. `<ViewTransition default="none">` works too, but its auto-name can't take `z-index`/backdrop `display:none` — hand-name when you need those.
-- **Floating elements** (popovers, menus): left open, they're captured in `root` and flicker on settle. Real name + isolation (`css-recipes.md` → Floating Element Isolation). A static name is fine if only one is mounted (`unmountOnHide`); native top-layer (`popover`/`<dialog>`) settle-flicker is a browser limit.
+- **Floating elements** (popovers, menus): left open, they're captured in `root` and flicker on settle. Real name + isolation ([Floating Element Isolation](css-recipes.md#floating-element-isolation-popovers-menus-tooltips-control-clusters)). A static name is fine if only one is mounted (`unmountOnHide`); native top-layer (`popover`/`<dialog>`) settle-flicker is a browser limit.
 - **Naming an interactive element has a cost:** named participants are skipped by hit-testing while a transition runs ([csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)) — clicks and hover fall through to whatever is beneath. Portal named popovers/menus; rendered inline in a clickable row, mid-transition clicks activate the row and read as outside-clicks that close the popover.
 - **Third-party floating components** (toast libraries, portals you don't render): put the name on an always-mounted wrapper you own — `<div style={{ viewTransitionName: 'toaster' }} className="pointer-events-none fixed inset-0">`. Library containers often unmount when empty, so naming them directly leaves the group unpinned exactly when a toast appears mid-transition. Name a dialog's backdrop separately from its panel so each pins independently.
 
@@ -134,7 +134,7 @@ Don't put a manual `viewTransitionName` on the root DOM node inside `<ViewTransi
 
 ## Sliding Indicator (tabs)
 
-One shared-name indicator rendered under the **active** tab morphs between positions on change (slide the group, disable old/new — see `css-recipes.md` → Sliding Indicator). Render it only under the active tab so exactly one element holds `indicatorName`; use a distinct `indicatorName` per tab strip. Trigger the state change inside `startTransition` so the move animates. Whatever owns `active` drives it — local state here, routing in Next (see `nextjs.md` → Routing-Driven Tabs).
+One shared-name indicator rendered under the **active** tab morphs between positions on change (slide the group, disable old/new — see [Sliding Indicator](css-recipes.md#sliding-indicator-tab-underline--segmented-pill)). Render it only under the active tab so exactly one element holds `indicatorName`; use a distinct `indicatorName` per tab strip. Trigger the state change inside `startTransition` so the move animates. Whatever owns `active` drives it — local state here, routing in Next (see [Routing-Driven Tabs](nextjs.md#routing-driven-tabs)).
 
 ```tsx
 import { useState, useTransition, ViewTransition } from 'react';
@@ -161,7 +161,7 @@ export function Tabs({ tabs, indicatorName = 'tab-indicator' }) {
 }
 ```
 
-Because the state change is a transition, if the newly-active tab renders suspending content the whole update — indicator **and** `aria-current` — waits for it to commit, and the strip feels dead on click. Give the controls an immediate value with `useOptimistic` (drive `aria-current` from it) so feedback is instant while the content streams. The routing variant (`nextjs.md` → Routing-Driven Tabs) does exactly this: optimistic `aria-current`, committed `active` for the bar.
+Because the state change is a transition, if the newly-active tab renders suspending content the whole update — indicator **and** `aria-current` — waits for it to commit, and the strip feels dead on click. Give the controls an immediate value with `useOptimistic` (drive `aria-current` from it) so feedback is instant while the content streams. The routing variant ([Routing-Driven Tabs](nextjs.md#routing-driven-tabs)) does exactly this: optimistic `aria-current`, committed `active` for the bar.
 
 ## Layout Displacement Morph
 
@@ -212,7 +212,7 @@ function AnimatedCollapse({ open, children }) {
 </Activity>
 ```
 
-Only reach for Activity when there's state worth preserving — a stateless element (e.g. the sliding indicator above) gains nothing from it. In Next.js, layout-hosted chrome already persists across navigations without Activity (see `nextjs.md`).
+Only reach for Activity when there's state worth preserving — a stateless element (e.g. the sliding indicator above) gains nothing from it. In Next.js, layout-hosted chrome already persists across navigations without Activity (see [nextjs.md](nextjs.md#layout-level-viewtransition)).
 
 ## Exclude Elements with `useOptimistic`
 
@@ -281,13 +281,13 @@ The `types` array (second argument) lets you vary animation based on transition 
 
 **Scrolling hangs while a transition animates:** the `::view-transition` overlay is `position: fixed` and its snapshots don't scroll — a browser limitation, not fixable in React (skipping snaps to the end). Keep reveal durations short; for scroll-driven UI use gesture transitions (experimental `useSwipeTransition`, if available).
 
-**Open popover flickers when a background transition settles:** it's captured in `root`. Give it a real `view-transition-name` + isolation (not `none`) — see "Floating Elements".
+**Open popover flickers when a background transition settles:** it's captured in `root`. Give it a real `view-transition-name` + isolation (not `none`) — see [Isolate Elements from Parent Animations](#isolate-elements-from-parent-animations).
 
-**Popover closes or goes dead when clicked mid-transition:** named participants are skipped by hit-testing while a transition runs; clicks land on what's beneath and read as outside-clicks. Portal the popover (see "Isolate Elements from Parent Animations"); brief dead clicks during the transition remain — that's the price of the name.
+**Popover closes or goes dead when clicked mid-transition:** named participants are skipped by hit-testing while a transition runs; clicks land on what's beneath and read as outside-clicks. Portal the popover (see [Isolate Elements from Parent Animations](#isolate-elements-from-parent-animations)); brief dead clicks during the transition remain — that's the price of the name.
 
 **Shared morph silently not firing:** `share` resolved to `none`. Either the VT has `default="none"` with no explicit `share` prop, or `share` is type-keyed and the navigation never adds the type — the link needs `transitionTypes` (or `addTransitionType` in the transition).
 
-**Section below a list teleports instead of gliding:** it's outside any activated boundary, its VT has `default="none"` (which disables `update`), or it isn't an immediate sibling of the changing content. See "Layout Displacement Morph" above.
+**Section below a list teleports instead of gliding:** it's outside any activated boundary, its VT has `default="none"` (which disables `update`), or it isn't an immediate sibling of the changing content. See [Layout Displacement Morph](#layout-displacement-morph).
 
 **`router.back()` and browser back/forward skip the directional slide:** traversals carry no transition types, so type-keyed maps resolve to `default` — untyped shared-element morphs still apply. Use `router.push()` for typed animations.
 
@@ -303,7 +303,7 @@ The `types` array (second argument) lets you vary animation based on transition 
 
 **Hash fragments cause scroll jumps:** Navigate without hash; scroll programmatically after navigation.
 
-**Backdrop-blur flickers:** Use the backdrop-blur workaround from `css-recipes.md`.
+**Backdrop-blur flickers:** Use the [Backdrop-Blur Workaround](css-recipes.md#backdrop-blur-workaround).
 
 **`border-radius` lost during transitions:** Apply `border-radius` directly to the captured element.
 

--- a/skills/react-view-transitions/references/patterns.md
+++ b/skills/react-view-transitions/references/patterns.md
@@ -118,7 +118,7 @@ Pull an element out of the animated `root` snapshot by giving it its own `view-t
 
 - **Persistent chrome** (nav, sidebar, player bar): `<nav style={{ viewTransitionName: 'persistent-nav' }}>` + isolation CSS. `<ViewTransition default="none">` works too, but its auto-name can't take `z-index`/backdrop `display:none` — hand-name when you need those.
 - **Floating elements** (popovers, menus): left open, they're captured in `root` and flicker on settle. Real name + isolation (`css-recipes.md` → Floating Element Isolation). A static name is fine if only one is mounted (`unmountOnHide`); native top-layer (`popover`/`<dialog>`) settle-flicker is a browser limit.
-- **Naming an interactive element has a cost:** named participants are skipped by hit-testing while a transition runs — hover, cursor, and clicks fall through to whatever is beneath for the transition's duration (spec behavior; [csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)). Always **portal** a named popover/menu so those fallback hits stay inside its own subtree: rendered inline in a clickable row, mid-transition clicks hover/activate the row behind it, and outside-click detection closes the popover.
+- **Naming an interactive element has a cost:** named participants are skipped by hit-testing while a transition runs ([csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)) — clicks and hover fall through to whatever is beneath. Portal named popovers/menus; rendered inline in a clickable row, mid-transition clicks activate the row and read as outside-clicks that close the popover.
 
 ## Suspense reveal flicker
 
@@ -178,7 +178,7 @@ Only content inside an activated boundary animates position — everything else 
 
 The section — heading included — morphs as one group when rows above are added or removed. Nothing inside the section changed; the *displacement* is the update.
 
-- React activates VT boundaries that are direct children (not behind an intermediate DOM node) of nodes along the changed path — siblings of the mutation and of its ancestors qualify; a VT buried under an extra wrapper element in a sibling does not (deliberate: page-wide re-layout would otherwise fire noisy animations everywhere). Place the boundary as a direct sibling of the changing content.
+- React only measures boundaries that are direct children of nodes along the changed path — a VT buried under an extra wrapper element won't activate. Place the boundary as a direct sibling of the changing content.
 - `default="none"` disables exactly this morph — it turns off `update`. Named/shared elements get `default="none"`; displaced siblings and keyed list items stay bare or set `update="auto"`.
 
 ## Reusable Animated Collapse
@@ -287,13 +287,13 @@ The `types` array (second argument) lets you vary animation based on transition 
 
 **Section below a list teleports instead of gliding:** it's outside any activated boundary, its VT has `default="none"` (which disables `update`), or it isn't an immediate sibling of the changing content. See "Layout Displacement Morph" above.
 
-**`router.back()` and browser back/forward skip the directional slide:** traversals carry no transition types, so type-keyed maps resolve to `default` — untyped shared-element morphs still apply. Use `router.push()` with an explicit URL for typed animations. See SKILL.md "router.back() and Browser Back Button."
+**`router.back()` and browser back/forward skip the directional slide:** traversals carry no transition types, so type-keyed maps resolve to `default` — untyped shared-element morphs still apply. Use `router.push()` for typed animations.
 
 **`flushSync` skips animations:** Use `startTransition` instead.
 
 **Only updates animate (no enter/exit):** Without `<Suspense>`, React treats swaps as updates. Conditionally render the VT itself, or wrap in `<Suspense>`.
 
-**Layout VT prevents page VTs from animating:** nested VTs don't fire their own enter/exit when they mount/unmount *as one unit* with a parent VT — only the outermost animates. (A child VT swapped inside a persistent parent fires normally; if page enter/exit is dead under a persistent layout VT, check the page VT isn't below a plain DOM node instead.) If your layout has a VT wrapping `{children}`, remove it and put VTs in pages.
+**Layout VT prevents page VTs from animating:** nested VTs skip their own enter/exit only when they mount/unmount *as one unit* with a parent VT. If page enter/exit is dead under a persistent layout VT, the usual culprit is a DOM node above the page VT. Keep VTs in pages, not layouts.
 
 **List reorder not animating with `useOptimistic`:** Optimistic values resolve before snapshot. Use committed state for list order.
 


### PR DESCRIPTION
## What

Field learnings for the `react-view-transitions` skill from applying it to real apps (next-beats music player and siblings). Every change traces to a confusion or silent failure that cost real debugging time — including cases where the skill's own guidance steered the wrong way.

## Fixes

**Triggers & morphs**
- `update` trigger definition was too narrow: it also fires when a boundary is *displaced* by surrounding content, not just on inner mutations. Added the **Layout Displacement Morph** pattern — bare `<ViewTransition>` around a sibling section so it glides (heading included) when a list above it grows/shrinks.
- "Always use `default="none"`" → "use deliberately": the absolute rule silently disables `update` (reflow/displacement morphs) and `share` (a named pair with `default="none"` and no explicit `share` prop never morphs — nothing errors).
- Documented the two silent shared-morph killers: `default="none"` without a `share` prop, and type-keyed `share` where links never add the type (`transitionTypes` / `addTransitionType` missing).

**Interactivity**
- New css-recipes section: `::view-transition { pointer-events: none }` and its hard limit — named participants are hit-test-skipped for the whole transition (spec, [csswg#10930](https://github.com/w3c/csswg-drafts/issues/10930)).
- Floating-element guidance now warns to **portal** named popovers: rendered inline in a clickable row, mid-transition clicks fall through to the row (phantom activations, hover flashes) and read as outside-clicks that close the popover.
- Matching troubleshooting entries: dead/closing popovers mid-transition, silent morphs, teleporting sections.

**Earlier commits on this branch** cover related learnings: isolation for persistent chrome and floating elements, scroll behavior during transitions, morph pairing requiring cached/prefetched targets, sliding-indicator and optimistic-controls patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
