### PR TITLE
fix: verifyclaim regular expression injection regex body before compiling

### DIFF
--- a/skills/vercel-optimize/lib/verify-claim.mjs
+++ b/skills/vercel-optimize/lib/verify-claim.mjs
@@ -1203,11 +1203,25 @@ function escapeRegExp(s) {
   return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+// Basic ReDoS guard for user-supplied regex sources.
+// Rejects common high-risk constructs such as nested quantifiers and backreferences.
+function isSafeRegexSource(source) {
+  const s = String(source ?? '');
+  if (s.length > 512) return false;
+  if (/\\[1-9]/.test(s)) return false; // backreferences
+  if (/\((?:[^()\\]|\\.)*[+*](?:[^()\\]|\\.)*\)[+*{]/.test(s)) return false; // quantified group then quantified again
+  if (/(?:^|[^\\])\.\*/.test(s)) return false; // broad wildcard repetition
+  return true;
+}
+
 // Supports `/pattern/flags` literal-regex form OR plain escaped string. Caller flags merge with embedded flags via Set dedup.
 function compilePattern(pattern, flags) {
   const m = pattern.match(/^\/(.+)\/([gimsu]*)$/);
   if (m) {
     const mergedFlags = [...new Set(((m[2] || '') + (flags || '')).split(''))].join('');
+    if (!isSafeRegexSource(m[1])) {
+      throw new Error('unsafe regex pattern');
+    }
     return new RegExp(m[1], mergedFlags);
   }
   return new RegExp(pattern.replace(/[.+^${}()|[\]\\?*]/g, '\\$&'), flags);

--- a/skills/vercel-optimize/lib/verify-claim.mjs
+++ b/skills/vercel-optimize/lib/verify-claim.mjs
@@ -1210,7 +1210,6 @@ function isSafeRegexSource(source) {
   if (s.length > 512) return false;
   if (/\\[1-9]/.test(s)) return false; // backreferences
   if (/\((?:[^()\\]|\\.)*[+*](?:[^()\\]|\\.)*\)[+*{]/.test(s)) return false; // quantified group then quantified again
-  if (/(?:^|[^\\])\.\*/.test(s)) return false; // broad wildcard repetition
   return true;
 }
 


### PR DESCRIPTION

fix this without breaking existing behavior, keep supporting `/pattern/flags` and plain string patterns, but **validate the regex body before compiling** to reject unsafe constructs commonly associated with catastrophic backtracking (for example nested quantifiers and backreferences), and continue escaping plain-string patterns.

Best single approach in the shown file:
- Edit `skills/vercel-optimize/lib/verify-claim.mjs` in `compilePattern(...)` region.
- Add a small helper (e.g., `isSafeRegexSource`) near `compilePattern`.
- In the `/pattern/flags` branch, call the helper on `m[1]`; if unsafe, throw an error (or reject) before `new RegExp`.
- Keep existing flag-merging behavior and plain-string escaping behavior unchanged.