### PR TITLE
feat: ✨ publish Agent Skills discovery index

### DIFF
--- a/.github/workflows/agent-skills-discovery.yml
+++ b/.github/workflows/agent-skills-discovery.yml
@@ -1,0 +1,42 @@
+name: Agent Skills Discovery
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'skills/**'
+      - 'scripts/build-discovery-index.mjs'
+      - '.github/workflows/agent-skills-discovery.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'skills/**'
+      - 'scripts/build-discovery-index.mjs'
+      - '.github/workflows/agent-skills-discovery.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - run: node scripts/build-discovery-index.mjs https://example.com/skills
+
+  publish:
+    if: github.event_name == 'push'
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: agent-skills-${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: node scripts/build-discovery-index.mjs "https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}"
+      - run: >-
+          gh release create "$RELEASE_TAG" dist/* --latest
+          --target "$GITHUB_SHA"
+          --title "Agent Skills ${{ github.sha }}"
+          --notes "Automated Agent Skills discovery release for ${{ github.sha }}."

--- a/.github/workflows/agent-skills-discovery.yml
+++ b/.github/workflows/agent-skills-discovery.yml
@@ -21,6 +21,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+      - run: npm ci --ignore-scripts
       - run: node scripts/build-discovery-index.mjs https://example.com/skills
 
   publish:
@@ -37,6 +38,7 @@ jobs:
       RELEASE_TAG: agent-skills-${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
+      - run: npm ci --ignore-scripts
       - run: node scripts/build-discovery-index.mjs "https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}"
       - run: |
           gh release view "$RELEASE_TAG" >/dev/null 2>&1 ||

--- a/.github/workflows/agent-skills-discovery.yml
+++ b/.github/workflows/agent-skills-discovery.yml
@@ -26,6 +26,9 @@ jobs:
   publish:
     if: github.event_name == 'push'
     needs: validate
+    concurrency:
+      group: agent-skills-discovery-publish
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -35,8 +38,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: node scripts/build-discovery-index.mjs "https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}"
-      - run: >-
-          gh release create "$RELEASE_TAG" dist/* --latest
-          --target "$GITHUB_SHA"
-          --title "Agent Skills ${{ github.sha }}"
-          --notes "Automated Agent Skills discovery release for ${{ github.sha }}."
+      - run: |
+          gh release view "$RELEASE_TAG" >/dev/null 2>&1 ||
+            gh release create "$RELEASE_TAG" --draft --target "$GITHUB_SHA" \
+              --title "Agent Skills ${{ github.sha }}" \
+              --notes "Automated Agent Skills discovery release for ${{ github.sha }}."
+          gh release upload "$RELEASE_TAG" dist/* --clobber
+          gh release edit "$RELEASE_TAG" --draft=false --latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .vercel
 .env*.local
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vercel
 .env*.local
 dist
+node_modules

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ an Agent Skills discovery index and one artifact per skill. Build the same
 artifacts locally with:
 
 ```bash
+npm ci --ignore-scripts
 node scripts/build-discovery-index.mjs https://example.com/skills
 ```
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,16 @@ Review this React component for performance issues
 Help me optimize this Next.js page
 ```
 
+## Discovery index
+
+Every change to a skill on `main` publishes an immutable GitHub release with
+an Agent Skills discovery index and one archive per skill. Build the same
+artifacts locally with:
+
+```bash
+node scripts/build-discovery-index.mjs https://example.com/skills
+```
+
 ## Skill Structure
 
 Each skill contains:

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Help me optimize this Next.js page
 ## Discovery index
 
 Every change to a skill on `main` publishes an immutable GitHub release with
-an Agent Skills discovery index and one archive per skill. Build the same
+an Agent Skills discovery index and one artifact per skill. Build the same
 artifacts locally with:
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "@vercel-labs/agent-skills",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@vercel-labs/agent-skills",
+      "dependencies": {
+        "yaml": "2.9.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@vercel-labs/agent-skills",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "yaml": "2.9.0"
+  }
+}

--- a/scripts/build-discovery-index.mjs
+++ b/scripts/build-discovery-index.mjs
@@ -8,6 +8,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import { parse } from 'yaml';
 
 const schema = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
 const baseUrl = process.argv[2];
@@ -36,34 +37,24 @@ const readMetadata = (directory) => {
   const frontmatter = source.match(/^---\r?\n([\s\S]*?)\r?\n---/)?.[1];
   if (!frontmatter) throw new Error(`Missing frontmatter in ${path}`);
 
-  const lines = frontmatter.split(/\r?\n/);
-  const name = lines.find((line) => line.startsWith('name:'))?.slice(5).trim();
-  const descriptionLine = lines.findIndex((line) =>
-    line.startsWith('description:'),
-  );
-  if (!name || descriptionLine === -1) {
+  let metadata;
+  try {
+    metadata = parse(frontmatter);
+  } catch (error) {
+    throw new Error(`Invalid frontmatter in ${path}`, { cause: error });
+  }
+
+  if (!metadata || typeof metadata !== 'object') {
+    throw new Error(`Invalid frontmatter in ${path}`);
+  }
+
+  const { name, description } = metadata;
+  if (typeof name !== 'string' || typeof description !== 'string') {
     throw new Error(`Missing name or description in ${path}`);
   }
 
-  const inlineDescription = lines[descriptionLine].slice(12).trim();
-  const descriptionLines = [];
-  for (
-    let index = descriptionLine + 1;
-    index < lines.length && /^\s/.test(lines[index]);
-    index++
-  ) {
-    descriptionLines.push(lines[index].trim());
-  }
-  const blockStyle = inlineDescription.match(/^([>|])[-+]?$/)?.[1];
-  const description = blockStyle
-    ? descriptionLines.join(blockStyle === '|' ? '\n' : ' ')
-    : inlineDescription.startsWith('"')
-      ? JSON.parse(inlineDescription)
-      : inlineDescription.startsWith("'") && inlineDescription.endsWith("'")
-        ? inlineDescription.slice(1, -1).replaceAll("''", "'")
-        : inlineDescription || descriptionLines.join(' ');
-
   if (
+    name.length === 0 ||
     name.length > 64 ||
     !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name) ||
     !description ||

--- a/scripts/build-discovery-index.mjs
+++ b/scripts/build-discovery-index.mjs
@@ -4,8 +4,6 @@ import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 import {
   mkdirSync,
-  readdirSync,
-  readFileSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -30,8 +28,11 @@ if (!baseUrl) {
   );
 }
 
-const readMetadata = (path) => {
-  const source = readFileSync(path, 'utf8');
+const readMetadata = (directory) => {
+  const path = `skills/${directory}/SKILL.md`;
+  const source = execFileSync('git', ['show', `HEAD:${path}`], {
+    encoding: 'utf8',
+  });
   const frontmatter = source.match(/^---\r?\n([\s\S]*?)\r?\n---/)?.[1];
   if (!frontmatter) throw new Error(`Missing frontmatter in ${path}`);
 
@@ -53,20 +54,28 @@ const readMetadata = (path) => {
   ) {
     descriptionLines.push(lines[index].trim());
   }
-  const description = inlineDescription
-    ? inlineDescription.startsWith('"')
+  const blockStyle = inlineDescription.match(/^([>|])[-+]?$/)?.[1];
+  const description = blockStyle
+    ? descriptionLines.join(blockStyle === '|' ? '\n' : ' ')
+    : inlineDescription.startsWith('"')
       ? JSON.parse(inlineDescription)
-      : inlineDescription.replaceAll('\\"', '"')
-    : descriptionLines.join(' ');
+      : inlineDescription.startsWith("'") && inlineDescription.endsWith("'")
+        ? inlineDescription.slice(1, -1).replaceAll("''", "'")
+        : inlineDescription || descriptionLines.join(' ');
 
-  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name) || !description) {
+  if (
+    name.length > 64 ||
+    !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name) ||
+    !description ||
+    description.length > 1024
+  ) {
     throw new Error(`Invalid name or description in ${path}`);
   }
 
   return { name, description };
 };
 
-const createArchive = (directory, name) => {
+const createArchive = (directory) => {
   const tree = execFileSync(
     'git',
     ['rev-parse', `HEAD:skills/${directory}`],
@@ -77,34 +86,74 @@ const createArchive = (directory, name) => {
     env: archiveEnvironment,
     input: 'Agent Skills archive\n',
   }).trim();
-  const tar = execFileSync('git', [
-    'archive',
-    '--format=tar',
-    `--prefix=${name}/`,
-    commit,
-  ]);
+  const tar = execFileSync('git', ['archive', '--format=tar', commit]);
   return execFileSync('gzip', ['-n', '-9', '-c'], { input: tar });
+};
+
+const createArtifact = (directory) => {
+  const entries = execFileSync(
+    'git',
+    ['ls-tree', '-r', `HEAD:skills/${directory}`],
+    { encoding: 'utf8' },
+  )
+    .trim()
+    .split('\n');
+  if (entries.some((entry) => !/^100(?:644|755) blob /.test(entry))) {
+    throw new Error(`Unsupported archive entry in skills/${directory}`);
+  }
+
+  const files = entries.map((entry) => entry.slice(entry.indexOf('\t') + 1));
+
+  if (files.length === 1 && files[0] === 'SKILL.md') {
+    return {
+      content: execFileSync('git', [
+        'show',
+        `HEAD:skills/${directory}/SKILL.md`,
+      ]),
+      extension: 'md',
+      type: 'skill-md',
+    };
+  }
+
+  return {
+    content: createArchive(directory),
+    extension: 'tar.gz',
+    type: 'archive',
+  };
 };
 
 rmSync(outputDirectory, { force: true, recursive: true });
 mkdirSync(outputDirectory);
 
-const skills = readdirSync('skills', { withFileTypes: true })
-  .filter((entry) => entry.isDirectory())
-  .map(({ name: directory }) => {
-    const metadata = readMetadata(join('skills', directory, 'SKILL.md'));
-    const artifact = createArchive(directory, metadata.name);
-    const filename = `${metadata.name}.tar.gz`;
-    writeFileSync(join(outputDirectory, filename), artifact);
+const directories = execFileSync(
+  'git',
+  ['ls-tree', '-d', '--name-only', 'HEAD:skills'],
+  { encoding: 'utf8' },
+)
+  .trim()
+  .split('\n');
+
+const skills = directories
+  .map((directory) => {
+    const metadata = readMetadata(directory);
+    const artifact = createArtifact(directory);
+    const filename = `${metadata.name}.${artifact.extension}`;
+    writeFileSync(join(outputDirectory, filename), artifact.content);
 
     return {
       ...metadata,
-      type: 'archive',
+      type: artifact.type,
       url: `${baseUrl.replace(/\/$/, '')}/${filename}`,
-      digest: `sha256:${createHash('sha256').update(artifact).digest('hex')}`,
+      digest: `sha256:${createHash('sha256')
+        .update(artifact.content)
+        .digest('hex')}`,
     };
   })
   .sort((a, b) => a.name.localeCompare(b.name));
+
+if (new Set(skills.map(({ name }) => name)).size !== skills.length) {
+  throw new Error('Skill names must be unique');
+}
 
 writeFileSync(
   join(outputDirectory, 'index.json'),

--- a/scripts/build-discovery-index.mjs
+++ b/scripts/build-discovery-index.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+const schema = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
+const baseUrl = process.argv[2];
+const outputDirectory = 'dist';
+const archiveEnvironment = {
+  ...process.env,
+  GIT_AUTHOR_DATE: '2000-01-01T00:00:00Z',
+  GIT_AUTHOR_EMAIL: 'agent-skills@vercel.com',
+  GIT_AUTHOR_NAME: 'Agent Skills',
+  GIT_COMMITTER_DATE: '2000-01-01T00:00:00Z',
+  GIT_COMMITTER_EMAIL: 'agent-skills@vercel.com',
+  GIT_COMMITTER_NAME: 'Agent Skills',
+};
+
+if (!baseUrl) {
+  throw new Error(
+    'Usage: node scripts/build-discovery-index.mjs <artifact-base-url>',
+  );
+}
+
+const readMetadata = (path) => {
+  const source = readFileSync(path, 'utf8');
+  const frontmatter = source.match(/^---\r?\n([\s\S]*?)\r?\n---/)?.[1];
+  if (!frontmatter) throw new Error(`Missing frontmatter in ${path}`);
+
+  const lines = frontmatter.split(/\r?\n/);
+  const name = lines.find((line) => line.startsWith('name:'))?.slice(5).trim();
+  const descriptionLine = lines.findIndex((line) =>
+    line.startsWith('description:'),
+  );
+  if (!name || descriptionLine === -1) {
+    throw new Error(`Missing name or description in ${path}`);
+  }
+
+  const inlineDescription = lines[descriptionLine].slice(12).trim();
+  const descriptionLines = [];
+  for (
+    let index = descriptionLine + 1;
+    index < lines.length && /^\s/.test(lines[index]);
+    index++
+  ) {
+    descriptionLines.push(lines[index].trim());
+  }
+  const description = inlineDescription
+    ? inlineDescription.startsWith('"')
+      ? JSON.parse(inlineDescription)
+      : inlineDescription.replaceAll('\\"', '"')
+    : descriptionLines.join(' ');
+
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name) || !description) {
+    throw new Error(`Invalid name or description in ${path}`);
+  }
+
+  return { name, description };
+};
+
+const createArchive = (directory, name) => {
+  const tree = execFileSync(
+    'git',
+    ['rev-parse', `HEAD:skills/${directory}`],
+    { encoding: 'utf8' },
+  ).trim();
+  const commit = execFileSync('git', ['commit-tree', tree], {
+    encoding: 'utf8',
+    env: archiveEnvironment,
+    input: 'Agent Skills archive\n',
+  }).trim();
+  const tar = execFileSync('git', [
+    'archive',
+    '--format=tar',
+    `--prefix=${name}/`,
+    commit,
+  ]);
+  return execFileSync('gzip', ['-n', '-9', '-c'], { input: tar });
+};
+
+rmSync(outputDirectory, { force: true, recursive: true });
+mkdirSync(outputDirectory);
+
+const skills = readdirSync('skills', { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map(({ name: directory }) => {
+    const metadata = readMetadata(join('skills', directory, 'SKILL.md'));
+    const artifact = createArchive(directory, metadata.name);
+    const filename = `${metadata.name}.tar.gz`;
+    writeFileSync(join(outputDirectory, filename), artifact);
+
+    return {
+      ...metadata,
+      type: 'archive',
+      url: `${baseUrl.replace(/\/$/, '')}/${filename}`,
+      digest: `sha256:${createHash('sha256').update(artifact).digest('hex')}`,
+    };
+  })
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+writeFileSync(
+  join(outputDirectory, 'index.json'),
+  `${JSON.stringify({ $schema: schema, skills }, null, 2)}\n`,
+);
+
+console.log(`Published ${skills.length} skills to ${outputDirectory}`);


### PR DESCRIPTION
## Summary

- discover every committed skill under `skills/`
- publish single-file skills as `skill-md` and multi-file skills as root-structured archives
- generate reproducible SHA-256 digests and immutable release URLs
- publish releases atomically and safely across reruns or overlapping pushes

## Dependent PR

[vercel/front#81517](https://github.com/vercel/front/pull/81517) consumes this index and should merge after this release workflow publishes the upstream artifacts.