### PR TITLE
docs(react-view-transitions): note the required next.config viewTransition flag

### DIFF
--- a/skills/react-view-transitions/SKILL.md
+++ b/skills/react-view-transitions/SKILL.md
@@ -42,7 +42,7 @@ Reserve directional slides for hierarchical navigation (list → detail) and ord
 
 ## Availability
 
-- **Next.js:** Do **not** install `react@canary` — the App Router already bundles React canary internally. `ViewTransition` works out of the box. `npm ls react` may show a stable-looking version; this is expected.
+- **Next.js:** Do **not** install `react@canary` — the App Router already bundles React canary internally. `npm ls react` may show a stable-looking version; this is expected. Enable the integration with `experimental: { viewTransition: true }` in `next.config.js`; without the flag, `<ViewTransition>` renders but navigations do not animate (see [`references/nextjs.md`](./references/nextjs.md)).
 - **Without Next.js:** Install `react@canary react-dom@canary` (`ViewTransition` is not in stable React).
 - Browser support: Chromium 125+ (React needs the v2 object form of `startViewTransition`), Firefox 144+, Safari 18.2+. Graceful degradation on unsupported browsers.
 


### PR DESCRIPTION
### Problem

`skills/react-view-transitions/SKILL.md` says `ViewTransition` "works out of the box" in Next.js and never mentions `experimental.viewTransition`:

> - **Next.js:** Do **not** install `react@canary` — the App Router already bundles React canary internally. `ViewTransition` works out of the box.

But the skill's own `references/nextjs.md` documents the flag as required:

> `<ViewTransition>` works out of the box — the bundled React canary ships it… **Set the documented flag:**
> ```js
> const nextConfig = { experimental: { viewTransition: true } };
> ```

So the two files contradict each other, and [Next's own docs](https://nextjs.org/docs/app/api-reference/config/next-config-js/viewTransition) make the flag a prerequisite for the Next.js integration:

> To enable this feature, you need to set the `viewTransition` property to `true` in your `next.config.js` file.

### Why it matters

`SKILL.md` is the file loaded first, and frequently the only one loaded — `references/` is progressive-disclosure by design. An agent that reads only `SKILL.md` will add `<ViewTransition>`, see nothing animate, and have no pointer to the cause. Nothing in the Availability section suggests there is further setup to find.

### Change

One line. Keeps the surrounding advice intact (don't install `react@canary`; `npm ls react` looking stable is expected), adds the flag, and links to `references/nextjs.md` for full setup.

Found while auditing vendored skills in a Next.js 16 / React 19 monorepo — this was the one issue that looked like an upstream defect rather than a local preference.