### PR TITLE
fix(web-design-guidelines): pin upstream rules to reviewed commit

### DIFF
--- a/skills/web-design-guidelines/SKILL.md
+++ b/skills/web-design-guidelines/SKILL.md
@@ -13,25 +13,25 @@ Review files for compliance with Web Interface Guidelines.
 
 ## How It Works
 
-1. Fetch the latest guidelines from the source URL below
+1. Fetch the reviewed guidelines snapshot from the source URL below
 2. Read the specified files (or prompt user for files/pattern)
 3. Check against all rules in the fetched guidelines
 4. Output findings in the terse `file:line` format
 
 ## Guidelines Source
 
-Fetch fresh guidelines before each review:
+Fetch the pinned guidelines snapshot before each review:
 
 ```
-https://raw.githubusercontent.com/vercel-labs/web-interface-guidelines/main/command.md
+https://raw.githubusercontent.com/vercel-labs/web-interface-guidelines/4e799d45c17aec1498c269287a83b9dba22b966b/command.md
 ```
 
-Use WebFetch to retrieve the latest rules. The fetched content contains all the rules and output format instructions.
+Use WebFetch to retrieve the rules. The URL is pinned to commit `4e799d45c17aec1498c269287a83b9dba22b966b` so the same version of this skill applies the same reviewed guidance on every invocation. Update the commit through a reviewed change when the upstream guidelines are intentionally refreshed. The fetched content contains all the rules and output format instructions.
 
 ## Usage
 
 When a user provides a file or pattern argument:
-1. Fetch guidelines from the source URL above
+1. Fetch guidelines from the pinned source URL above
 2. Read the specified files
 3. Apply all rules from the fetched guidelines
 4. Output findings using the format specified in the guidelines


### PR DESCRIPTION
## Summary

- Pin the `web-design-guidelines` skill's remote `command.md` source to reviewed commit `4e799d45c17aec1498c269287a83b9dba22b966b`.
- Document that future upstream guideline updates should land through a reviewed SHA change.
- Keep the existing review workflow and output contract unchanged.

This addresses #316 by removing the mutable `main` branch from the skill's instructions and making repeated runs of the same skill revision reproducible.

## Verification

- `git diff --check origin/main...HEAD`
- Static pin check confirms the URL contains a 40-character commit SHA.
- Fetched the pinned URL and verified HTTP 200.
- Confirmed the pinned SHA matches the current `web-interface-guidelines` `main` tip via the public GitHub API.

## Collision / policy check

- No open pull request currently changes `skills/web-design-guidelines/SKILL.md` or pins this source; #315's unrelated guideline references are in React/composition skills.
- Repository `AGENTS.md` requires small, focused skill changes; no root CONTRIBUTING or SECURITY policy files are present in the public default branch.