### PR TITLE
feat: add HOL Guard Vercel command safety skill

### DIFF
--- a/skills.sh.json
+++ b/skills.sh.json
@@ -18,7 +18,8 @@
       "skills": [
         "deploy-to-vercel",
         "vercel-cli-with-tokens",
-        "vercel-optimize"
+        "vercel-optimize",
+        "hol-guard-vercel"
       ]
     },
     {

--- a/skills/hol-guard-vercel/SKILL.md
+++ b/skills/hol-guard-vercel/SKILL.md
@@ -22,15 +22,21 @@ If `pipx` is unavailable, do not silently install into the project's Python envi
 
 ## Prefer a protected agent runtime
 
-When the current coding agent is one of HOL Guard's supported harnesses, install Guard into that harness and run the agent through Guard so review/approval decisions can happen at the actual tool boundary:
+Use HOL Guard's own detection result rather than maintaining a hand-written list of supported harness identifiers:
 
 ```bash
-hol-guard install <harness>
-hol-guard run <harness> --dry-run
-hol-guard run <harness>
+hol-guard detect --json
 ```
 
-Supported harnesses include Claude Code, Codex, Copilot CLI, Cursor, Gemini CLI, Hermes, OpenClaw, OpenCode, and Antigravity. Use `hol-guard detect --json` when the active harness is unclear.
+If detection reports a supported local coding-agent harness, use the exact identifier it returns when installing and launching the protected session so review/approval decisions can happen at the actual tool boundary:
+
+```bash
+hol-guard install <detected-harness>
+hol-guard run <detected-harness> --dry-run
+hol-guard run <detected-harness>
+```
+
+If detection reports no supported harness, do not claim the current session is protected and do not guess an adapter name.
 
 ## Preflight an exact Vercel command
 

--- a/skills/hol-guard-vercel/SKILL.md
+++ b/skills/hol-guard-vercel/SKILL.md
@@ -5,7 +5,7 @@ description: Use when an AI coding agent is about to deploy, promote, roll back,
 
 # HOL Guard for Vercel CLI safety
 
-Use HOL Guard as a pre-execution command-safety check for Vercel CLI operations.
+Use HOL Guard as a pre-execution safety layer for Vercel CLI operations.
 
 HOL Guard release/3.0 includes `command.platform.vercel` coverage for production-impacting Vercel operations such as removing deployments or projects and deploying, promoting, or rolling back production. It preserves safe inspection/help counterparts such as help, project inspection, and promotion status.
 
@@ -20,7 +20,21 @@ hol-guard --version
 
 If `pipx` is unavailable, do not silently install into the project's Python environment. Explain that an isolated CLI install is recommended.
 
-## Guard a Vercel command
+## Prefer a protected agent runtime
+
+When the current coding agent is one of HOL Guard's supported harnesses, install Guard into that harness and run the agent through Guard so review/approval decisions can happen at the actual tool boundary:
+
+```bash
+hol-guard install <harness>
+hol-guard run <harness> --dry-run
+hol-guard run <harness>
+```
+
+Supported harnesses include Claude Code, Codex, Copilot CLI, Cursor, Gemini CLI, Hermes, OpenClaw, OpenCode, and Antigravity. Use `hol-guard detect --json` when the active harness is unclear.
+
+## Preflight an exact Vercel command
+
+Before a production-impacting Vercel CLI operation:
 
 1. Build the exact `vercel` command that would otherwise run.
 2. Do **not** execute it yet.
@@ -31,8 +45,8 @@ hol-guard command test '<exact vercel command>' --json
 ```
 
 4. Read the JSON result.
-5. Execute the original Vercel command **exactly once** only when HOL Guard explicitly classifies it as benign and the minimum action is `allow`.
-6. For `review`, `block`, unknown/malformed output, CLI errors, or timeouts, do not run the Vercel command. Report the Guard result and ask for the appropriate review/approval path instead.
+5. If the result is explicitly benign with minimum action `allow`, the command passed this command-safety preflight.
+6. If the result requires `review` or `block`, or output is unknown/malformed, the CLI errors, or the check times out, do not bypass the decision. When running through a Guard-protected harness, let the Guard runtime own the review/approval flow. Otherwise stop and surface the exact command and Guard result to the user.
 
 `hol-guard command test` is side-effect free. It classifies the command; it does not execute the Vercel command, create a final approval, evaluate the complete runtime policy, or record a receipt.
 
@@ -64,7 +78,7 @@ inspect it:
 hol-guard command test 'vercel promote my-deployment.vercel.app' --json
 ```
 
-Do not run `vercel promote ...` unless the result is explicitly benign with minimum action `allow`.
+If Guard requires review, do not rewrite or split the command to evade the result. Use the protected runtime's review path or stop for user review.
 
 ## Safety rules
 
@@ -72,7 +86,7 @@ Do not run `vercel promote ...` unless the result is explicitly benign with mini
 - Never split one risky command into multiple commands to bypass a Guard decision.
 - Never treat scanner or CLI failure as approval.
 - Never read `.env` files to satisfy Guard.
-- Do not claim HOL Guard is a native Vercel runtime integration. This skill uses HOL Guard's command-safety engine before Vercel CLI execution.
+- Do not claim HOL Guard is a native Vercel runtime integration. This skill applies HOL Guard's command-safety engine before Vercel CLI execution.
 - Guard Cloud is optional for this workflow.
 - Preserve the user's target project, team, scope, and CLI flags exactly when inspecting the command.
 

--- a/skills/hol-guard-vercel/SKILL.md
+++ b/skills/hol-guard-vercel/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: hol-guard-vercel
+description: Use when an AI coding agent is about to deploy, promote, roll back, remove, or otherwise mutate Vercel resources and you want HOL Guard to inspect the exact Vercel CLI command before it executes.
+---
+
+# HOL Guard for Vercel CLI safety
+
+Use HOL Guard as a pre-execution command-safety check for Vercel CLI operations.
+
+HOL Guard release/3.0 includes `command.platform.vercel` coverage for production-impacting Vercel operations such as removing deployments or projects and deploying, promoting, or rolling back production. It preserves safe inspection/help counterparts such as help, project inspection, and promotion status.
+
+## Install
+
+The Vercel command coverage currently lives in the HOL Guard 3.x prerelease channel:
+
+```bash
+pipx install --pip-args="--pre" hol-guard
+hol-guard --version
+```
+
+If `pipx` is unavailable, do not silently install into the project's Python environment. Explain that an isolated CLI install is recommended.
+
+## Guard a Vercel command
+
+1. Build the exact `vercel` command that would otherwise run.
+2. Do **not** execute it yet.
+3. Inspect that exact command with HOL Guard:
+
+```bash
+hol-guard command test '<exact vercel command>' --json
+```
+
+4. Read the JSON result.
+5. Execute the original Vercel command **exactly once** only when HOL Guard explicitly classifies it as benign and the minimum action is `allow`.
+6. For `review`, `block`, unknown/malformed output, CLI errors, or timeouts, do not run the Vercel command. Report the Guard result and ask for the appropriate review/approval path instead.
+
+`hol-guard command test` is side-effect free. It classifies the command; it does not execute the Vercel command, create a final approval, evaluate the complete runtime policy, or record a receipt.
+
+## Operations to inspect
+
+Always inspect production-impacting operations, including:
+
+- production deploys
+- production promotion
+- production rollback
+- deployment removal
+- project removal
+
+Also inspect any Vercel command whose effect or target is unclear.
+
+HOL Guard recognizes safe counterparts such as help, project inspection, and promotion status, but still use the exact command rather than paraphrasing it.
+
+## Example
+
+Before running:
+
+```bash
+vercel promote my-deployment.vercel.app
+```
+
+inspect it:
+
+```bash
+hol-guard command test 'vercel promote my-deployment.vercel.app' --json
+```
+
+Do not run `vercel promote ...` unless the result is explicitly benign with minimum action `allow`.
+
+## Safety rules
+
+- Never transform a blocked command just to make it pass.
+- Never split one risky command into multiple commands to bypass a Guard decision.
+- Never treat scanner or CLI failure as approval.
+- Never read `.env` files to satisfy Guard.
+- Do not claim HOL Guard is a native Vercel runtime integration. This skill uses HOL Guard's command-safety engine before Vercel CLI execution.
+- Guard Cloud is optional for this workflow.
+- Preserve the user's target project, team, scope, and CLI flags exactly when inspecting the command.
+
+## Install this skill
+
+```bash
+npx skills add vercel-labs/agent-skills --skill hol-guard-vercel
+```
+
+HOL Guard: https://hol.org/guard
+Source: https://github.com/hashgraph-online/hol-guard


### PR DESCRIPTION
## Summary

Adds `hol-guard-vercel`, a focused Agent Skill for applying HOL Guard before production-impacting Vercel CLI operations.

- adds `skills/hol-guard-vercel/SKILL.md`
- groups the skill under Vercel in `skills.sh.json`
- documents the standard `npx skills add vercel-labs/agent-skills --skill hol-guard-vercel` install path

## Why

HOL Guard release/3.0 includes `command.platform.vercel` coverage for removing deployments/projects and production deploy, promote, and rollback operations, while preserving documented inspection/help counterparts. The skill uses that existing command-safety surface rather than asking this repo for new framework behavior.

The workflow prefers a Guard-protected supported coding-agent harness for real review/approval handling. `hol-guard command test` is presented only as a side-effect-free preflight and is explicitly not described as a final runtime policy or approval decision.

## Scope and safety

- no Vercel API or runtime changes
- no claim of native Vercel interception
- `review` / `block` / unknown / error paths are fail-closed
- no Guard Cloud dependency
- no production Vercel mutation is performed by the skill itself

## Verification

- directory name matches frontmatter name
- skill is under the repository's 500-line guidance
- `skills.sh.json` remains valid JSON with the skill in the Vercel grouping
- Vercel operation coverage checked against HOL Guard's current release/3.0 coverage docs

Affiliation: I maintain HOL Guard / Hashgraph Online. AI assistance was used to prepare this contribution; the commands and scope were checked against the current source/docs before submission.